### PR TITLE
fix: useLiveQuery undefined values

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:file": "vitest --config vitest.file.config.ts --run",
     "test:indexdb": "vitest --config vitest.browser.config.ts --run",
     "format": "prettier .",
+    "format-fix": "prettier . --write",
     "lint": "eslint"
   },
   "keywords": [

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,5 +1,5 @@
 export { type TLUseDocument, useDocument } from "./useDocument";
-export { FireproofCtx, type UseFireproof, useFireproof } from "./useFireproof";
+export { FireproofCtx, type UseFireproof, useFireproof, type LiveQueryResult, type UseLiveQuery } from "./useFireproof";
 export { type TLUseLiveQuery, useLiveQuery } from "./useLiveQuery";
 export { type TLUseAllDocs, useAllDocs } from "./useAllDocs";
 export { type TLUseChanges, useChanges } from "./useChanges";

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,7 +2,7 @@ import { runtimeFn, toCryptoRuntime, URI } from "@adviser/cement";
 import { dataDir, rt } from "@fireproof/core";
 import { renderHook, RenderHookResult } from "@testing-library/react";
 import { Database, useFireproof } from "use-fireproof";
-import type { UseFireproof, ConfigOpts, LiveQueryResult, QueryOpts, IndexRow, DocFragment, MapFn, UseLiveQuery } from "use-fireproof";
+import type { UseFireproof, ConfigOpts } from "use-fireproof";
 
 
 export { dataDir };
@@ -69,10 +69,4 @@ export async function populateDatabase(db: Database, texts: string[]) {
 type UseFireproofProps = [Partial<string | Database>, Partial<ConfigOpts>];
 export function getUseFireproofHook(db: Database): RenderHookResult<UseFireproof, UseFireproofProps> {
   return renderHook(() => useFireproof(db));
-}
-
-type UseLiveQueryHook = RenderHookResult<LiveQueryResult<Todo, string>, UseLiveQueryProps>;
-type UseLiveQueryProps = [string | MapFn<Todo>, QueryOpts<string>, IndexRow<string, Todo, DocFragment>[]];
-export function getUseLiveQueryHook(useLiveQuery: UseLiveQuery): UseLiveQueryHook {
-  return renderHook(() => useLiveQuery("date", { limit: 100, descending: true }));
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,6 @@ import { renderHook, RenderHookResult } from "@testing-library/react";
 import { Database, useFireproof } from "use-fireproof";
 import type { UseFireproof, ConfigOpts } from "use-fireproof";
 
-
 export { dataDir };
 
 export function sleep(ms: number) {
@@ -57,7 +56,7 @@ export function generateTexts(): string[] {
     texts.push(text);
   }
   return texts;
-};
+}
 
 export async function populateDatabase(db: Database, texts: string[]) {
   for (const text of texts) {

--- a/tests/react/useLiveQuery.test.tsx
+++ b/tests/react/useLiveQuery.test.tsx
@@ -33,11 +33,9 @@ describe("HOOK: useLiveQuery", () => {
     expect(typeof useLiveQuery).toBe("function");
   });
 
-
   it("reads from the database", async () => {
     // populate database with test data
     await populateDatabase(db, texts);
-    // const allDocs = await db.allDocs();
 
     // render component
     const { getByText } = render(<TestComponent />);
@@ -47,7 +45,6 @@ describe("HOOK: useLiveQuery", () => {
       expect(countTxt).toBeTruthy();
     });
   });
-
 });
 
 function TestComponent() {

--- a/tests/react/useLiveQuery.test.tsx
+++ b/tests/react/useLiveQuery.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rt, Database, useFireproof } from "use-fireproof";
+import { generateTexts, getUseFireproofHook, populateDatabase, Todo } from "../helpers";
+
+const TEST_DB_NAME = "test-useLiveQuery";
+
+describe("HOOK: useLiveQuery", () => {
+  let db: Database;
+  const texts = generateTexts();
+
+  afterEach(async () => {
+    cleanup();
+    await db.close();
+    await db.destroy();
+  });
+
+  beforeEach(async () => {
+    await rt.SysContainer.start();
+    db = new Database(TEST_DB_NAME);
+  });
+
+  it("should be defined", async () => {
+    const useFireproofHook = getUseFireproofHook(db);
+    const { useLiveQuery } = useFireproofHook.result.current;
+    expect(useLiveQuery).toBeDefined();
+  });
+
+  it("renders the hook correctly and checks types", () => {
+    const useFireproofHook = getUseFireproofHook(db);
+    const { useLiveQuery } = useFireproofHook.result.current;
+    expect(typeof useLiveQuery).toBe("function");
+  });
+
+
+  it("reads from the database", async () => {
+    // populate database with test data
+    await populateDatabase(db, texts);
+    // const allDocs = await db.allDocs();
+
+    // render component
+    const { getByText } = render(<TestComponent />);
+
+    await waitFor(() => {
+      const countTxt = getByText("count: 10");
+      expect(countTxt).toBeTruthy();
+    });
+  });
+
+});
+
+function TestComponent() {
+  const { useLiveQuery } = useFireproof(TEST_DB_NAME);
+  const todos = useLiveQuery<Todo>("date", { limit: 10, descending: true });
+  return (
+    <div>
+      <p>count: {todos.docs.length}</p>
+      <ul>
+        {todos.docs.map((todo) => (
+          <li key={todo._id}>{todo.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    "jsx": "react",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react",                                /* Specify what JSX code is generated. */
+    "jsx": "react" /* Specify what JSX code is generated. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */


### PR DESCRIPTION
Troubleshoot and fix the `undefined` values sometimes seen in use of `useLiveQuery()` hook.

Notes:
* I don't like changing `tsconfig.json` globally with `"jsx": "react"` and tried a `tsconfig.json` file in the `tests/react` folder, but no dice so far.
* I haven't recreated the issue yet, but want to add data to the database after the hook has rendered once.
