### PR TITLE
build: use tsup to bundle @fireproof/core

### DIFF
--- a/packages/encrypted-blockstore/tsconfig.json
+++ b/packages/encrypted-blockstore/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src"],
+  "include": ["src", "test", "scripts", ".eslintrc.cjs"],
   "compilerOptions": {
     "baseUrl": ".",
     "module": "esnext",

--- a/packages/encrypted-blockstore/tsup.config.ts
+++ b/packages/encrypted-blockstore/tsup.config.ts
@@ -81,30 +81,37 @@ const LIBRARY_BUNDLES: readonly Options[] = [
   },
 ]
 
+const TEST_BUNDLE_OPTIONS: Options = {
+  outDir: "dist/test",
+  format: ["esm"],
+  target: ["esnext"],
+  platform: "node",
+  clean: true,
+  sourcemap: true,
+  minify: false,
+}
+
 const TEST_BUNDLES: readonly Options[] = [
   {
-    ...CORE_OPTIONS,
+    ...TEST_BUNDLE_OPTIONS,
     name: "test/transaction",
     entry: ['src/transaction.ts'],
-    outDir: "dist/test",
     dts: {
       footer: "declare module '@fireproof/encrypted-blockstore/transaction'"
     },
   },
   {
-    ...CORE_OPTIONS,
+    ...TEST_BUNDLE_OPTIONS,
     name: "test/loader",
     entry: ['src/loader.ts'],
-    outDir: "dist/test",
     dts: {
       footer: "declare module '@fireproof/encrypted-blockstore/loader'"
     },
   },
   {
-    ...CORE_OPTIONS,
+    ...TEST_BUNDLE_OPTIONS,
     name: "test/loader-helpers",
     entry: ['src/loader-helpers.ts'],
-    outDir: "dist/test",
     dts: {
       footer: "declare module '@fireproof/encrypted-blockstore/loader-helpers'"
     },

--- a/packages/fireproof/package.json
+++ b/packages/fireproof/package.json
@@ -2,64 +2,68 @@
   "name": "@fireproof/core",
   "version": "0.16.2",
   "description": "Live database for the web.",
+  "type": "module",
+  "module": "./dist/browser/fireproof.js",
   "main": "./dist/browser/fireproof.cjs",
-  "module": "./dist/browser/fireproof.esm.js",
+  "browser": "./dist/browser/fireproof.global.js",
+  "types": "./dist/browser/fireproof.d.ts",
+  "files": [
+    "dist/browser",
+    "dist/memory",
+    "dist/node"
+  ],
   "exports": {
     ".": {
-      "import": "./dist/browser/fireproof.esm.js",
+      "import": "./dist/browser/fireproof.js",
       "require": "./dist/browser/fireproof.cjs",
-      "types": "./dist/types/fireproof.d.ts",
-      "script": "./dist/browser/fireproof.iife.js"
+      "script": "./dist/browser/fireproof.global.js",
+      "types": "./dist/browser/fireproof.d.ts"
     },
     "./node": {
-      "import": "./dist/node/fireproof.esm.js",
+      "import": "./dist/node/fireproof.js",
       "require": "./dist/node/fireproof.cjs",
-      "types": "./dist/types/fireproof.d.ts",
-      "script": "./dist/browser/fireproof.iife.js",
-      "default": "./dist/node/fireproof.esm.js"
+      "script": "./dist/node/fireproof.global.js",
+      "types": "./dist/node/fireproof.d.ts",
+      "default": "./dist/node/fireproof.js"
     },
     "./memory": {
-      "import": "./dist/memory/fireproof.esm.js",
-      "types": "./dist/types/fireproof.d.ts",
-      "default": "./dist/memory/fireproof.esm.js"
+      "import": "./dist/memory/fireproof.js",
+      "require": "./dist/memory/fireproof.cjs",
+      "types": "./dist/memory/fireproof.d.ts",
+      "default": "./dist/memory/fireproof.js"
     }
   },
-  "browser": "./dist/fireproof.browser.iife.js",
-  "types": "./dist/types/fireproof.d.ts",
-  "files": [
-    "dist/node",
-    "dist/memory",
-    "dist/browser",
-    "dist/types"
-  ],
-  "type": "module",
   "scripts": {
     "prepublishOnly": "cp ../../README.md . && npm run build:all",
     "postpublish": "rm README.md",
-    "build": "npm run build:version && npm run build:tsc && npm run build:test && cp dist/browser/fireproof.iife.* test/www/",
+    "analyze": "node ./scripts/analyze.js",
+    "build": "tsup && npm run cp:artifacts",
     "build:all": " npm run build && npm run test:browser",
     "build:clean": "rm -rf dist",
     "build:esbuild": "node ./scripts/build.js",
     "build:rollup": "rollup -c scripts/rollup.js",
+    "build:scripts": "npm run build:version && npm run build:tsc && npm run build:test && npm run cp:artifacts:scripts",
     "build:test": "node ./scripts/build.js",
     "build:tsc": "npm run build:clean && tsc && mkdir dist/tsc && mv dist/*.js dist/tsc/ && node ./scripts/types.js",
     "build:version": "node -p \"'export const PACKAGE_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build:_types": "tsc --declaration --outDir dist/types && node ./scripts/types.js",
     "clean": "rm -rf node_modules",
-    "test:watch:follow": "nodemon -w src -w test -e ts,js --exec \"sleep 2 && npm run test:node\"",
-    "test:node": "node ./scripts/test.js",
-    "test:browser": "node ./scripts/browser-test.js",
-    "lint:fix": "eslint --fix '{src,test}/**/*.{js,ts}'",
-    "lint:exports": "ts-unused-exports tsconfig.json",
-    "serve": "npx serve-http -p 8080 test/www",
+    "cp:artifacts": "cp dist/browser/fireproof.global.js test/www/fireproof.iife.js",
+    "cp:artifacts:scripts": "cp dist/browser/fireproof.iife.* test/www/",
     "lint": "eslint 'src/**/*.{js,ts}'",
-    "analyze": "node ./scripts/analyze.js",
-    "test:coverage": "c8 --reporter=html --include='dist/*' node ./scripts/test.js && open coverage/src/index.html",
-    "tsc:watch": "tsc --watch",
     "lint:all": "npm run lint:fix && npm run lint:exports",
+    "lint:exports": "ts-unused-exports tsconfig.json",
+    "lint:fix": "eslint --fix '{src,test}/**/*.{js,ts}'",
+    "serve": "npx serve-http -p 8080 test/www",
+    "test": "npm run build && npm run test:node",
+    "test:scripts": "npm run test && tsc",
+    "test:browser": "node ./scripts/browser-test.js",
+    "test:coverage": "c8 --reporter=html --include='dist/*' node ./scripts/test.js && open coverage/src/index.html",
+    "test:node": "node ./scripts/test.js",
+    "test:serve": "npx serve-http test/www -p 8080",
     "test:watch": "nodemon -w src -w test -e ts,js --exec \"npm run build:test && npm run test:node\"",
-    "test": "npm run build:test && npm run test:node && tsc",
-    "test:serve": "npx serve-http test/www -p 8080"
+    "test:watch:follow": "nodemon -w src -w test -e ts,js --exec \"sleep 2 && npm run test:node\"",
+    "tsc:watch": "tsc --watch"
   },
   "keywords": [
     "database",
@@ -102,6 +106,7 @@
     "esbuild": "^0.18.14",
     "esbuild-plugin-alias": "^0.2.1",
     "esbuild-plugin-polyfill-node": "^0.3.0",
+    "esbuild-plugin-resolve": "^2.0.0",
     "esbuild-plugin-tsc": "^0.4.0",
     "eslint": "^8.45.0",
     "eslint-config-standard": "^17.1.0",

--- a/packages/fireproof/scripts/build.js
+++ b/packages/fireproof/scripts/build.js
@@ -6,6 +6,7 @@ import { createBuildSettings } from './settings.js'
 async function buildProject() {
   const buildConfigs = createBuildSettings()
 
+  console.log('Building FIREPROOF', buildConfigs)
   for (const config of buildConfigs) {
     console.log('Building', config.outfile)
     await build(config).catch(() => {

--- a/packages/fireproof/test/crdt.test.js
+++ b/packages/fireproof/test/crdt.test.js
@@ -6,8 +6,8 @@
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable mocha/max-top-level-suites */
 import { assert, equals, matches, notEquals, resetDirectory, dataDir } from './helpers.js'
-import { CRDT } from '../dist/test/crdt.esm.js'
-import { index } from '../dist/test/index.esm.js'
+import { CRDT } from '../dist/test/crdt.js'
+import { index } from '../dist/test/index.js'
 import { parseCarFile } from '../../encrypted-blockstore/dist/test/loader-helpers.js'
 
 describe('Fresh crdt', function () {

--- a/packages/fireproof/test/database.test.js
+++ b/packages/fireproof/test/database.test.js
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { assert, equals, notEquals, matches, resetDirectory, dataDir, getDirectoryName, readImages } from './helpers.js'
-import { Database } from '../dist/test/database.esm.js'
+import { Database } from '../dist/test/database.js'
 // import { Doc } from '../dist/test/types.d.esm.js'
 
 /**

--- a/packages/fireproof/test/fireproof.test.js
+++ b/packages/fireproof/test/fireproof.test.js
@@ -10,8 +10,8 @@ import { assert, equals, notEquals, matches, equalsJSON, resetDirectory, dataDir
 
 import { CID } from 'multiformats/cid'
 
-import { fireproof, Database } from '../dist/test/database.esm.js'
-import { index } from '../dist/test/index.esm.js'
+import { fireproof, Database } from '../dist/test/database.js'
+import { index } from '../dist/test/index.js'
 
 export function cidListIncludes(list, cid) {
   return list.some(c => c.equals(cid))

--- a/packages/fireproof/test/hello.test.js
+++ b/packages/fireproof/test/hello.test.js
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable mocha/max-top-level-suites */
 import { assert, equals, resetDirectory, dataDir } from './helpers.js'
-import { fireproof as database, Database } from '../dist/test/database.esm.js'
-import { index, Index } from '../dist/test/index.esm.js'
+import { fireproof as database, Database } from '../dist/test/database.js'
+import { index, Index } from '../dist/test/index.js'
 
 describe('Hello World Test', function () {
   it('should pass the hello world test', function () {

--- a/packages/fireproof/test/indexer.test.js
+++ b/packages/fireproof/test/indexer.test.js
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Index, index } from '../dist/test/index.esm.js'
-import { Database } from '../dist/test/database.esm.js'
-import { CRDT } from '../dist/test/crdt.esm.js'
+import { Index, index } from '../dist/test/index.js'
+import { Database } from '../dist/test/database.js'
+import { CRDT } from '../dist/test/crdt.js'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { assert, matches, equals, resetDirectory, equalsJSON, dataDir } from './helpers.js'

--- a/packages/fireproof/tsconfig.json
+++ b/packages/fireproof/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "include": ["src"],
+  "include": ["src", "test", "scripts", ".eslintrc.cjs"],
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "esnext",
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -11,7 +12,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "emitDeclarationOnly": false,
-    "declarationDir": "dist/types",
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/fireproof/tsup.config.ts
+++ b/packages/fireproof/tsup.config.ts
@@ -1,0 +1,124 @@
+import { defineConfig, Options } from 'tsup';
+import resolve from "esbuild-plugin-resolve"
+import path from "path"
+
+const LIBRARY_BUNDLE_OPTIONS: Options = {
+  format: ["esm", "cjs", "iife"],
+  target: ["esnext", "node18"],
+  globalName: "Fireproof",
+  clean: true,
+  sourcemap: true,
+  metafile: true,
+  minify: false,
+}
+
+const LIBRARY_BUNDLES: readonly Options[] = [
+  {
+    ...LIBRARY_BUNDLE_OPTIONS,
+    name: "core/browser",
+    entry: ["src/fireproof.ts"],
+    platform: "browser",
+    outDir: "dist/browser",
+    dts: {
+      footer: "declare module '@fireproof/core'"
+    },
+  },
+  {
+    ...LIBRARY_BUNDLE_OPTIONS,
+    name: "core/node",
+    entry: ["src/fireproof.ts"],
+    platform: "node",
+    outDir: "dist/node",
+    dts: {
+      footer: "declare module '@fireproof/core'"
+    },
+  },
+  {
+    ...LIBRARY_BUNDLE_OPTIONS,
+    name: "core/memory",
+    entry: ["src/fireproof.ts"],
+    platform: "browser",
+    outDir: "dist/memory",
+    dts: {
+      footer: "declare module '@fireproof/core'"
+    },
+  },
+]
+
+const TEST_BUNDLE_OPTIONS: Options = {
+  outDir: "dist/test",
+  format: ["esm"],
+  target: ["esnext"],
+  platform: "node",
+  clean: true,
+  sourcemap: true,
+  minify: false,
+}
+
+const TEST_BUNDLES: readonly Options[] = [
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/apply-head-queue",
+    entry: ['src/apply-head-queue.ts'],
+    dts: {
+      footer: "declare module '@fireproof/core/apply-head-queue'"
+    },
+  },
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/crdt-clock",
+    entry: ['src/crdt-clock.ts'],
+    dts: {
+      footer: "declare module '@fireproof/core/crdt-clock'"
+    },
+  },
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/crdt-helpers",
+    entry: ['src/crdt-helpers.ts'],
+    dts: {
+      footer: "declare module '@fireproof/core/crdt-helpers'"
+    },
+  },
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/crdt",
+    entry: ['src/crdt.ts'],
+    esbuildPlugins: [
+      resolve({
+        "./eb-web": path.join(__dirname, './src/eb-node.ts'),
+      })
+    ],
+    dts: {
+      footer: "declare module '@fireproof/core/crdt'"
+    },
+  },
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/database",
+    entry: ['src/database.ts'],
+    esbuildPlugins: [
+      resolve({
+        "./eb-web": path.join(__dirname, './src/eb-node.ts'),
+      })
+    ],
+    dts: {
+      footer: "declare module '@fireproof/core/database'"
+    },
+  },
+  {
+    ...TEST_BUNDLE_OPTIONS,
+    name: "test/index",
+    entry: ['src/index.ts'],
+    esbuildPlugins: [
+      resolve({
+        "./eb-web": path.join(__dirname, './src/eb-node.ts'),
+      })
+    ],
+    dts: {
+      footer: "declare module '@fireproof/core/index'"
+    },
+  },
+]
+
+export default defineConfig([ ...LIBRARY_BUNDLES, ...TEST_BUNDLES ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       esbuild-plugin-polyfill-node:
         specifier: ^0.3.0
         version: 0.3.0(esbuild@0.18.20)
+      esbuild-plugin-resolve:
+        specifier: ^2.0.0
+        version: 2.0.0
       esbuild-plugin-tsc:
         specifier: ^0.4.0
         version: 0.4.0(typescript@5.3.3)
@@ -5443,6 +5446,10 @@ packages:
       '@jspm/core': 2.0.1
       esbuild: 0.18.20
       import-meta-resolve: 3.1.1
+    dev: true
+
+  /esbuild-plugin-resolve@2.0.0:
+    resolution: {integrity: sha512-eJy9B8yDW5X/J48eWtR1uVmv+DKfHvYYnrrcqQoe/nUkVHVOTZlJnSevkYyGOz6hI90t036Y5QIPDrGzmppxfg==}
     dev: true
 
   /esbuild-plugin-tsc@0.4.0(typescript@5.3.3):


### PR DESCRIPTION
This PR is the follow-up to https://github.com/fireproof-storage/fireproof/pull/61 where we use `tsup` as the primary tool for bundling the `@fireproof` packages.