### PR TITLE
refactor: adds tsconfig alias path in core for @fireproof/encrypted-blockstore

### DIFF
--- a/packages/fireproof/src/eb-node.ts
+++ b/packages/fireproof/src/eb-node.ts
@@ -1,6 +1,4 @@
-// @ts-ignore
 import * as crypto from '@fireproof/encrypted-blockstore/crypto-node'
-// @ts-ignore
 import * as store from '@fireproof/encrypted-blockstore/store-node'
 
 export { store, crypto }

--- a/packages/fireproof/src/eb-web.ts
+++ b/packages/fireproof/src/eb-web.ts
@@ -1,6 +1,4 @@
-// @ts-ignore
 import * as crypto from '@fireproof/encrypted-blockstore/crypto-web'
-// @ts-ignore
 import * as store from '@fireproof/encrypted-blockstore/store-web'
 
 export { store, crypto }

--- a/packages/fireproof/src/version.ts
+++ b/packages/fireproof/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "0.16.1";
+export const PACKAGE_VERSION = "0.16.2";

--- a/packages/fireproof/tsconfig.json
+++ b/packages/fireproof/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "include": ["src", "test", ".eslintrc.cjs", "scripts", "../encrypted-blockstore/test/loader.test.js", "../encrypted-blockstore/test/store-node.test.js", "../encrypted-blockstore/test/transaction.test.js"],
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "esnext",
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "strict": true,
     "moduleResolution": "node",
-    "jsx": "react",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -15,6 +16,9 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "forceConsistentCasingInFileNames": true
-  }
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@fireproof/encrypted-blockstore/*": ["./node_modules/@fireproof/encrypted-blockstore/dist/types/*"]
+    }
+  },
 }


### PR DESCRIPTION
Minor refactor PR adding the alias `path` to get rid of the `@ts-ignore` comments when importing from `@fireproof/encrypted-blockstore`