### PR TITLE
test for deterministic iv

### DIFF
--- a/tests/blockstore/keyed-crypto.test.ts
+++ b/tests/blockstore/keyed-crypto.test.ts
@@ -265,7 +265,7 @@ describe("KeyedCrypto", () => {
     const codec = kycr.codec();
     const blk = await codec.encode(testData);
     const blk2 = await codec.encode(testData);
-    expect(blk).toEqual(blk2)
+    expect(blk).toEqual(blk2);
   });
 });
 

--- a/tests/blockstore/keyed-crypto.test.ts
+++ b/tests/blockstore/keyed-crypto.test.ts
@@ -259,6 +259,14 @@ describe("KeyedCrypto", () => {
     const dec = await codec.decode(blk);
     expect(dec).toEqual(testData);
   });
+
+  it("codec implict iv same for multiple clients", async () => {
+    const testData = kb.rt.crypto.randomBytes(1024);
+    const codec = kycr.codec();
+    const blk = await codec.encode(testData);
+    const blk2 = await codec.encode(testData);
+    expect(blk).toEqual(blk2)
+  });
 });
 
 // describe("KeyedCryptoStore RunLength", () => {


### PR DESCRIPTION
test asserts that the encode result is the same, which can only happen when the same iv is used for provided input