### PR TITLE
introduce abstraction for websocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^22.2.0",
     "@types/randombytes": "^2.0.3",
     "@types/react": "^18.3.3",
+    "@types/ws": "^8.5.12",
     "@typescript-eslint/typescript-estree": "^8.0.1",
     "@vitest/browser": "^2.0.5",
     "@vitest/coverage-v8": "^2.0.5",
@@ -93,7 +94,8 @@
     "prolly-trees": "^1.0.4",
     "randombytes": "^2.1.0",
     "react": "^18.3.1",
-    "uuidv7": "^1.0.0"
+    "uuidv7": "^1.0.0",
+    "ws": "^8.18.0"
   },
   "bundle-phobia": {
     "max-size": "390kB",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       uuidv7:
         specifier: ^1.0.0
         version: 1.0.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.8.0
@@ -78,6 +81,9 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.5.12
       '@typescript-eslint/typescript-estree':
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.5.4)
@@ -838,8 +844,8 @@ packages:
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
-  '@types/ws@8.5.10':
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+  '@types/ws@8.5.12':
+    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -3539,7 +3545,7 @@ snapshots:
 
   '@types/wrap-ansi@3.0.0': {}
 
-  '@types/ws@8.5.10':
+  '@types/ws@8.5.12':
     dependencies:
       '@types/node': 22.2.0
 
@@ -5690,7 +5696,7 @@ snapshots:
   webdriver@8.39.0:
     dependencies:
       '@types/node': 20.14.11
-      '@types/ws': 8.5.10
+      '@types/ws': 8.5.12
       '@wdio/config': 8.39.0
       '@wdio/logger': 8.38.0
       '@wdio/protocols': 8.38.0

--- a/src/runtime/node-sys-container.ts
+++ b/src/runtime/node-sys-container.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as os from "os";
 import * as url from "url";
 import { toArrayBuffer } from "./gateways/file/utils.js";
+import WebSocket from 'ws';
 
 export async function createNodeSysContainer(): Promise<NodeMap> {
   // const nodePath = "node:path";
@@ -30,5 +31,6 @@ export async function createNodeSysContainer(): Promise<NodeMap> {
       return toArrayBuffer(rs);
     },
     writefile: fs.writeFile as NodeMap["writefile"],
+    websocket: () => { return WebSocket }
   };
 }

--- a/src/runtime/node-sys-container.ts
+++ b/src/runtime/node-sys-container.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as os from "os";
 import * as url from "url";
 import { toArrayBuffer } from "./gateways/file/utils.js";
-import WebSocket from 'ws';
+import WebSocket from "ws";
 
 export async function createNodeSysContainer(): Promise<NodeMap> {
   // const nodePath = "node:path";
@@ -31,6 +31,8 @@ export async function createNodeSysContainer(): Promise<NodeMap> {
       return toArrayBuffer(rs);
     },
     writefile: fs.writeFile as NodeMap["writefile"],
-    websocket: () => { return WebSocket }
+    websocket: () => {
+      return WebSocket;
+    },
   };
 }

--- a/src/runtime/sys-container.ts
+++ b/src/runtime/sys-container.ts
@@ -91,7 +91,7 @@ class sysContainer implements SysFileSystem {
     unlink: () => Promise.reject(new Error("SysContainer:unlink is not available in seeded state")),
     writefile: () => Promise.reject(new Error("SysContainer:writefile is not available in seeded state")),
     stat: () => Promise.reject(new Error("SysContainer:stat is not available in seeded state")),
-    websocket: () => Promise.reject(new Error("SysContainer:websocket is not available in seeded state"))
+    websocket: () => Promise.reject(new Error("SysContainer:websocket is not available in seeded state")),
   };
 
   // readonly id = uuidv4();

--- a/src/runtime/sys-container.ts
+++ b/src/runtime/sys-container.ts
@@ -22,6 +22,7 @@ export interface NodeMap extends Omit<SysFileSystem, "start"> {
   join: (...args: string[]) => string;
   dirname: (path: string) => string;
   homedir: () => string;
+  websocket: () => any;
   // fileURLToPath: (url: string | URL) => string;
   // assert: (condition: unknown, message?: string | Error) => void;
 }
@@ -90,6 +91,7 @@ class sysContainer implements SysFileSystem {
     unlink: () => Promise.reject(new Error("SysContainer:unlink is not available in seeded state")),
     writefile: () => Promise.reject(new Error("SysContainer:writefile is not available in seeded state")),
     stat: () => Promise.reject(new Error("SysContainer:stat is not available in seeded state")),
+    websocket: () => Promise.reject(new Error("SysContainer:websocket is not available in seeded state"))
   };
 
   // readonly id = uuidv4();
@@ -188,6 +190,11 @@ class sysContainer implements SysFileSystem {
   homedir = () => {
     this.logSeeded("homedir");
     return throwFalsy(this.freight).homedir();
+  };
+
+  websocket = () => {
+    this.logSeeded("websocket");
+    return throwFalsy(this.freight).websocket();
   };
 
   logSeeded(method: string) {


### PR DESCRIPTION
access websocket from node is different from browser partykit handles browser case automatically
but requries us to pass in WebSocket from ws

currently this does not do the browser side