### PR TITLE
Fix safari URL Parser Oddities

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "homepage": "https://github.com/fireproof-storage/fireproof#readme",
   "dependencies": {
-    "@adviser/cement": "^0.2.12",
+    "@adviser/cement": "^0.2.22",
     "@ipld/car": "^5.3.2",
     "@ipld/dag-cbor": "^9.2.1",
     "@ipld/dag-json": "^10.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^0.2.22
+        version: 0.2.22
       '@ipld/car':
         specifier: ^5.3.2
         version: 5.3.2
@@ -139,8 +139,8 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
-  '@adviser/cement@0.2.12':
-    resolution: {integrity: sha512-aCnDcVje5nqZHk5AHL1BdXJotNe7CzwMwRzNctAPO6l3lDG/GAdczQPSqdGX9VWiqkKqHj8+0BUdzuQw0H2KcA==}
+  '@adviser/cement@0.2.22':
+    resolution: {integrity: sha512-SsGqnbG3Ef54DSDJMZGJdkYaHerF/xXNWIhFfrHPWNY7jW3hCeWv31wUAOw0mqIbBu2M0MhJODEtTwlqwgPdng==}
     engines: {node: '>=16'}
 
   '@ampproject/remapping@2.3.0':
@@ -2956,7 +2956,7 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@adviser/cement@0.2.12': {}
+  '@adviser/cement@0.2.22': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:

--- a/setup.browser.ts
+++ b/setup.browser.ts
@@ -3,5 +3,5 @@ function gthis() {
 }
 
 gthis()[Symbol.for("FP_PRESET_ENV")] = {
-  //	FP_DEBUG: "DataStoreImpl,MetaStoreImpl,IndexDBGateway"
+  // FP_DEBUG: "metaStoreFactory"
 };

--- a/tests/fireproof/fireproof.test.ts
+++ b/tests/fireproof/fireproof.test.ts
@@ -637,7 +637,6 @@ describe("same workload twice, same CID", function () {
   beforeEach(async function () {
     let ok: DocResponse;
     await rt.SysContainer.start();
-
     // todo this fails because the test setup doesn't properly configure both databases to use the same key
     dbA = fireproof("test-dual-workload-a", configA);
     for (const doc of docs) {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -28,8 +28,11 @@ export async function buildBlobFiles(): Promise<FileWithCid[]> {
 
 export function storageURL(): URI {
   const old = rt.SysContainer.env.get("FP_STORAGE_URL");
+  let merged: URI;
   if (runtimeFn().isBrowser) {
-    return URI.merge(`indexdb://fp`, old);
+    merged = URI.merge(`indexdb://fp`, old, "indexdb:");
+  } else {
+    merged = URI.merge(`./dist/env`, old);
   }
-  return URI.merge(`./dist/env`, old);
+  return merged;
 }


### PR DESCRIPTION
To address the strange behaviour of Safari if a indexdb://fp?dkdkd is come a long I need to update 
@adviser/cement@0.2.22 to make use of a "stabilized" URL Parser.

If you fine with that please release a new dev version and inform salem

