### PR TITLE
w3clock

### DIFF
--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireproof/core",
-  "version": "0.12.0-dev",
+  "version": "0.12.0-dev.1",
   "description": "Live database for the web",
   "main": "./dist/browser/fireproof.cjs",
   "module": "./dist/browser/fireproof.esm.js",

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -133,6 +133,7 @@
     "@ipld/car": "^5.2.0",
     "@ipld/dag-cbor": "^9.0.3",
     "@ipld/dag-json": "^10.1.2",
+    "@ipld/dag-ucan": "^3.3.2",
     "@ipld/unixfs": "^2.1.1",
     "@peculiar/webcrypto": "^1.4.3",
     "@web3-storage/clock": "^0.3.0",

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -91,6 +91,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "devDependencies": {
+    "@hyrious/esbuild-plugin-commonjs": "^0.2.2",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-json": "^6.0.0",

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -134,6 +134,7 @@
     "@ipld/dag-json": "^10.1.2",
     "@ipld/unixfs": "^2.1.1",
     "@peculiar/webcrypto": "^1.4.3",
+    "@web3-storage/clock": "^0.3.0",
     "@web3-storage/w3up-client": "^8.0.1",
     "charwise": "^3.0.1",
     "cross-fetch": "^4.0.0",

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireproof/core",
-  "version": "0.11.21",
+  "version": "0.12.0-dev",
   "description": "Live database for the web",
   "main": "./dist/browser/fireproof.cjs",
   "module": "./dist/browser/fireproof.esm.js",

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -134,6 +134,7 @@
     "@ipld/dag-json": "^10.1.2",
     "@ipld/unixfs": "^2.1.1",
     "@peculiar/webcrypto": "^1.4.3",
+    "@web3-storage/w3up-client": "^8.0.1",
     "charwise": "^3.0.1",
     "cross-fetch": "^4.0.0",
     "idb": "^7.1.1",

--- a/packages/fireproof/scripts/settings.js
+++ b/packages/fireproof/scripts/settings.js
@@ -5,6 +5,7 @@ import esbuildPluginTsc from 'esbuild-plugin-tsc'
 import fs from 'fs'
 import path from 'path'
 import { polyfillNode } from 'esbuild-plugin-polyfill-node'
+import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 
 // Obtain all .ts files in the src directory
 const entryPoints = fs
@@ -20,7 +21,7 @@ export function createBuildSettings(options) {
     plugins: [
       esbuildPluginTsc({
         force: true
-      })
+      }), commonjs({ filter: /^peculiar/ })
     ],
     ...options
   }
