### PR TITLE
build: bundle @fireproof/ipfs using tsup instead of manual scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:clean:react": "pnpm --filter use-fireproof build:clean",
     "build:clean:solid": "pnpm --filter @fireproof/solid-js build:clean",
     "build:core": "pnpm --filter @fireproof/core build",
+    "build:ipfs": "pnpm --filter @fireproof/ipfs build",
     "build:react": "pnpm --filter use-fireproof build",
     "build:scripts": "pnpm -r build:scripts",
     "build:scripts:blockstore": "pnpm --filter @fireproof/encrypted-blockstore build:scripts",

--- a/packages/connect-ipfs/package.json
+++ b/packages/connect-ipfs/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "build:clean": "rm -rf dist",
+    "build:tsup": "tsup",
     "build:tsc": "npm run build:clean && tsc && mkdir dist/tsc && mv dist/*.js dist/tsc/ && node ./scripts/types.js",
     "build:script": "node ./scripts/build.js",
     "build": "npm run build:tsc && npm run build:script && cp dist/browser/index.iife.js ../fireproof/test/www/ipfs.iife.js",
@@ -51,8 +52,8 @@
   },
   "dependencies": {
     "@web3-storage/pail": "^0.4.0",
-    "@fireproof/core": "workspace:^",
     "@fireproof/connect": "workspace:^",
+    "@fireproof/core": "workspace:^",
     "@fireproof/encrypted-blockstore": "workspace:^",
     "@ucanto/core": "^8.2.0",
     "@ucanto/interface": "^8.1.0",

--- a/packages/connect-ipfs/tsup.config.ts
+++ b/packages/connect-ipfs/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'tsup';
+
+/*
+By default tsup bundles all import-ed modules but, dependencies and peerDependencies in your package.json are always excluded. 
+You can also use --external <module|pkgJson> flag to mark other packages or other special package.json's dependencies and peerDependencies as external.
+
+If you are using tsup to build for Node.js applications/APIs, usually bundling dependencies is not needed, 
+and it can even break things, for instance, while outputting to ESM.
+*/
+export default defineConfig({
+  name: "@fireproof/ipfs",
+  // Entry file for your library
+  entryPoints: ['src/index.ts'],
+
+  // Output directory for the bundled files
+  outDir: 'dist',
+
+  // Format options for ESM and UMD bundles
+  format: ['esm', 'cjs', 'iife'],
+
+  // Enable TypeScript type generation
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: true,
+
+  /** Always bundle modules matching given patterns */
+  noExternal: [],
+  /** Don't bundle these modules */
+  external: [],
+});


### PR DESCRIPTION
## Summary

This is a draft PR and me just kicking the tires in trying out a different bundling strategy for `@fireproof/ipfs` using `tsup` (a very convenient wrapper around `esbuild`). 

NOTE: Putting this one on pause until https://github.com/fireproof-storage/fireproof/pull/61 works and gets merged in