### PR TITLE
in memory storage option

### DIFF
--- a/packages/connect-partykit/package.json
+++ b/packages/connect-partykit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireproof/partykit",
-  "version": "0.14.4",
+  "version": "0.14.6",
   "description": "",
   "main": "./dist/browser/index.cjs",
   "module": "./dist/browser/index.esm.js",

--- a/packages/connect-partykit/src/connect-partykit.ts
+++ b/packages/connect-partykit/src/connect-partykit.ts
@@ -30,7 +30,7 @@ export class ConnectPartyKit extends Connection {
     this.party = new PartySocket({
       party: 'fireproof',
       host: params.host,
-      room: `fireproof:${params.name}`
+      room: params.name
     })
     this.ready = new Promise<void>((resolve, reject) => {
       this.party.addEventListener('open', () => {
@@ -85,7 +85,7 @@ export class ConnectPartyKit extends Connection {
     const base64String = Base64.fromUint8Array(event.bytes)
     const partyMessage = {
       data: base64String,
-      cid: event.cid,
+      cid: event.cid.toString(),
       parents: this.parents.map(p => p.toString())
     }
     this.party.send(JSON.stringify(partyMessage))

--- a/packages/connect-partykit/src/connect-partykit.ts
+++ b/packages/connect-partykit/src/connect-partykit.ts
@@ -32,6 +32,7 @@ export class ConnectPartyKit extends Connection {
       host: params.host,
       room: params.name
     })
+    
     this.ready = new Promise<void>((resolve, reject) => {
       this.party.addEventListener('open', () => {
         resolve()

--- a/packages/connect-partykit/src/server.ts
+++ b/packages/connect-partykit/src/server.ts
@@ -18,7 +18,7 @@ export default class Server implements Party.Server {
     })
   }
 
-  onConnect(conn: Party.Connection) {
+  async onConnect(conn: Party.Connection) {
     for (const value of this.clockHead.values()) {
       conn.send(value)
     }

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireproof/core",
-  "version": "0.14.2",
+  "version": "0.14.4",
   "description": "Live database for the web.",
   "main": "./dist/browser/fireproof.cjs",
   "module": "./dist/browser/fireproof.esm.js",
@@ -17,12 +17,18 @@
       "types": "./dist/types/fireproof.d.ts",
       "script": "./dist/browser/fireproof.iife.js",
       "default": "./dist/node/fireproof.esm.js"
+    },
+    "./memory": {
+      "import": "./dist/memory/fireproof.esm.js",
+      "types": "./dist/types/fireproof.d.ts",
+      "default": "./dist/memory/fireproof.esm.js"
     }
   },
   "browser": "./dist/fireproof.browser.iife.js",
   "types": "./dist/types/fireproof.d.ts",
   "files": [
     "dist/node",
+    "dist/memory",
     "dist/browser",
     "dist/types"
   ],

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireproof/core",
-  "version": "0.14.4",
+  "version": "0.14.8",
   "description": "Live database for the web.",
   "main": "./dist/browser/fireproof.cjs",
   "module": "./dist/browser/fireproof.esm.js",

--- a/packages/fireproof/scripts/settings.js
+++ b/packages/fireproof/scripts/settings.js
@@ -90,6 +90,27 @@ const require = createRequire(import.meta.url);
 
     }
 
+
+    const memEsmConfig = {
+      ...esmConfig,
+      // platform: 'node',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      plugins: [...esmConfig.plugins,
+        alias(
+          {
+            // 'ipfs-utils/src/http/fetch.js': join(__dirname, '../../../node_modules/.pnpm/ipfs-utils@9.0.14/node_modules/ipfs-utils/src/http/fetch.node.js'),
+            './store-browser': join(__dirname, '../src/store-memory.ts'),
+            // './crypto-web': join(__dirname, '../src/crypto-node.ts')
+          }
+        ),
+        commonjs({ filter: /^peculiar|ipfs-utils/ })
+        // polyfillNode({
+        //   polyfills: { crypto: false, fs: true, process: 'empty' }
+        // })
+      ]
+
+    }
+
     builds.push(testEsmConfig)
 
     if (/fireproof\./.test(entryPoint)) {
@@ -100,6 +121,16 @@ const require = createRequire(import.meta.url);
         minify: false
       }
       builds.push(esmPublishConfig)
+
+      const memConfig = {
+        ...memEsmConfig,
+        outfile: `dist/memory/${filename}.esm.js`,
+        format: 'esm',
+        // platform: 'node',
+        entryPoints: [entryPoint]}
+        
+        builds.push(memConfig)
+
 
       const cjsConfig = {
         ...testEsmConfig,

--- a/packages/fireproof/scripts/settings.js
+++ b/packages/fireproof/scripts/settings.js
@@ -107,7 +107,8 @@ const require = createRequire(import.meta.url);
         // polyfillNode({
         //   polyfills: { crypto: false, fs: true, process: 'empty' }
         // })
-      ]
+      
+      ], banner: {}
 
     }
 
@@ -126,7 +127,7 @@ const require = createRequire(import.meta.url);
         ...memEsmConfig,
         outfile: `dist/memory/${filename}.esm.js`,
         format: 'esm',
-        // platform: 'node',
+        platform: 'browser',
         entryPoints: [entryPoint]}
         
         builds.push(memConfig)

--- a/packages/fireproof/src/crypto-web.ts
+++ b/packages/fireproof/src/crypto-web.ts
@@ -1,7 +1,7 @@
 export function getCrypto() {
   try {
-    if (window.crypto && window.crypto.subtle) {
-      return window.crypto
+    if (crypto && crypto.subtle) {
+      return crypto
     } else {
       return new Crypto()
     }
@@ -9,7 +9,9 @@ export function getCrypto() {
     return null
   }
 }
-export const crypto = getCrypto()
+const gotCrypto = getCrypto()
+
+export { gotCrypto as crypto }
 
 export function randomBytes(size: number) {
   const bytes = new Uint8Array(size)

--- a/packages/fireproof/src/store-memory.ts
+++ b/packages/fireproof/src/store-memory.ts
@@ -1,0 +1,94 @@
+/* eslint-disable import/first */
+import { format, parse, ToString } from '@ipld/dag-json'
+import { AnyBlock, AnyLink, DbMeta } from './types'
+import { DataStore as DataStoreBase, MetaStore as MetaStoreBase } from './store'
+import { RemoteWAL as RemoteWALBase, WALState } from './remote-wal'
+
+// ts-unused-exports:disable-next-line
+export class DataStore extends DataStoreBase {
+  tag: string = 'car-mem'
+  store = new Map<string, Uint8Array>()
+
+  async load(cid: AnyLink): Promise<AnyBlock> {
+    const bytes = this.store.get(cid.toString())
+    if (!bytes) throw new Error(`missing memory block ${cid.toString()}`)
+    return { cid, bytes }
+  }
+
+  async save(car: AnyBlock): Promise<void> {
+    this.store.set(car.cid.toString(), car.bytes)
+  }
+
+  async remove(cid: AnyLink): Promise<void> {
+    this.store.delete(cid.toString())
+  }
+}
+
+// ts-unused-exports:disable-next-line
+export class RemoteWAL extends RemoteWALBase {
+  tag: string = 'wal-mem'
+  store = new Map<string, string>()
+
+  headerKey(branch: string) {
+    // remove 'public' on next storage version bump
+    return `fp.${this.STORAGE_VERSION}.wal.${this.loader.name}.${branch}`
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async load(branch = 'main'): Promise<WALState | null> {
+    try {
+      const bytesString = this.store.get(this.headerKey(branch))
+      if (!bytesString) return null
+      return parse<WALState>(bytesString)
+    } catch (e) {
+      return null
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async save(state: WALState, branch = 'main'): Promise<void> {
+    try {
+      const encoded: ToString<WALState> = format(state)
+      this.store.set(this.headerKey(branch), encoded)
+    } catch (e) {
+      console.error('error saving wal', e)
+      throw e
+    }
+  }
+}
+
+// ts-unused-exports:disable-next-line
+export class MetaStore extends MetaStoreBase {
+  tag: string = 'header-mem'
+  store = new Map<string, string>()
+
+  headerKey(branch: string) {
+    return `fp.${this.STORAGE_VERSION}.meta.${this.name}.${branch}`
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async load(branch: string = 'main'): Promise<DbMeta[] | null> {
+    try {
+      const bytesString = this.store.get(this.headerKey(branch))
+      if (!bytesString) return null
+      // browser assumes a single writer process
+      // to support concurrent updates to the same database across multiple tabs
+      // we need to implement the same kind of mvcc.crdt solution as in store-fs and connect-s3
+      return [this.parseHeader(bytesString)]
+    } catch (e) {
+      return null
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async save(meta: DbMeta, branch: string = 'main') {
+    try {
+      const headerKey = this.headerKey(branch)
+      const bytes = this.makeHeader(meta)
+      this.store.set(headerKey, bytes)
+      return null
+    } catch (e) {
+      return null
+    }
+  }
+}

--- a/packages/fireproof/src/version.ts
+++ b/packages/fireproof/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "0.14.4";
+export const PACKAGE_VERSION = "0.14.8";

--- a/packages/fireproof/src/version.ts
+++ b/packages/fireproof/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "0.14.2";
+export const PACKAGE_VERSION = "0.14.4";


### PR DESCRIPTION
This is one architectural choice -- do in memory for process local, and treat any persistent storage as remote. the other option would be to plug in directly to the remote (as local) but that would likely not save any real in-memory copy or anything.