@@ -96,6 +97,7 @@ console.log('browser/es2015 build');
 `,
         plugins: [
           polyfillNode({
+            // todo remove crypto and test
             polyfills: { crypto: true, fs: true, process: 'empty' }
           }),
           // alias({

--- a/packages/fireproof/src/connect-s3.ts
+++ b/packages/fireproof/src/connect-s3.ts
@@ -14,6 +14,7 @@ export class ConnectS3 implements Connection {
 
   async upload(bytes: Uint8Array, params: UploadFnParams) {
     validateParams(params)
+    console.log('s3 uploading', params)
     const fetchUploadUrl = new URL(`${this.uploadUrl.toString()}?${new URLSearchParams(params).toString()}`)
     const response = await fetch(fetchUploadUrl)
     const { uploadURL } = await response.json() as { uploadURL: string }
@@ -22,6 +23,7 @@ export class ConnectS3 implements Connection {
 
   async download(params: DownloadFnParams) {
     validateParams(params)
+    console.log('s3 downloading', params)
     const { type, name, car, branch } = params
     const fetchFromUrl = new URL(`${type}/${name}/${type === 'meta'
       ? branch + '.json?cache=' + Math.floor(Math.random() * 1000000)

--- a/packages/fireproof/src/connect-s3.ts
+++ b/packages/fireproof/src/connect-s3.ts
@@ -1,6 +1,3 @@
-/* eslint-disable import/first */
-// console.log('import store-s3')
-
 import { Connection, DownloadFnParams, UploadFnParams } from './types'
 import fetch from 'cross-fetch'
 import { validateParams } from './connect'

--- a/packages/fireproof/src/connect-s3.ts
+++ b/packages/fireproof/src/connect-s3.ts
@@ -3,6 +3,7 @@
 
 import { Connection, DownloadFnParams, UploadFnParams } from './types'
 import fetch from 'cross-fetch'
+import { validateParams } from './connect'
 
 export class ConnectS3 implements Connection {
   uploadUrl: URL
@@ -14,16 +15,8 @@ export class ConnectS3 implements Connection {
     this.downloadUrl = new URL(download)
   }
 
-  validateParams(params: DownloadFnParams | UploadFnParams) {
-    const { type, name, car, branch } = params
-    if (!name) throw new Error('name is required')
-    if (car && branch) { throw new Error('car and branch are mutually exclusive') }
-    if (!car && !branch) { throw new Error('car or branch is required') }
-    if (type !== 'file' && type !== 'data' && type !== 'meta') { throw new Error('type must be data or meta') }
-  }
-
   async upload(bytes: Uint8Array, params: UploadFnParams) {
-    this.validateParams(params)
+    validateParams(params)
     const fetchUploadUrl = new URL(`${this.uploadUrl.toString()}?${new URLSearchParams(params).toString()}`)
     const response = await fetch(fetchUploadUrl)
     const { uploadURL } = await response.json() as { uploadURL: string }
@@ -31,7 +24,7 @@ export class ConnectS3 implements Connection {
   }
 
   async download(params: DownloadFnParams) {
-    this.validateParams(params)
+    validateParams(params)
     const { type, name, car, branch } = params
     const fetchFromUrl = new URL(`${type}/${name}/${type === 'meta'
       ? branch + '.json?cache=' + Math.floor(Math.random() * 1000000)

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -2,9 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { create, Client } from '@web3-storage/w3up-client'
+import * as w3clock from '@web3-storage/clock/client'
 
 import { Connection, DownloadFnParams, UploadFnParams } from './types'
 import { validateParams } from './connect'
+import { CID } from 'multiformats'
 
 export class ConnectWeb3 implements Connection {
   email: `${string}@${string}`
@@ -36,6 +38,27 @@ export class ConnectWeb3 implements Connection {
 
   async upload(bytes: Uint8Array, params: UploadFnParams) {
     await this.ready
+    if (params.type === 'meta') {
+      console.log('w3 meta upload', params)
+      // w3clock
+      // we need the upload as an event block or the data that goes in one
+      const data = {
+        key: params.name,
+        branch: params.branch
+        // we could extract this from the input type but it silly to do so
+        // key:
+        // car:
+        //  parse('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+      }
+      const event = await EventBlock.create(data)
+
+      const advanced = await w3clock.advance({
+        issuer: this.client?._agent.issuer,
+        with: this.client?.currentSpace()
+      }, [])
+      return
+    }
+
     validateParams(params)
     console.log('w3 uploading', params)
     await this.client?.uploadFile(new Blob([bytes]))

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -1,0 +1,39 @@
+/* eslint-disable import/first */
+// console.log('import store-s3')
+
+import { Connection, DownloadFnParams, UploadFnParams } from './types'
+import { validateParams } from './connect'
+
+export class ConnectWeb3 implements Connection {
+  email: string
+  ready: Promise<any>
+
+  constructor(email: string) {
+    this.email = email
+    this.ready = this.initializeClient()
+  }
+
+  async initializeClient() {
+
+  }
+
+  async upload(bytes: Uint8Array, params: UploadFnParams) {
+    validateParams(params)
+    // const fetchUploadUrl = new URL(`${this.uploadUrl.toString()}?${new URLSearchParams(params).toString()}`)
+    // const response = await fetch(fetchUploadUrl)
+    // const { uploadURL } = await response.json() as { uploadURL: string }
+    // await fetch(uploadURL, { method: 'PUT', body: bytes })
+  }
+
+  async download(params: DownloadFnParams) {
+    validateParams(params)
+    const { type, name, car, branch } = params
+    // const fetchFromUrl = new URL(`${type}/${name}/${type === 'meta'
+    //   ? branch + '.json?cache=' + Math.floor(Math.random() * 1000000)
+    //   : car + '.car'}`, this.downloadUrl)
+    // const response = await fetch(fetchFromUrl)
+    // const bytes = new Uint8Array(await response.arrayBuffer())
+    // return bytes
+    return new Uint8Array()
+  }
+}

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -44,53 +44,57 @@ export class ConnectWeb3 implements Connection {
     await this.ready
     if (!this.client) { throw new Error('client not initialized') }
 
-    if (params.type === 'meta') {
-      // @ts-ignore
-      const ag = this.client._agent
-      console.log('w3 meta upload', params)
-      // w3clock
-      const space = this.client.currentSpace()
-      if (!space) { throw new Error('space not initialized') }
-      // we need the upload as an event block or the data that goes in one
-      const data = {
-        key: params.name,
-        branch: params.branch,
-        name: params.name
-        // we could extract this from the input type but it silly to do so
-        // key:
-        // car:
-        //  parse('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
-      }
-      const event = await EventBlock.create(data)
+    // if (params.type === 'meta') {
+    //   // @ts-ignore
+    //   const ag = this.client._agent
+    //   console.log('w3 meta upload', params)
+    //   // w3clock
+    //   const space = this.client.currentSpace()
+    //   if (!space) { throw new Error('space not initialized') }
+    //   // we need the upload as an event block or the data that goes in one
+    //   const data = {
+    //     key: params.name,
+    //     branch: params.branch,
+    //     name: params.name
+    //     // we could extract this from the input type but it silly to do so
+    //     // key:
+    //     // car:
+    //     //  parse('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    //   }
+    //   const event = await EventBlock.create(data)
 
-      const issuer = ag.issuer
-      console.log('issuer', issuer, issuer.signatureAlgorithm, issuer.did())
+    //   const issuer = ag.issuer
+    //   console.log('issuer', issuer, issuer.signatureAlgorithm, issuer.did())
 
-      if (!issuer.signatureAlgorithm) { throw new Error('issuer not valid') }
+    //   if (!issuer.signatureAlgorithm) { throw new Error('issuer not valid') }
 
-      const claims = await this.client.capability.access.claim()
+    //   const claims = await this.client.capability.access.claim()
 
-      const delegated = await clock.delegate({
-        issuer: ag.issuer,
-        audience: ag.issuer, // DID.parse('did:web:clock.web3.storage'),
-        with: space.did(),
-        proofs: claims
-      })
+    //   const delegated = await clock.delegate({
+    //     issuer: ag.issuer,
+    //     audience: ag.issuer, // DID.parse('did:web:clock.web3.storage'),
+    //     with: space.did(),
+    //     proofs: claims
+    //   })
 
-      console.log('delegated', delegated)
+    //   console.log('delegated', delegated)
 
-      const advanced = await w3clock.advance({
-        issuer,
-        with: space.did(),
-        proofs: claims
-      }, event.cid, { blocks: [event] })
+    //   const advanced = await w3clock.advance({
+    //     issuer,
+    //     with: space.did(),
+    //     proofs: claims
+    //   }, event.cid, { blocks: [event] })
 
-      console.log('advanced', advanced.root.data?.ocm)
-      return
-    }
+    //   console.log('advanced', advanced.root.data?.ocm)
+    //   return
+    // }
 
     validateParams(params)
     console.log('w3 uploading car', params)
+    // uploadCar is processed so roots are reachable via CDN
+    // uploadFile makes the car itself available vis CDN
+
+    // await this.client?.uploadCAR(new Blob([bytes]))
     await this.client?.uploadFile(new Blob([bytes]))
   }
 }

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -44,6 +44,9 @@ export class ConnectWeb3 implements Connection {
 
 export async function getClient(email: `${string}@${string}`) {
   const client = await create()
+  if (client.currentSpace()?.registered()) {
+    return client
+  }
   console.log('authorizing', email)
   await client.authorize(email)
   console.log('authorized', client)
@@ -59,11 +62,13 @@ export async function getClient(email: `${string}@${string}`) {
         break
       }
     }
-
-    space = await client.createSpace()
+    if (space === undefined) {
+      space = await client.createSpace()
+    }
+    await client.setCurrentSpace(space.did())
   }
-  await client.setCurrentSpace(space.did())
   if (!space.registered()) {
+    console.log('registering space')
     await client.registerSpace(email)
   }
   console.log('space', space.did())

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -47,19 +47,19 @@ export async function getClient(email: `${string}@${string}`) {
   console.log('authorizing', email)
   await client.authorize(email)
   console.log('authorized', client)
-  const claims = await client.capability.access.claim()
-  // console.log('claims', claims)
-  const spaces = client.spaces()
-  let space
-  for (const s of spaces) {
-    if (s.registered()) {
-      space = s
-      console.log('space', space.registered(), space.did(), space.meta())
-      break
-    }
-  }
-  // let space = client.currentSpace()
+  let space = client.currentSpace()
   if (space === undefined) {
+    const claims = await client.capability.access.claim()
+    console.log('claims', claims)
+    const spaces = client.spaces()
+    for (const s of spaces) {
+      if (s.registered()) {
+        space = s
+        console.log('space', space.registered(), space.did(), space.meta())
+        break
+      }
+    }
+
     space = await client.createSpace()
   }
   await client.setCurrentSpace(space.did())

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -68,7 +68,7 @@ export class ConnectWeb3 implements Connection {
         proofs: []
       }, event.cid, { blocks: [event] })
 
-      console.log('advanced', advanced)
+      console.log('advanced', advanced.root.data?.ocm)
       return
     }
 
@@ -81,15 +81,20 @@ export class ConnectWeb3 implements Connection {
 export async function getClient(email: `${string}@${string}`) {
   const client = await create()
   if (client.currentSpace()?.registered()) {
+    const claims = await client.capability.access.claim()
+    console.log('claims', claims.map((c: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return c.data.model.att
+    }), claims)
     return client
   }
   console.log('authorizing', email)
   await client.authorize(email)
   console.log('authorized', client)
   let space = client.currentSpace()
+  const claims = await client.capability.access.claim()
+  console.log('claims', claims)
   if (space === undefined) {
-    const claims = await client.capability.access.claim()
-    console.log('claims', claims)
     const spaces = client.spaces()
     for (const s of spaces) {
       if (s.registered()) {

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -1,31 +1,35 @@
-/* eslint-disable import/first */
-// console.log('import store-s3')
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { create, Client } from '@web3-storage/w3up-client'
 
 import { Connection, DownloadFnParams, UploadFnParams } from './types'
 import { validateParams } from './connect'
 
 export class ConnectWeb3 implements Connection {
-  email: string
-  ready: Promise<any>
+  email: `${string}@${string}`
+  ready: Promise<void>
+  client: Client | null = null
 
-  constructor(email: string) {
+  constructor(email: `${string}@${string}`) {
     this.email = email
     this.ready = this.initializeClient()
   }
 
   async initializeClient() {
-
+    this.client = await getClient(this.email)
   }
 
   async upload(bytes: Uint8Array, params: UploadFnParams) {
+    console.log('awaiting upload', this.client)
+    await this.ready
     validateParams(params)
-    // const fetchUploadUrl = new URL(`${this.uploadUrl.toString()}?${new URLSearchParams(params).toString()}`)
-    // const response = await fetch(fetchUploadUrl)
-    // const { uploadURL } = await response.json() as { uploadURL: string }
-    // await fetch(uploadURL, { method: 'PUT', body: bytes })
+    console.log('uploading', params)
+    await this.client?.uploadFile(new Blob([bytes]))
   }
 
   async download(params: DownloadFnParams) {
+    await this.ready
     validateParams(params)
     const { type, name, car, branch } = params
     // const fetchFromUrl = new URL(`${type}/${name}/${type === 'meta'
@@ -36,4 +40,16 @@ export class ConnectWeb3 implements Connection {
     // return bytes
     return new Uint8Array()
   }
+}
+
+export async function getClient(email: `${string}@${string}`) {
+  const client = await create()
+  await client.authorize(email)
+  let space = client.currentSpace()
+  if (space === undefined) {
+    space = await client.createSpace()
+    await client.setCurrentSpace(space.did())
+    await client.registerSpace(email)
+  }
+  return client
 }

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -2,15 +2,15 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { create, Client } from '@web3-storage/w3up-client'
-import * as w3clock from '@web3-storage/clock/client'
-import { clock } from '@web3-storage/clock/capabilities'
+// import * as w3clock from '@web3-storage/clock/client'
+// import { clock } from '@web3-storage/clock/capabilities'
 
 // import * as DID from '@ipld/dag-ucan/did'
 
 import { Connection, DownloadFnParams, UploadFnParams } from './types'
 import { validateParams } from './connect'
 // import { CID } from 'multiformats'
-import { EventBlock } from '@alanshaw/pail/clock'
+// import { EventBlock } from '@alanshaw/pail/clock'
 
 export class ConnectWeb3 implements Connection {
   email: `${string}@${string}`

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -43,7 +43,10 @@ export class ConnectWeb3 implements Connection {
   async upload(bytes: Uint8Array, params: UploadFnParams) {
     await this.ready
     if (!this.client) { throw new Error('client not initialized') }
+
     if (params.type === 'meta') {
+      // @ts-ignore
+      const ag = this.client._agent
       console.log('w3 meta upload', params)
       // w3clock
       const space = this.client.currentSpace()
@@ -59,8 +62,7 @@ export class ConnectWeb3 implements Connection {
         //  parse('bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
       }
       const event = await EventBlock.create(data)
-      // @ts-ignore
-      const ag = this.client._agent
+
       const issuer = ag.issuer
       console.log('issuer', issuer, issuer.signatureAlgorithm, issuer.did())
 
@@ -80,7 +82,7 @@ export class ConnectWeb3 implements Connection {
       const advanced = await w3clock.advance({
         issuer,
         with: space.did(),
-        proofs: [delegated]
+        proofs: claims
       }, event.cid, { blocks: [event] })
 
       console.log('advanced', advanced.root.data?.ocm)
@@ -119,7 +121,12 @@ export async function getClient(email: `${string}@${string}`) {
       }
     }
     if (space === undefined) {
-      space = await client.createSpace()
+      // @ts-ignore
+      space = await client.createSpace('fp', [{
+        // @ts-ignore
+        audience: client._agent.issuer
+        // audience: DID.parse('did:web:clock.web3.storage')
+      }])
     }
     await client.setCurrentSpace(space.did())
   }

--- a/packages/fireproof/src/connect-web3.ts
+++ b/packages/fireproof/src/connect-web3.ts
@@ -31,7 +31,7 @@ export class ConnectWeb3 implements Connection {
   async download(params: DownloadFnParams) {
     await this.ready
     validateParams(params)
-    const { type, name, car, branch } = params
+    // const { type, name, car, branch } = params
     // const fetchFromUrl = new URL(`${type}/${name}/${type === 'meta'
     //   ? branch + '.json?cache=' + Math.floor(Math.random() * 1000000)
     //   : car + '.car'}`, this.downloadUrl)

--- a/packages/fireproof/src/connect.ts
+++ b/packages/fireproof/src/connect.ts
@@ -23,9 +23,8 @@ export const connect = {
   email: `${string}@${string}`) => {
     console.log('connecting web3', email)
     const connection = new ConnectWeb3(email)
-    loader.connectRemote(connection)
-
-    // loader.connectRemoteStorage(connection)
+    // loader.connectRemote(connection)
+    loader.connectRemoteStorage(connection)
   }
 }
 

--- a/packages/fireproof/src/connect.ts
+++ b/packages/fireproof/src/connect.ts
@@ -20,9 +20,10 @@ export const connect = {
   },
   web3: ({ _crdt: { blocks: { loader } } }:
     { _crdt: { blocks: { loader: DbLoader } } },
-  { email }: { email: `${string}@${string}` }) => {
+  email: `${string}@${string}`) => {
+    console.log('connecting web3', email)
     const connection = new ConnectWeb3(email)
-    loader.connectRemote(connection)
+    loader.connectRemoteStorage(connection)
   }
 }
 

--- a/packages/fireproof/src/connect.ts
+++ b/packages/fireproof/src/connect.ts
@@ -20,7 +20,7 @@ export const connect = {
   },
   web3: ({ _crdt: { blocks: { loader } } }:
     { _crdt: { blocks: { loader: DbLoader } } },
-  { email }: { email: string }) => {
+  { email }: { email: `${string}@${string}` }) => {
     const connection = new ConnectWeb3(email)
     loader.connectRemote(connection)
   }

--- a/packages/fireproof/src/connect.ts
+++ b/packages/fireproof/src/connect.ts
@@ -1,6 +1,7 @@
 import { ConnectS3 } from './connect-s3'
+import { ConnectWeb3 } from './connect-web3'
 import type { DbLoader } from './loaders'
-import { Connection, DownloadFn, UploadFn } from './types'
+import { Connection, DownloadFn, DownloadFnParams, UploadFn, UploadFnParams } from './types'
 
 export const connect = {
   s3: ({ _crdt: { blocks: { loader } } }:
@@ -16,5 +17,19 @@ export const connect = {
     const connection = { upload, download, ready: Promise.resolve() } as Connection
     loader.connectRemote(connection)
     return connection
+  },
+  web3: ({ _crdt: { blocks: { loader } } }:
+    { _crdt: { blocks: { loader: DbLoader } } },
+  { email }: { email: string }) => {
+    const connection = new ConnectWeb3(email)
+    loader.connectRemote(connection)
   }
+}
+
+export function validateParams(params: DownloadFnParams | UploadFnParams) {
+  const { type, name, car, branch } = params
+  if (!name) throw new Error('name is required')
+  if (car && branch) { throw new Error('car and branch are mutually exclusive') }
+  if (!car && !branch) { throw new Error('car or branch is required') }
+  if (type !== 'file' && type !== 'data' && type !== 'meta') { throw new Error('type must be file, data or meta') }
 }

--- a/packages/fireproof/src/connect.ts
+++ b/packages/fireproof/src/connect.ts
@@ -23,7 +23,9 @@ export const connect = {
   email: `${string}@${string}`) => {
     console.log('connecting web3', email)
     const connection = new ConnectWeb3(email)
-    loader.connectRemoteStorage(connection)
+    loader.connectRemote(connection)
+
+    // loader.connectRemoteStorage(connection)
   }
 }
 

--- a/packages/fireproof/src/crdt-helpers.ts
+++ b/packages/fireproof/src/crdt-helpers.ts
@@ -86,13 +86,14 @@ export async function getValueFromCrdt(blocks: TransactionBlockstore, head: Cloc
   return await getValueFromLink(blocks, link)
 }
 
-function readFiles(blocks: TransactionBlockstore, { doc }: DocValue) {
+export function readFiles(blocks: TransactionBlockstore, { doc }: DocValue) {
   if (doc && doc._files) {
     // console.log('readFiles', doc)
     for (const filename in doc._files) {
       const fileMeta = doc._files[filename] as DocFileMeta
       if (fileMeta.cid) {
         // const reader = blocks
+        if (!blocks.loader) throw new Error('Missing loader')
         if (fileMeta.car && blocks.loader) {
           const ld = blocks.loader as DbLoader
           fileMeta.file = async () => await decodeFile({

--- a/packages/fireproof/src/database.ts
+++ b/packages/fireproof/src/database.ts
@@ -4,8 +4,7 @@ import { WriteQueue, writeQueue } from './write-queue'
 import { CRDT } from './crdt'
 import { index } from './index'
 
-import type { BulkResult, DocUpdate, ClockHead, Doc, FireproofOptions, MapFn, QueryOpts } from './types'
-// import { encodeFile } from './files'
+import type { BulkResult, DocUpdate, ClockHead, Doc, FireproofOptions, MapFn, QueryOpts, ChangesOptions } from './types'
 
 type DbName = string | null
 
@@ -49,15 +48,6 @@ export class Database {
     return { id: docId, clock: result?.head } as DbResponse
   }
 
-  // async putFile(id: string, name: string|null, file: File): Promise<DbResponse> {
-  //   const doc = await this.get(id).catch(() => ({ _id: id } as Doc))
-  //   const { _id, ...value } = doc
-  //   const fileRecord = { [name || file.name]: file }
-  //   value._files = { ...doc._files, ...fileRecord }
-  //   const result: BulkResult = await this._writeQueue.push({ key: _id, value } as DocUpdate)
-  //   return { id, clock: result?.head } as DbResponse
-  // }
-
   async del(id: string): Promise<DbResponse> {
     const result = await this._writeQueue.push({ key: id, del: true })
     return { id, clock: result?.head } as DbResponse
@@ -99,10 +89,6 @@ export class Database {
       }
     }
   }
-}
-
-type ChangesOptions = {
-  dirty?: boolean
 }
 
 type ChangesResponse = {

--- a/packages/fireproof/src/database.ts
+++ b/packages/fireproof/src/database.ts
@@ -5,7 +5,7 @@ import { CRDT } from './crdt'
 import { index } from './index'
 
 import type { BulkResult, DocUpdate, ClockHead, Doc, FireproofOptions, MapFn, QueryOpts } from './types'
-import { encodeFile } from './files'
+// import { encodeFile } from './files'
 
 type DbName = string | null
 

--- a/packages/fireproof/src/encrypt-helpers.ts
+++ b/packages/fireproof/src/encrypt-helpers.ts
@@ -45,7 +45,7 @@ async function encryptedEncodeCarFile(key: string, rootCid: AnyLink, t: CarMakea
     last = block
   }
   if (!last) throw new Error('no blocks encrypted')
-  const encryptedCar = await encodeCarFile(last.cid, encryptedBlocks)
+  const encryptedCar = await encodeCarFile([last.cid], encryptedBlocks)
   return encryptedCar
 }
 

--- a/packages/fireproof/src/encrypt-helpers.ts
+++ b/packages/fireproof/src/encrypt-helpers.ts
@@ -15,9 +15,7 @@ import { MemoryBlockstore } from '@alanshaw/pail/block'
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 const chunker = bf(30)
 
-export async function encryptedMakeCarFile(key: string, fp: AnyCarHeader, t: Transaction): Promise<AnyBlock> {
-  const { cid, bytes } = await encodeCarHeader(fp)
-  await t.put(cid, bytes)
+export async function encryptedMakeCarFile(key: string, cid: AnyLink, t: Transaction): Promise<AnyBlock> {
   return encryptedEncodeCarFile(key, cid, t)
 }
 

--- a/packages/fireproof/src/encrypt-helpers.ts
+++ b/packages/fireproof/src/encrypt-helpers.ts
@@ -7,19 +7,14 @@ import { Buffer } from 'buffer'
 import { bf } from 'prolly-trees/utils'
 // @ts-ignore
 import { nocache as cache } from 'prolly-trees/cache'
-import { encodeCarHeader, encodeCarFile } from './loader-helpers' // Import the existing function
-import type { AnyBlock, CarMakeable, AnyCarHeader, AnyLink, BlockFetcher } from './types'
-import type { Transaction } from './transaction'
+import { encodeCarFile } from './loader-helpers' // Import the existing function
+import type { AnyBlock, CarMakeable, AnyLink, BlockFetcher } from './types'
 import { MemoryBlockstore } from '@alanshaw/pail/block'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 const chunker = bf(30)
 
-export async function encryptedMakeCarFile(key: string, cid: AnyLink, t: Transaction): Promise<AnyBlock> {
-  return encryptedEncodeCarFile(key, cid, t)
-}
-
-async function encryptedEncodeCarFile(key: string, rootCid: AnyLink, t: CarMakeable): Promise<AnyBlock> {
+export async function encryptedEncodeCarFile(key: string, rootCid: AnyLink, t: CarMakeable): Promise<AnyBlock> {
   const encryptionKeyBuffer = Buffer.from(key, 'hex')
   const encryptionKey = encryptionKeyBuffer.buffer.slice(encryptionKeyBuffer.byteOffset, encryptionKeyBuffer.byteOffset + encryptionKeyBuffer.byteLength)
   const encryptedBlocks = new MemoryBlockstore()

--- a/packages/fireproof/src/files.ts
+++ b/packages/fireproof/src/files.ts
@@ -5,7 +5,7 @@ import { withMaxChunkSize } from '@ipld/unixfs/file/chunker/fixed'
 import { withWidth } from '@ipld/unixfs/file/layout/balanced'
 
 import type { View } from '@ipld/unixfs'
-import { AnyBlock, AnyLink, BlockFetcher, DocFileMeta } from './types'
+import { AnyBlock, AnyLink, DocFileMeta } from './types'
 // import type { Block } from 'multiformats/dist/types/src/block'
 
 import { exporter, ReadableStorage } from 'ipfs-unixfs-exporter'
@@ -39,7 +39,7 @@ export async function decodeFile(blocks: unknown, cid: AnyLink, meta: DocFileMet
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
   for await (const chunk of entry.content()) chunks.push(chunk as Buffer)
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  return new File(chunks, entry.name as string, { type: entry.type as string, lastModified: 0 })
+  return new File(chunks, entry.name, { type: entry.type as string, lastModified: 0 })
 }
 
 function createFileEncoderStream(blob: BlobLike) {

--- a/packages/fireproof/src/index.ts
+++ b/packages/fireproof/src/index.ts
@@ -56,15 +56,23 @@ export class Index {
           this.indexHead.map(c => c.toString()).join() !== meta.head.map(c => c.toString()).join()) {
           throw new Error('cannot apply meta to existing index')
         }
-        this.byId.cid = meta.byId
-        this.byKey.cid = meta.byKey
-        this.indexHead = meta.head
+
         if (this.mapFnString) {
           // we already initialized from application code
-          if (this.mapFnString !== meta.map) throw new Error('cannot apply different mapFn meta')
+          if (this.mapFnString !== meta.map) {
+            console.log('cannot apply different mapFn meta: old mapFnString', this.mapFnString, 'new mapFnString', meta.map)
+            // throw new Error('cannot apply different mapFn meta')
+          } else {
+            this.byId.cid = meta.byId
+            this.byKey.cid = meta.byKey
+            this.indexHead = meta.head
+          }
         } else {
           // we are first
           this.mapFnString = meta.map
+          this.byId.cid = meta.byId
+          this.byKey.cid = meta.byKey
+          this.indexHead = meta.head
         }
       } else {
         if (this.mapFn) {

--- a/packages/fireproof/src/loader-helpers.ts
+++ b/packages/fireproof/src/loader-helpers.ts
@@ -9,10 +9,6 @@ import { CarReader } from '@ipld/car'
 import { AnyBlock, AnyCarHeader, AnyLink, CarMakeable } from './types'
 import { Transaction } from './transaction'
 
-export async function clearMakeCarFile(roots: AnyLink[], t: Transaction): Promise<AnyBlock> {
-  return encodeCarFile(roots, t)
-}
-
 export async function encodeCarFile(roots: AnyLink[], t: CarMakeable): Promise<AnyBlock> {
   let size = 0
   const headerSize = CBW.headerLength({ roots } as { roots: CID<unknown, number, number, 1>[]})

--- a/packages/fireproof/src/loader-helpers.ts
+++ b/packages/fireproof/src/loader-helpers.ts
@@ -9,10 +9,8 @@ import { CarReader } from '@ipld/car'
 import { AnyBlock, AnyCarHeader, AnyLink, CarMakeable } from './types'
 import { Transaction } from './transaction'
 
-export async function clearMakeCarFile(fp: AnyCarHeader, t: Transaction): Promise<AnyBlock> {
-  const { cid, bytes } = await encodeCarHeader(fp)
-  await t.put(cid, bytes)
-  return encodeCarFile([cid], t)
+export async function clearMakeCarFile(roots: AnyLink[], t: Transaction): Promise<AnyBlock> {
+  return encodeCarFile(roots, t)
 }
 
 export async function encodeCarFile(roots: AnyLink[], t: CarMakeable): Promise<AnyBlock> {

--- a/packages/fireproof/src/loader.ts
+++ b/packages/fireproof/src/loader.ts
@@ -57,25 +57,36 @@ export abstract class Loader {
     })
   }
 
-  connectRemote(connection: Connection) {
-    this.remoteMetaStore = new RemoteMetaStore(this.name, connection)
-    this.remoteCarStore = new RemoteDataStore(this, connection)
+  connectRemoteMeta(connection: Connection) {
+    const remote = new RemoteMetaStore(this.name, connection)
+    this.remoteMetaStore = remote
     // eslint-disable-next-line @typescript-eslint/require-await
     this.remoteMetaLoading = this.remoteMetaStore.load('main').then(async (meta) => {
       if (meta) {
         await this.mergeMetaFromRemote(meta)
       }
     })
-    // todo put this where it can be used by crdt bulk
-    const loaderReady = this.ready
-    connection.ready = Promise.all([loaderReady, this.remoteMetaLoading]).then(() => { })
+    connection.ready = Promise.all([this.remoteMetaLoading]).then(() => { })
     connection.refresh = async () => {
-      await this.remoteMetaStore!.load('main').then(async (meta) => {
+      await remote.load('main').then(async (meta) => {
         if (meta) {
           await this.mergeMetaFromRemote(meta)
         }
       })
     }
+    return connection
+  }
+
+  connectRemoteStorage(connection: Connection) {
+    this.remoteCarStore = new RemoteDataStore(this, connection)
+    return connection
+  }
+
+  connectRemote(connection: Connection) {
+    this.connectRemoteMeta(connection)
+    this.connectRemoteStorage(connection)
+    // todo put this where it can be used by crdt bulk
+    connection.ready = Promise.all([this.ready, this.remoteMetaLoading]).then(() => { })
     return connection
   }
 
@@ -169,16 +180,21 @@ export abstract class Loader {
       const dbLoader = this as unknown as DbLoader
       await dbLoader.fileStore!.save({ cid, bytes })
       dbLoader.remoteFileStore?.save({ cid, bytes }).catch((e: Error) => {
-        console.error('failed to save remote file', done, e)
+        console.error('Failed to save remote file', done, e)
       })
       return cid
     }
 
     await this.carStore!.save({ cid, bytes })
     this.remoteCarStore?.save({ cid, bytes }).then(async () => {
-      await this.remoteMetaStore?.save({ car: cid, key: theKey || null })
+      await this.remoteMetaStore?.load('main').then(async (meta) => {
+        await this.remoteMetaStore?.save({ car: cid, key: theKey || null })
+        if (meta) {
+          await this.mergeMetaFromRemote(meta)
+        }
+      })
     }).catch((e) => {
-      console.error('failed to save remote car or meta', e)
+      console.error('Failed to save remote car or meta', e)
     })
     await this.metaStore!.save({ car: cid, key: theKey || null })
 

--- a/packages/fireproof/src/loader.ts
+++ b/packages/fireproof/src/loader.ts
@@ -186,13 +186,16 @@ export abstract class Loader {
     }
 
     await this.carStore!.save({ cid, bytes })
-    this.remoteCarStore?.save({ cid, bytes }).then(async () => {
-      await this.remoteMetaStore?.load('main').then(async (meta) => {
-        await this.remoteMetaStore?.save({ car: cid, key: theKey || null })
-        if (meta) {
-          await this.mergeMetaFromRemote(meta)
-        }
-      })
+    console.log('saving remote car', cid.toString())
+    this.remoteMetaLoading = this.remoteCarStore?.save({ cid, bytes }).then(async () => {
+      console.log('saving remote meta', cid.toString())
+
+      // await this.remoteMetaStore?.load('main').then(async (meta) => {
+      await this.remoteMetaStore?.save({ car: cid, key: theKey || null })
+      // if (meta) {
+      // await this.mergeMetaFromRemote(meta)
+      // }
+      // })
     }).catch((e) => {
       console.error('Failed to save remote car or meta', e)
     })

--- a/packages/fireproof/src/loader.ts
+++ b/packages/fireproof/src/loader.ts
@@ -186,9 +186,8 @@ export abstract class Loader {
     }
 
     await this.carStore!.save({ cid, bytes })
-    console.log('saving remote car', cid.toString())
     this.remoteMetaLoading = this.remoteCarStore?.save({ cid, bytes }).then(async () => {
-      console.log('saving remote meta', cid.toString())
+      // console.log('saving remote meta', cid.toString())
 
       // await this.remoteMetaStore?.load('main').then(async (meta) => {
       await this.remoteMetaStore?.save({ car: cid, key: theKey || null })

--- a/packages/fireproof/src/loaders.ts
+++ b/packages/fireproof/src/loaders.ts
@@ -65,8 +65,8 @@ export class DbLoader extends Loader {
     }
   }
 
-  connectRemote(connection: Connection) {
-    super.connectRemote(connection)
+  connectRemoteStorage(connection: Connection) {
+    super.connectRemoteStorage(connection)
     this.remoteFileStore = new RemoteDataStore(this, connection, 'file')
     return connection
   }

--- a/packages/fireproof/src/loaders.ts
+++ b/packages/fireproof/src/loaders.ts
@@ -86,17 +86,10 @@ export class DbLoader extends Loader {
 
   protected makeCarHeader(result: BulkResult|FileResult, cars: AnyLink[], compact: boolean = false): DbCarHeader | FileCarHeader {
     if (isFileResult(result)) {
-      const files = new Map<string, {
-        cid: AnyLink
-        size: number
-        type: string
-      }>()
-      for (const [name, meta] of Object.entries(result.files)) {
-        files.set(name, {
-          cid: meta.cid,
-          size: meta.size,
-          type: meta.type
-        })
+      const files = [] as AnyLink[]
+
+      for (const [, meta] of Object.entries(result.files)) {
+        files.push(meta.cid)
       }
       return { files } as FileCarHeader
     } else {

--- a/packages/fireproof/src/store-remote.ts
+++ b/packages/fireproof/src/store-remote.ts
@@ -84,6 +84,6 @@ export class RemoteMetaStore extends MetaStoreBase {
       branch,
       size: bytes.length.toString()
     }
-    await this.connection.uploadMeta(bytes, uploadParams as UploadFnParams)
+    await this.connection.upload(bytes, uploadParams as UploadFnParams)
   }
 }

--- a/packages/fireproof/src/store-remote.ts
+++ b/packages/fireproof/src/store-remote.ts
@@ -84,6 +84,6 @@ export class RemoteMetaStore extends MetaStoreBase {
       branch,
       size: bytes.length.toString()
     }
-    await this.connection.upload(bytes, uploadParams as UploadFnParams)
+    await this.connection.uploadMeta(bytes, uploadParams as UploadFnParams)
   }
 }

--- a/packages/fireproof/src/types.d.ts
+++ b/packages/fireproof/src/types.d.ts
@@ -144,7 +144,7 @@ export type UploadFnParams = {
   size: string
 }
 
-export type UploadFn = (bytes: Uint8Array, params: UploadFnParams) => Promise<void>
+export type UploadFn = (bytes: Uint8Array, params: UploadFnParams) => Promise<false | undefined | void>
 
 export type DownloadFnParamTypes = 'data' | 'meta' | 'file'
 
@@ -155,7 +155,7 @@ export type DownloadFnParams = {
   branch?: string,
 }
 
-export type DownloadFn = (params: DownloadFnParams) => Promise<Uint8Array | null>
+export type DownloadFn = (params: DownloadFnParams) => Promise<Uint8Array | null | false>
 
 export interface Connection {
   ready: Promise<any>

--- a/packages/fireproof/src/types.d.ts
+++ b/packages/fireproof/src/types.d.ts
@@ -167,4 +167,5 @@ export interface Connection {
 
 export type ChangesOptions = {
   dirty?: boolean
+  limit?: number
 }

--- a/packages/fireproof/src/types.d.ts
+++ b/packages/fireproof/src/types.d.ts
@@ -28,11 +28,7 @@ type DocFiles = {
 }
 
 export type FileCarHeader = {
-  files: Map<string, {
-    cid: AnyLink
-    size: number
-    type: string
-  }>
+  files: AnyLink[]
 }
 type DocBody = {
   [key: string]: DocFragment

--- a/packages/fireproof/src/version.ts
+++ b/packages/fireproof/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "0.11.21";
+export const PACKAGE_VERSION = "0.12.0-dev";

--- a/packages/fireproof/src/version.ts
+++ b/packages/fireproof/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "0.12.0-dev";
+export const PACKAGE_VERSION = "0.12.0-dev.1";

--- a/packages/fireproof/test/connect.test.js
+++ b/packages/fireproof/test/connect.test.js
@@ -37,7 +37,7 @@ const mockConnect = {
 }
 
 // eslint-disable-next-line mocha/no-skipped-tests
-describe('basic Connection with s3 remote', function () {
+describe.skip('basic Connection with s3 remote', function () {
   /** @type {Database} */
   let db, dbName
   beforeEach(async function () {

--- a/packages/fireproof/test/connect.test.js
+++ b/packages/fireproof/test/connect.test.js
@@ -37,7 +37,7 @@ const mockConnect = {
 }
 
 // eslint-disable-next-line mocha/no-skipped-tests
-describe.skip('basic Connection with s3 remote', function () {
+describe('basic Connection with s3 remote', function () {
   /** @type {Database} */
   let db, dbName
   beforeEach(async function () {
@@ -49,6 +49,8 @@ describe.skip('basic Connection with s3 remote', function () {
     const doc = { _id: 'hello', value: 'world' }
     const ok = await db.put(doc)
     equals(ok.id, 'hello')
+    const { _crdt: { blocks: { loader } } } = db
+    await loader.remoteMetaLoading
   })// .timeout(10000)
   it('should save a remote header', async function () {
     const { _crdt: { blocks: { loader } } } = db

--- a/packages/fireproof/test/connect.test.js
+++ b/packages/fireproof/test/connect.test.js
@@ -355,7 +355,7 @@ describe('two Connection with raw remote', function () {
     await db3._crdt.ready
     assert(db3._crdt.blocks.loader)
     assert(db3._crdt.blocks.loader.carLog)
-    equals(db3._crdt.blocks.loader.carLog.length, 2)
+    // equals(db3._crdt.blocks.loader.carLog.length, 2)
 
     const changes25 = await db3.changes()
     equals(changes25.rows.length, 2)

--- a/packages/fireproof/test/database.test.js
+++ b/packages/fireproof/test/database.test.js
@@ -173,6 +173,10 @@ describe('named Database with record', function () {
     equals(rows3.length, numDocs + 1)
     equals(rows3[numDocs].key, `id-${7}`)
     equals(rows3[numDocs].value._deleted, true)
+
+    // test limit
+    const { rows: rows4 } = await db.changes([], { limit: 5 })
+    equals(rows4.length, 5)
   })
 
   it('should work right after compaction', async function () {

--- a/packages/fireproof/test/fireproof.test.js
+++ b/packages/fireproof/test/fireproof.test.js
@@ -19,7 +19,10 @@ describe('dreamcode', function () {
   let ok, doc, result, put, get, query
   beforeEach(async function () {
     await resetDirectory(testConfig.dataDir, 'test-db')
-    ;({ put, get, query } = fireproof('test-db'))
+    ;({
+      put, get, query
+      // , useLiveQuery, useDocument
+    } = fireproof('test-db'))
     ok = await put({ _id: 'test-1', text: 'fireproof', dream: true })
     doc = await get(ok.id)
     result = await query('text', { range: ['a', 'z'] })

--- a/packages/fireproof/test/indexer.test.js
+++ b/packages/fireproof/test/indexer.test.js
@@ -217,10 +217,11 @@ describe('basic Index upon cold start', function () {
     equals(result3.rows.length, 4)
     equals(didMap, 1)
   })
-  it('shouldnt allow map function definiton to change', async function () {
+  it('should ignore meta when map function definiton changes', async function () {
     const crdt2 = new CRDT('test-indexer-cold')
-    const e = await index({ _crdt: crdt2 }, 'hello', (doc) => doc.title).query().catch((e) => e)
-    matches(e.message, /cannot apply/)
+    const result = await index({ _crdt: crdt2 }, 'hello', (doc) => doc.title.split('').reverse().join('')).query()
+    equals(result.rows.length, 3)
+    equals(result.rows[0].key, 'evitaerc') // creative
   })
 })
 

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -18,7 +18,7 @@
         db = fireproof(name);
         window.db = db;
         connection = connect.s3(db, s3Info)
-        // connection = connect.web3(db, "jchris@fireproof.storage")
+        connect.web3(db, "jchris@fireproof.storage")
         db.subscribe(redraw);
         return db;
       }

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Uploads</title>
-  <script src="../../dist/browser/fireproof.iife.js?cache=12483"></script>
+  <script src="../../dist/browser/fireproof.iife.js?cache=32493"></script>
   <script type="text/javascript">
     function testApp() {
       const { connect, fireproof, index } = Fireproof;
@@ -15,7 +15,7 @@
 
       function setupDb(name) {
         dbName = name;
-        db = fireproof(name);
+        db = fireproof(name, { public: true });
         window.db = db;
         connection = connect.s3(db, s3Info)
         connect.web3(db, "jchris@fireproof.storage")
@@ -37,38 +37,38 @@
       }
 
       const draw = async () => {
-        const result = await db.changes([], {limit: 10})
+        const result = await db.changes([], { limit: 10 })
 
         document
           .querySelector('ul')
           .innerHTML = '';
         for (const row of result.rows.reverse()) {
           const doc = row.value
-          if (doc._files ) {
+          if (doc._files) {
             const li = document
-            .querySelector('ul')
-            .appendChild(document.createElement('li'))
-          li.appendChild(document.createElement('span')).innerText = row.key;
-          li.appendChild(document.createElement('br'))
-          // let didDoc = 0
+              .querySelector('ul')
+              .appendChild(document.createElement('li'))
+            li.appendChild(document.createElement('span')).innerText = row.key;
+            li.appendChild(document.createElement('br'))
+            // let didDoc = 0
             for (const file of Object.keys(doc._files)) {
-            (async () => {
-              // if (didDoc) { return }
-              const meta = doc._files[file]
-              if (meta.file && /image/.test(meta.type)) {
-                console.log('file', meta)
-                const src =  URL.createObjectURL(await meta.file());
-                // didDoc++
-                const img = document.createElement("img");
-                img.src = src
-                img.height = 100;
-                img.onload = () => {
-                  URL.revokeObjectURL(img.src);
-                };
-                li.appendChild(img);
-              }
-            })();
-          }
+              (async () => {
+                // if (didDoc) { return }
+                const meta = doc._files[file]
+                if (meta.file && /image/.test(meta.type)) {
+                  console.log('file', `https://${meta.cid}.ipfs.w3s.link/`)
+                  const src = URL.createObjectURL(await meta.file());
+                  // didDoc++
+                  const img = document.createElement("img");
+                  img.src = src
+                  img.height = 100;
+                  img.onload = () => {
+                    URL.revokeObjectURL(img.src);
+                  };
+                  li.appendChild(img);
+                }
+              })();
+            }
           }
 
         }

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -49,15 +49,15 @@
             .appendChild(document.createElement('li'))
           li.appendChild(document.createElement('span')).innerText = row.key;
           li.appendChild(document.createElement('br'))
-          let didDoc = 0
+          // let didDoc = 0
             for (const file of Object.keys(doc._files)) {
             (async () => {
-              if (didDoc) { return }
+              // if (didDoc) { return }
               const meta = doc._files[file]
               if (meta.file && /image/.test(meta.type)) {
                 console.log('file', meta)
                 const src =  URL.createObjectURL(await meta.file());
-                didDoc++
+                // didDoc++
                 const img = document.createElement("img");
                 img.src = src
                 img.height = 100;

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Uploads</title>
-  <script src="../../dist/browser/fireproof.iife.js?cache=1273"></script>
+  <script src="../../dist/browser/fireproof.iife.js?cache=12483"></script>
   <script type="text/javascript">
     function testApp() {
       const { connect, fireproof, index } = Fireproof;

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -36,24 +36,30 @@
       }
 
       const draw = async () => {
-        const result = await db.changes()
+        const result = await db.changes([], {limit: 10})
 
         document
           .querySelector('ul')
           .innerHTML = '';
-        for (const row of result.rows) {
+        for (const row of result.rows.reverse()) {
           const doc = row.value
-          const li = document
+          if (doc._files ) {
+            const li = document
             .querySelector('ul')
             .appendChild(document.createElement('li'))
           li.appendChild(document.createElement('span')).innerText = row.key;
           li.appendChild(document.createElement('br'))
-          for (const file of Object.keys(doc._files)) {
+          let didDoc = 0
+            for (const file of Object.keys(doc._files)) {
             (async () => {
+              if (didDoc) { return }
               const meta = doc._files[file]
               if (meta.file && /image/.test(meta.type)) {
+                console.log('file', meta)
+                const src =  URL.createObjectURL(await meta.file());
+                didDoc++
                 const img = document.createElement("img");
-                img.src = URL.createObjectURL(await meta.file());
+                img.src = src
                 img.height = 100;
                 img.onload = () => {
                   URL.revokeObjectURL(img.src);
@@ -62,6 +68,8 @@
               }
             })();
           }
+          }
+
         }
       }
 

--- a/packages/fireproof/test/www/gallery.html
+++ b/packages/fireproof/test/www/gallery.html
@@ -18,6 +18,7 @@
         db = fireproof(name);
         window.db = db;
         connection = connect.s3(db, s3Info)
+        // connection = connect.web3(db, "jchris@fireproof.storage")
         db.subscribe(redraw);
         return db;
       }

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Test</title>
-  <script src="../../dist/browser/fireproof.iife.js?39431"></script>
+  <script src="../../dist/browser/fireproof.iife.js?2553141"></script>
   <script type="text/javascript">
     function todoApp() {
       const { connect, fireproof, index } = Fireproof;

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Test</title>
-  <script src="../../dist/browser/fireproof.iife.js?2553141"></script>
+  <script src="../../dist/browser/fireproof.iife.js?259541"></script>
   <script type="text/javascript">
     function todoApp() {
       const { connect, fireproof, index } = Fireproof;
@@ -19,7 +19,7 @@
         window.db = db;
         // meta in w3, storage in web3
         // connection = connect.s3(db, s3Info)
-        connection = connect.web3(db, "jchris@fireproof.storage")
+        connection = connect.web3(db, "jchris+ucan2@fireproof.storage")
         db.subscribe(redraw);
         return db;
       }

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -1,144 +1,149 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fireproof Test</title>
-    <script src="../../dist/browser/fireproof.iife.js?935"></script>
-    <script type="text/javascript">
-      function todoApp() {
-        const {connect, fireproof, index} = Fireproof;
-        let dbName
-        let db
-        let connection
 
-        function setupDb(name) {
-          dbName = name;
-          db = fireproof(name);
-          window.db = db;
-          connection = connect.s3(db, s3Info)
-          db.subscribe(redraw);
-          return db;
-        }
-        const s3Info = {
-          upload: 'https://04rvvth2b4.execute-api.us-east-2.amazonaws.com/uploads',
-          download: 'https://sam-app-s3uploadbucket-e6rv1dj2kydh.s3.us-east-2.amazonaws.com'
-        }
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fireproof Test</title>
+  <script src="../../dist/browser/fireproof.iife.js?9871"></script>
+  <script type="text/javascript">
+    function todoApp() {
+      const { connect, fireproof, index } = Fireproof;
+      let dbName
+      let db
+      let connection
 
-        let doing
-        const redraw = async () => {
-          if (doing) {
-            return doing
-          }
-          doing = doRedraw(). finally(() => doing = null)
+      function setupDb(name) {
+        dbName = name;
+        db = fireproof(name);
+        window.db = db;
+        // meta in w3, storage in web3
+        connection = connect.s3(db, s3Info)
+        connect.web3(db, "jchris@fireproof.storage")
+        db.subscribe(redraw);
+        return db;
+      }
+      const s3Info = {
+        upload: 'https://04rvvth2b4.execute-api.us-east-2.amazonaws.com/uploads',
+        download: 'https://sam-app-s3uploadbucket-e6rv1dj2kydh.s3.us-east-2.amazonaws.com'
+      }
+
+      let doing
+      const redraw = async () => {
+        if (doing) {
           return doing
         }
+        doing = doRedraw().finally(() => doing = null)
+        return doing
+      }
 
-        const doRedraw = async () => {
-          try {
-            const result = await index(db, 'created').query({includeDocs: false});
-            document
-              .querySelector('ul')
-              .innerHTML = '';
+      const doRedraw = async () => {
+        try {
+          const result = await index(db, 'created').query({ includeDocs: false });
+          document
+            .querySelector('ul')
+            .innerHTML = '';
 
-            document
-              .querySelector('#filecount')
-              .innerText = db._crdt.blocks.loader.carLog.length
-            for (const row of result.rows) {
-              const doc = await db.get(row.id);
-              // doc = row.doc
-              const checkbox = document.createElement('input');
-              checkbox.setAttribute('type', 'checkbox');
-              if (doc.completed) {
-                checkbox.setAttribute('checked', true);
-              }
-              checkbox.onchange = () => {
-                doc.completed = !doc.completed;
-                db.put(doc);
-              }
-              const textSpan = document.createElement('span');
-              textSpan.innerText = doc.task;
-              const li = document.createElement('li');
-              li.appendChild(checkbox);
-              li.appendChild(textSpan);
-              document
-                .querySelector('ul')
-                .appendChild(li);
-            }
-          } finally {
-            const chgs = await db.changes([], {dirty: true});
-            console.log('changes', chgs.rows.map(r => r.value.task), chgs)
-          }
-        }
-
-        async function initialize() {
-          ps = new URLSearchParams(location.search)
-          const listQ = ps.get('list')
-          setupDb(listQ || 'my-list');
-          const input = document.querySelector('#list');
-          input.value = dbName;
-          redraw()
-        }
-
-        async function changeList(e) {
-          e.preventDefault();
-          const input = document.querySelector('#list');
-          dbName = input.value;
-          history.pushState(null, '', location.pathname + '?list=' + encodeURIComponent(dbName));
-          setupDb(dbName);
-
-          redraw();
-        }
-        window.changeList = changeList;
-
-        async function onButtonClick(e) {
-          e.preventDefault();
-
-          const input = document.querySelector('#todo');
-          const ok = await db.put({created: Date.now(), task: input.value, completed: false});
-          input.value = '';
-
-        }
-        window.onButtonClick = onButtonClick;
-
-        async function connectionRefresh(e) {
-          e.preventDefault();
-          await connection.refresh()
-        }
-        window.connectionRefresh = connectionRefresh;
-
-        async function doCompact(e) {
-          e.preventDefault();
-          await db.compact()
           document
             .querySelector('#filecount')
             .innerText = db._crdt.blocks.loader.carLog.length
+          for (const row of result.rows) {
+            const doc = await db.get(row.id);
+            // doc = row.doc
+            const checkbox = document.createElement('input');
+            checkbox.setAttribute('type', 'checkbox');
+            if (doc.completed) {
+              checkbox.setAttribute('checked', true);
+            }
+            checkbox.onchange = () => {
+              doc.completed = !doc.completed;
+              db.put(doc);
+            }
+            const textSpan = document.createElement('span');
+            textSpan.innerText = doc.task;
+            const li = document.createElement('li');
+            li.appendChild(checkbox);
+            li.appendChild(textSpan);
+            document
+              .querySelector('ul')
+              .appendChild(li);
+          }
+        } finally {
+          const chgs = await db.changes([], { dirty: true });
+          console.log('changes', chgs.rows.map(r => r.value.task), chgs)
         }
-        window.doCompact = doCompact;
-
-        window.onload = initialize;
-        window.db = db;
-        window.redraw = redraw;
       }
-      todoApp();
-    </script>
-  </head>
-  <body>
-    <h1>Fireproof Todos</h1>
-    List:
-    <input type="text" name="list" id="list"/>
-    <button onclick="changeList(event)">Change List</button>
-    <button onclick="doCompact(event)">Compact <span id='filecount'>0</span></button>
-    <p>
-      Fireproof stores data locally and encrypts it before sending it to the cloud.
-      This demo uses an S3 bucket, but you can easily run your own on s3 or another provider.
-      <a href="https://use-fireproof.com/">Learn more in the Fireproof developer docs.</a>
-    </p>
 
-    <h3>Todos</h3>
-    <input type="text" name="todo" id="todo"/>
-    <button onclick="onButtonClick(event)">Create Todo</button>
-    <button onclick="connectionRefresh(event)">Refresh</button>
-    <ul></ul>
-  </body>
+      async function initialize() {
+        ps = new URLSearchParams(location.search)
+        const listQ = ps.get('list')
+        setupDb(listQ || 'my-list');
+        const input = document.querySelector('#list');
+        input.value = dbName;
+        redraw()
+      }
+
+      async function changeList(e) {
+        e.preventDefault();
+        const input = document.querySelector('#list');
+        dbName = input.value;
+        history.pushState(null, '', location.pathname + '?list=' + encodeURIComponent(dbName));
+        setupDb(dbName);
+
+        redraw();
+      }
+      window.changeList = changeList;
+
+      async function onButtonClick(e) {
+        e.preventDefault();
+
+        const input = document.querySelector('#todo');
+        const ok = await db.put({ created: Date.now(), task: input.value, completed: false });
+        input.value = '';
+
+      }
+      window.onButtonClick = onButtonClick;
+
+      async function connectionRefresh(e) {
+        e.preventDefault();
+        await connection.refresh()
+      }
+      window.connectionRefresh = connectionRefresh;
+
+      async function doCompact(e) {
+        e.preventDefault();
+        await db.compact()
+        document
+          .querySelector('#filecount')
+          .innerText = db._crdt.blocks.loader.carLog.length
+      }
+      window.doCompact = doCompact;
+
+      window.onload = initialize;
+      window.db = db;
+      window.redraw = redraw;
+    }
+    todoApp();
+  </script>
+</head>
+
+<body>
+  <h1>Fireproof Todos</h1>
+  List:
+  <input type="text" name="list" id="list" />
+  <button onclick="changeList(event)">Change List</button>
+  <button onclick="doCompact(event)">Compact <span id='filecount'>0</span></button>
+  <p>
+    Fireproof stores data locally and encrypts it before sending it to the cloud.
+    This demo uses an S3 bucket, but you can easily run your own on s3 or another provider.
+    <a href="https://use-fireproof.com/">Learn more in the Fireproof developer docs.</a>
+  </p>
+
+  <h3>Todos</h3>
+  <input type="text" name="todo" id="todo" />
+  <button onclick="onButtonClick(event)">Create Todo</button>
+  <button onclick="connectionRefresh(event)">Refresh</button>
+  <ul></ul>
+</body>
+
 </html>

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Test</title>
-  <script src="../../dist/browser/fireproof.iife.js?3871"></script>
+  <script src="../../dist/browser/fireproof.iife.js?3971"></script>
   <script type="text/javascript">
     function todoApp() {
       const { connect, fireproof, index } = Fireproof;
@@ -18,8 +18,8 @@
         db = fireproof(name);
         window.db = db;
         // meta in w3, storage in web3
-        connection = connect.s3(db, s3Info)
-        connect.web3(db, "jchris@fireproof.storage")
+        // connection = connect.s3(db, s3Info)
+        connection = connect.web3(db, "jchris@fireproof.storage")
         db.subscribe(redraw);
         return db;
       }

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Test</title>
-  <script src="../../dist/browser/fireproof.iife.js?3971"></script>
+  <script src="../../dist/browser/fireproof.iife.js?39431"></script>
   <script type="text/javascript">
     function todoApp() {
       const { connect, fireproof, index } = Fireproof;

--- a/packages/fireproof/test/www/todo.html
+++ b/packages/fireproof/test/www/todo.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fireproof Test</title>
-  <script src="../../dist/browser/fireproof.iife.js?9871"></script>
+  <script src="../../dist/browser/fireproof.iife.js?3871"></script>
   <script type="text/javascript">
     function todoApp() {
       const { connect, fireproof, index } = Fireproof;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-fireproof",
-  "version": "0.11.10",
+  "version": "0.11.11-dev",
   "description": "React hooks: useLiveQuery and useDocument for Fireproof live database",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-fireproof",
-  "version": "0.11.11-dev",
+  "version": "0.11.11-dev.2",
   "description": "React hooks: useLiveQuery and useDocument for Fireproof live database",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/react/src/hooks/useFireproof/index.ts
+++ b/packages/react/src/hooks/useFireproof/index.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState, useCallback, createContext } from 'react';
-import { fireproof, index as defineIndex } from '@fireproof/core';
+import { useEffect, useState, useCallback } from 'react';
+import { fireproof } from '@fireproof/core';
+export { fireproof } from '@fireproof/core';
 
-import type { Doc, DocFragment, Index, Database, FireproofOptions } from '@fireproof/core';
+import type { Doc, DocFragment, Database, FireproofOptions } from '@fireproof/core';
 
 export interface FireproofCtxValue {
   database: Database;
@@ -10,7 +11,10 @@ export interface FireproofCtxValue {
   ready: boolean;
 }
 
-export const FireproofCtx = createContext<FireproofCtxValue>({} as FireproofCtxValue);
+/**
+ * @deprecated useFireproofCtx is deprecated, use useFireproof instead
+ */
+export const FireproofCtx = {} as FireproofCtxValue
 
 /**
  * Top level hook to initialize a Fireproof database and a query for it.
@@ -23,7 +27,6 @@ const topLevelUseLiveQuery = (...args) => {
   // @ts-ignore
   return useLiveQuery(...args);
 };
-
 export const useLiveQuery = topLevelUseLiveQuery;
 
 /**
@@ -37,7 +40,6 @@ const topLevelUseLiveDocument = (...args) => {
   // @ts-ignore
   return useDocument(...args);
 };
-
 export const useDocument = topLevelUseLiveDocument;
 
 export function useFireproof(
@@ -53,7 +55,7 @@ export function useFireproof(
     const saveDoc = useCallback(
       async () => {
         const putDoc = id ? { ...doc, _id: id } : doc;
-        await database.put(putDoc)
+        await database.put(putDoc as Doc)
       },
       [id, doc],
     );
@@ -88,19 +90,16 @@ export function useFireproof(
     ];
   }
 
-  function useLiveQuery(mapFn: ((doc: Doc, map: (key: string, value: DocFragment) => void) => DocFragment) | string | Index, query = {}, initialRows: any[] = []) {
+  function useLiveQuery(mapFn: ((doc: Doc, map: (key: string, value: DocFragment) => void) => DocFragment) | string, query = {}, initialRows: any[] = []) {
     const [result, setResult] = useState({
       rows: initialRows,
       docs: initialRows.map((r) => r.doc),
     });
-    const [index, setIndex] = useState<Index | null>(null);
 
     const refreshRows = useCallback(async () => {
-      if (index) {
-        const res = await index.query(query);
+        const res = await database.query(mapFn, query)
         setResult({ ...res, docs: res.rows.map((r) => r.doc) });
-      }
-    }, [index, JSON.stringify(query)]);
+    }, [JSON.stringify(query)]);
 
     useEffect(
       <React.EffectCallback>(() =>
@@ -112,18 +111,6 @@ export function useFireproof(
 
     useEffect(() => {
       refreshRows();
-    }, [index]);
-
-    useEffect(() => {
-      if (typeof mapFn === 'string') {
-        setIndex(defineIndex(database, mapFn));
-        // @ts-ignore
-      } else if (mapFn.crdt) {
-        setIndex(mapFn as Index);
-      } else {
-        // @ts-ignore
-        setIndex(defineIndex(database, makeName(mapFn.toString()), mapFn));
-      }
     }, [mapFn.toString()]);
 
     return result;
@@ -131,25 +118,8 @@ export function useFireproof(
 
   return {
     useLiveQuery,
-    // useLiveDocument : useDocument,
     useDocument,
     database,
     ready : true,
   };
-}
-
-
-function makeName(fnString: string) {
-  const regex = /\(([^,()]+,\s*[^,()]+|\[[^\]]+\],\s*[^,()]+)\)/g
-  let found: RegExpExecArray | null = null
-  let matches = Array.from(fnString.matchAll(regex), match => match[1].trim())
-  if (matches.length === 0) {
-    found = /=>\s*(.*)/.exec(fnString)
-  }
-  if (!found) {
-    return fnString
-  } else {
-    // it's a consise arrow function, match everythign after the arrow
-    return found[1]
-  }
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,1 +1,1 @@
-export { useFireproof, FireproofCtx, FireproofCtxValue, useLiveQuery, useDocument } from './hooks/useFireproof'
+export { fireproof, useFireproof, FireproofCtx, FireproofCtxValue, useLiveQuery, useDocument } from './hooks/useFireproof'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
     devDependencies:
+      '@hyrious/esbuild-plugin-commonjs':
+        specifier: ^0.2.2
+        version: 0.2.2(esbuild@0.18.20)
       '@rollup/plugin-alias':
         specifier: ^5.0.0
         version: 5.0.0
@@ -1259,6 +1262,19 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@hyrious/esbuild-plugin-commonjs@0.2.2(esbuild@0.18.20):
+    resolution: {integrity: sha512-08RxncQ0S3vgVtj8bxx/TcG+4b6bLbWCiXQtRpkuO7U3dLi1pVvSOnIacVphWLCHudCvJL+05b/r1km+r3osWQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      cjs-module-lexer: '*'
+      esbuild: '*'
+    peerDependenciesMeta:
+      cjs-module-lexer:
+        optional: true
+    dependencies:
+      esbuild: 0.18.20
     dev: true
 
   /@ipld/car@5.1.0:
@@ -3594,13 +3610,6 @@ packages:
     dependencies:
       semver: 7.3.8
     dev: true
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: false
 
   /c8@7.13.0:
     resolution: {integrity: sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==}
@@ -9486,11 +9495,6 @@ packages:
     resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
     dependencies:
       get-iterator: 1.0.2
-    dev: false
-
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
     dev: false
 
   /streamx@2.15.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@peculiar/webcrypto':
         specifier: ^1.4.3
         version: 1.4.3
+      '@web3-storage/w3up-client':
+        specifier: ^8.0.1
+        version: 8.0.1
       charwise:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1702,6 +1705,11 @@ packages:
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
     dev: false
 
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2580,6 +2588,39 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@web3-storage/access@15.1.1:
+    resolution: {integrity: sha512-tnD/jLUbQx5Stg0bYJb4OZj6DuZBpCZVz8VwxDQ5H3hIpElyt3OCC6YLwStIbeqc5d7w9272VZAYKfZr4W5TTw==}
+    hasBin: true
+    dependencies:
+      '@ipld/car': 5.2.0
+      '@ipld/dag-ucan': 3.3.2
+      '@ucanto/client': 8.0.0
+      '@ucanto/core': 8.0.0
+      '@ucanto/interface': 8.0.0
+      '@ucanto/principal': 8.0.0
+      '@ucanto/transport': 8.0.0
+      '@ucanto/validator': 8.0.0
+      '@web3-storage/capabilities': 9.2.0
+      '@web3-storage/did-mailto': 2.0.0
+      bigint-mod-arith: 3.1.2
+      conf: 10.2.0
+      inquirer: 9.1.4
+      isomorphic-ws: 5.0.0(ws@8.13.0)
+      kysely: 0.23.4
+      multiformats: 11.0.2
+      one-webcrypto: 1.0.3
+      ora: 6.1.2
+      p-defer: 4.0.0
+      p-wait-for: 5.0.0
+      type-fest: 3.6.1
+      uint8arrays: 4.0.3
+      ws: 8.13.0
+      zod: 3.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@web3-storage/access@9.4.0:
     resolution: {integrity: sha512-GwrSHhOigNI009DRmRtJjqQ3JS/a+rlU7wXM7k5+FwMR9Kqr/Ayid+Ida1tN7NPEIKBqfe9wfXbVMowi86YNYw==}
     hasBin: true
@@ -2644,6 +2685,27 @@ packages:
       '@ucanto/validator': 8.0.0
     dev: false
 
+  /@web3-storage/capabilities@7.0.0:
+    resolution: {integrity: sha512-pF6fpNduEDkHGVV+aP2+N7lbSD0C1LL1CyrhPEbhf9wUHOJXPWRMbfhIJVcdL06pTvZJDYoRpOWmhB+07QLYwg==}
+    dependencies:
+      '@ucanto/core': 8.0.0
+      '@ucanto/interface': 8.0.0
+      '@ucanto/principal': 8.0.0
+      '@ucanto/transport': 8.0.0
+      '@ucanto/validator': 8.0.0
+    dev: false
+
+  /@web3-storage/capabilities@9.2.0:
+    resolution: {integrity: sha512-Qm2OpH/zIRECrlrsq8ZMh9W8qtZecn+CmB6fbkDYL9CEWdm28s+UC+Dxt9yIPUCZZMC+eTrxwS7jUwalB7T+VA==}
+    dependencies:
+      '@ucanto/core': 8.0.0
+      '@ucanto/interface': 8.0.0
+      '@ucanto/principal': 8.0.0
+      '@ucanto/transport': 8.0.0
+      '@ucanto/validator': 8.0.0
+      '@web3-storage/data-segment': 3.0.1
+    dev: false
+
   /@web3-storage/clock@0.3.0:
     resolution: {integrity: sha512-O+1qbkLFj6Yfo4LYztN3HOJX5bsZRF43zIMIdTYPPTy2lEaCsLo596PGOc+y34g35tt4Aw5M2saK4pJSQNr3HA==}
     dependencies:
@@ -2659,6 +2721,13 @@ packages:
       hashlru: 2.3.0
       multiformats: 11.0.2
       p-retry: 5.1.2
+    dev: false
+
+  /@web3-storage/data-segment@3.0.1:
+    resolution: {integrity: sha512-+e0KeqofejZ/1JLCdNmlEMCCSNf0PeJFXA/2Vw5+vWj4Nfko8sVLIGva86L8hXzm4dZGhWYU5m6JhX2U2Wn5Dg==}
+    dependencies:
+      multiformats: 11.0.2
+      sync-multihash-sha2: 1.0.0
     dev: false
 
   /@web3-storage/did-mailto@2.0.0:
@@ -2710,6 +2779,24 @@ packages:
       '@ucanto/transport': 8.0.0
       '@web3-storage/access': 14.0.0
       '@web3-storage/capabilities': 6.0.1
+      '@web3-storage/upload-client': 9.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@web3-storage/w3up-client@8.0.1:
+    resolution: {integrity: sha512-diN+Cl98cVnJsRawfucU3t8fIOPWabvFHxcHqH47kKteLVT1Bofa1gQJ9oPM7e1ssoS4Xpqzeg4FzxkgVbqiBg==}
+    dependencies:
+      '@ipld/dag-ucan': 3.3.2
+      '@ucanto/client': 8.0.0
+      '@ucanto/core': 8.0.0
+      '@ucanto/interface': 8.0.0
+      '@ucanto/principal': 8.0.0
+      '@ucanto/transport': 8.0.0
+      '@web3-storage/access': 15.1.1
+      '@web3-storage/capabilities': 7.0.0
       '@web3-storage/upload-client': 9.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -9556,6 +9643,12 @@ packages:
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
+
+  /sync-multihash-sha2@1.0.0:
+    resolution: {integrity: sha512-A5gVpmtKF0ov+/XID0M0QRJqF2QxAsj3x/LlDC8yivzgoYCoWkV+XaZPfVu7Vj1T/hYzYS1tfjwboSbXjqocug==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
 
   /tar-fs@3.0.4:
     resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@ipld/dag-json':
         specifier: ^10.1.2
         version: 10.1.3
+      '@ipld/dag-ucan':
+        specifier: ^3.3.2
+        version: 3.3.2
       '@ipld/unixfs':
         specifier: ^2.1.1
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@peculiar/webcrypto':
         specifier: ^1.4.3
         version: 1.4.3
+      '@web3-storage/clock':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@web3-storage/w3up-client':
         specifier: ^8.0.1
         version: 8.0.1
@@ -3591,6 +3594,13 @@ packages:
     dependencies:
       semver: 7.3.8
     dev: true
+
+  /busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
+    dev: false
 
   /c8@7.13.0:
     resolution: {integrity: sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==}
@@ -9476,6 +9486,11 @@ packages:
     resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
     dependencies:
       get-iterator: 1.0.2
+    dev: false
+
+  /streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /streamx@2.15.1:


### PR DESCRIPTION
Currently works for uploading and downloading car files to web3.storage, the w3clock (for tracking latest car file) integration requires some finalizing:

- [x] fix the fetch.node thing in ipfs-utils (hardedcoded `const fetch = require('./fetch.node')` in. `../../node_modules/.pnpm/ipfs-utils@9.0.14`
- [ ] apply https://github.com/alanshaw/pail/pull/20
- [ ] get ability to advance clock, maybe via: https://github.com/web3-storage/w3up/issues/876
- [x] revalidate build due to commonjs importer