### PR TITLE
mprove the storekey url parameter handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "homepage": "https://github.com/fireproof-storage/fireproof#readme",
   "dependencies": {
-    "@adviser/cement": "^0.2.12",
+    "@adviser/cement": "^0.2.15",
     "@ipld/car": "^5.3.2",
     "@ipld/dag-cbor": "^9.2.1",
     "@ipld/dag-json": "^10.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^0.2.15
+        version: 0.2.15
       '@ipld/car':
         specifier: ^5.3.2
         version: 5.3.2
@@ -139,8 +139,8 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
-  '@adviser/cement@0.2.12':
-    resolution: {integrity: sha512-aCnDcVje5nqZHk5AHL1BdXJotNe7CzwMwRzNctAPO6l3lDG/GAdczQPSqdGX9VWiqkKqHj8+0BUdzuQw0H2KcA==}
+  '@adviser/cement@0.2.15':
+    resolution: {integrity: sha512-YaigkDG4qjzssjpmoQZ17ez9NNRTCSBvlXpAy0z3ajsIV1H6rXQmvPUFUm4D0av3T7GqMyqInKgHVuAfF8whwQ==}
     engines: {node: '>=16'}
 
   '@ampproject/remapping@2.3.0':
@@ -2960,7 +2960,7 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@adviser/cement@0.2.12': {}
+  '@adviser/cement@0.2.15': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:

--- a/src/blockstore/types.ts
+++ b/src/blockstore/types.ts
@@ -124,7 +124,7 @@ export interface KeyedCrypto {
   readonly crypto: CryptoRuntime;
   readonly url: URI;
   // readonly codec: BlockCodec<number, IvAndBytes>;
-  readonly isEncrypting: boolean;
+  // readonly isEncrypting: boolean;
   fingerPrint(): Promise<string>;
   algo(iv?: Uint8Array): { name: string; iv: Uint8Array; tagLength: number };
   codec(iv?: Uint8Array, codecOpts?: Partial<CodecOpts>): BlockCodec<number, Uint8Array>;

--- a/tests/fireproof/fireproof.test.ts
+++ b/tests/fireproof/fireproof.test.ts
@@ -67,12 +67,12 @@ describe("public API", function () {
   let doc: DocWithId<Doc>;
   let query: IndexRows<string, Doc>;
 
-  afterEach(async function () {
+  afterEach(async () => {
     await db.close();
     await db.destroy();
   });
 
-  beforeEach(async function () {
+  beforeEach(async () => {
     await rt.SysContainer.start();
     db = fireproof("test-api");
     // index = index(db, 'test-index', (doc) => doc.foo)
@@ -615,7 +615,7 @@ describe("same workload twice, same CID", function () {
   const configA = {
     store: {
       stores: {
-        base: storageURL().build().setParam("storagekey", "zTvTPEPQRWij8rfb3FrFqBm"),
+        base: storageURL().build().setParam("storekey", "@test@"),
       },
     },
   };
@@ -623,7 +623,7 @@ describe("same workload twice, same CID", function () {
   const configB = {
     store: {
       stores: {
-        base: storageURL().build().setParam("storagekey", "zTvTPEPQRWij8rfb3FrFqBm"),
+        base: storageURL().build().setParam("storekey", "@test@"),
       },
     },
   };

--- a/tests/fireproof/hello.test.ts
+++ b/tests/fireproof/hello.test.ts
@@ -7,7 +7,7 @@ describe("Hello World Test", function () {
   });
 });
 
-describe("public API", function () {
+describe("hello public API", function () {
   interface TestDoc {
     foo: string;
   }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -28,8 +28,11 @@ export async function buildBlobFiles(): Promise<FileWithCid[]> {
 
 export function storageURL(): URI {
   const old = rt.SysContainer.env.get("FP_STORAGE_URL");
+  let merged: URI;
   if (runtimeFn().isBrowser) {
-    return URI.merge(`indexdb://fp`, old);
+    merged = URI.merge(`indexdb://fp`, old, "indexdb:");
+  } else {
+    merged = URI.merge(`./dist/env`, old);
   }
-  return URI.merge(`./dist/env`, old);
+  return merged;
 }


### PR DESCRIPTION
There had been some oddities about when a key in the key-bag is created.

This should be now like:
if you pass not as storekey is created with the pattern
-  @[dbname](:idx):[data|meta|wal]@
if you pass a storekey with a starting and ending '@'
- the key is lookup and if not found it created from a random source
if you pass a btcbase58 z leading string than this is used as key!
if you pass insecure no encryption and decryption is used
