### PR TITLE
fix: stabilizes inferred generic typings

### DIFF
--- a/packages/fireproof/src/database.ts
+++ b/packages/fireproof/src/database.ts
@@ -46,7 +46,7 @@ export class Database {
     })
   }
 
-  async get<T extends DocRecord = {}>(id: string): Promise<Doc<T>> {
+  async get<T extends DocRecord<T> = {}>(id: string): Promise<Doc<T>> {
     const got = await this._crdt.get(id).catch(e => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       e.message = `Not found: ${id} - ` + e.message
@@ -57,7 +57,7 @@ export class Database {
     return { _id: id, ...doc } as Doc<T>
   }
 
-  async put<T extends DocRecord = {}>(doc: Doc<T>): Promise<DbResponse> {
+  async put<T extends DocRecord<T> = {}>(doc: Doc<T>): Promise<DbResponse> {
     const { _id, ...value } = doc
     const docId = _id || uuidv7()
     const result: CRDTMeta = await this._writeQueue.push({ key: docId, value } as DocUpdate)
@@ -69,7 +69,7 @@ export class Database {
     return { id, clock: result?.head } as DbResponse
   }
 
-  async changes<T extends DocRecord = {}>(since: ClockHead = [], opts: ChangesOptions = {}): Promise<ChangesResponse<T>> {
+  async changes<T extends DocRecord<T> = {}>(since: ClockHead = [], opts: ChangesOptions = {}): Promise<ChangesResponse<T>> {
     const { result, head } = await this._crdt.changes(since, opts)
     const rows = result.map(({ key, value, del, clock }) => ({
       key,
@@ -79,7 +79,7 @@ export class Database {
     return { rows, clock: head }
   }
 
-  async allDocs<T extends DocRecord = {}>() {
+  async allDocs<T extends DocRecord<T> = {}>() {
     const { result, head } = await this._crdt.allDocs()
     const rows = result.map(({ key, value, del }) => ({
       key,
@@ -88,7 +88,7 @@ export class Database {
     return { rows, clock: head }
   }
 
-  async allDocuments<T extends DocRecord = {}>() {
+  async allDocuments<T extends DocRecord<T> = {}>() {
     return this.allDocs<T>()
   }
 
@@ -113,7 +113,7 @@ export class Database {
   }
 
   // todo if we add this onto dbs in fireproof.ts then we can make index.ts a separate package
-  async query<T extends DocRecord = {}>(field: string | MapFn, opts: QueryOpts = {}) {
+  async query<T extends DocRecord<T> = {}>(field: string | MapFn, opts: QueryOpts = {}) {
     const idx =
       typeof field === 'string'
         ? index({ _crdt: this._crdt }, field)
@@ -147,7 +147,7 @@ export class Database {
   }
 }
 
-type UpdateListenerFn = <T extends DocRecord = {}>(docs: Doc<T>[]) => Promise<void> | void
+type UpdateListenerFn = <T extends DocRecord<T>>(docs: Doc<T>[]) => Promise<void> | void
 type NoUpdateListenerFn = () => Promise<void> | void
 type ListenerFn = UpdateListenerFn | NoUpdateListenerFn
 

--- a/packages/fireproof/src/index.ts
+++ b/packages/fireproof/src/index.ts
@@ -72,7 +72,7 @@ export class Index {
     //   })
   }
 
-  applyMapFn<T extends Record<string, any> = {}>(name: string, mapFn?: MapFn, meta?: IdxMeta) {
+  applyMapFn<T extends DocRecord<T> = {}>(name: string, mapFn?: MapFn, meta?: IdxMeta) {
     if (mapFn && meta) throw new Error('cannot provide both mapFn and meta')
     if (this.name && this.name !== name) throw new Error('cannot change name')
     this.name = name
@@ -118,7 +118,7 @@ export class Index {
         } else {
           // application code is creating an index
           if (!mapFn) {
-            mapFn = makeMapFnFromName(name)
+            mapFn = (doc) => doc[name as keyof Doc<T>] ?? undefined
           }
           if (this.mapFnString) {
             // we already loaded from a header
@@ -138,7 +138,7 @@ export class Index {
     }
   }
 
-  async query<T extends DocRecord = {}>(opts: QueryOpts = {}): Promise<{ rows: IndexRow<T>[] }> {
+  async query<T extends DocRecord<T> = {}>(opts: QueryOpts = {}): Promise<{ rows: IndexRow<T>[] }> {
     // this._resetIndex()
     await this._updateIndex()
     await this._hydrateIndex()
@@ -261,8 +261,4 @@ export class Index {
       return indexerMeta as unknown as TransactionMeta
     })
   }
-}
-
-function makeMapFnFromName<T extends DocRecord = {}>(name: keyof Doc<T>): MapFn {
-  return doc => doc[name] ?? undefined
 }

--- a/packages/fireproof/src/indexer-helpers.ts
+++ b/packages/fireproof/src/indexer-helpers.ts
@@ -122,7 +122,7 @@ export async function loadIndex(tblocks: BlockFetcher, cid: AnyLink, opts: Stati
   return await DbIndex.load({ cid, get: makeProllyGetBlock(tblocks), ...opts }) as ProllyNode
 }
 
-export async function applyQuery<T extends DocRecord = {}>(crdt: CRDT, resp: { result: IndexRow<T>[] }, query: QueryOpts) {
+export async function applyQuery<T extends DocRecord<T> = {}>(crdt: CRDT, resp: { result: IndexRow<T>[] }, query: QueryOpts) {
   if (query.descending) {
     resp.result = resp.result.reverse()
   }
@@ -163,10 +163,10 @@ export function encodeKey(key: DocFragment): string {
 
 // ProllyNode type based on the ProllyNode from 'prolly-trees/base'
 interface ProllyNode extends BaseNode {
-  getAllEntries<T extends DocRecord = {}>(): PromiseLike<{ [x: string]: any; result: IndexRow<T>[] }>
+  getAllEntries<T extends DocRecord<T> = {}>(): PromiseLike<{ [x: string]: any; result: IndexRow<T>[] }>
   getMany(removeIds: string[]): Promise<{ [x: string]: any; result: IndexKey[] }>
-  range<T extends DocRecord = {}>(a: IndexKey, b: IndexKey): Promise<{ result: IndexRow<T>[] }>
-  get<T extends DocRecord = {}>(key: string): Promise<{ result: IndexRow<T>[] }>
+  range<T extends DocRecord<T> = {}>(a: IndexKey, b: IndexKey): Promise<{ result: IndexRow<T>[] }>
+  get<T extends DocRecord<T> = {}>(key: string): Promise<{ result: IndexRow<T>[] }>
   bulk(bulk: IndexUpdate[]): PromiseLike<{ root: ProllyNode | null; blocks: Block[] }>
   address: Promise<Link>
   distance: number

--- a/packages/fireproof/src/types.ts
+++ b/packages/fireproof/src/types.ts
@@ -25,14 +25,19 @@ export type DocFragment =
   | DocFragment[]
   | { [key: string]: DocFragment }
 
-export type DocRecord = Record<string, DocFragment>;
-export type Doc<T extends DocRecord = {}> = DocBase & DocBody<T>
+export type DocRecord<T> = {
+  [K in keyof T]: DocFragment;
+};
+
+export type DocFiles = Record<string, DocFileMeta | File>;
 
 export type DocBase = {
   _id?: string
   _files?: DocFiles
   _publicFiles?: DocFiles
 }
+
+export type Doc<T extends DocRecord<T> = {}> = DocBase & T
 
 export type DocFileMeta = {
   type: string
@@ -43,18 +48,13 @@ export type DocFileMeta = {
   file?: () => Promise<File>
 }
 
-export type DocFiles = Record<string, DocFileMeta | File>;
-
-export type DocBody<T extends DocRecord = {}> = {
-  _id?: string;
-} & { [K in Exclude<keyof T, keyof DocBase>]: DocFragment } & T
-
 export type DocUpdate = {
   key: string
   value?: Record<string, any>
   del?: boolean
   clock?: AnyLink
 }
+
 // todo merge into above
 export type DocValue = {
   doc?: DocBase
@@ -69,7 +69,7 @@ export type IndexUpdate = {
   del?: boolean
 }
 
-export type IndexRow<T extends DocRecord = {}> = {
+export type IndexRow<T extends DocRecord<T> = {}> = {
   id: string
   key: IndexKey
   row?: DocFragment
@@ -109,14 +109,14 @@ export type AnyBlock = { cid: AnyLink; bytes: Uint8Array }
 export type AnyDecodedBlock = { cid: AnyLink; bytes: Uint8Array; value: any }
 
 type EmitFn = (k: DocFragment, v?: DocFragment) => void
-export type MapFn = <T extends DocRecord = {}>(doc: Doc<T>, emit: EmitFn) => DocFragment | void
+export type MapFn = <T extends DocRecord<T> = {}>(doc: Doc<T>, emit: EmitFn) => DocFragment | void
 
 export type ChangesOptions = {
   dirty?: boolean
   limit?: number
 }
 
-export type ChangesResponse<T extends DocRecord = {}> = {
+export type ChangesResponse<T extends DocRecord<T> = {}> = {
   clock: ClockHead
   rows: { 
     key: string; 


### PR DESCRIPTION
Discovered an issue while kicking the tires with the SolidJS adapter where the TypeScript compiler was not inferring the correct typings for object fields. Came to realize that our `DocRecord` type needed to be refined further. This should stabilize the types and give better autocomplete.

Concrete example is, if you had something like `{ foo: true }` that was passed into the generics formula, the compiler would say your object had a field `foo` whose available values were `DocFragment & true` instead of simply resolving to `boolean` which is a valid `DocFragment` value type.