### PR TITLE
Relax indexeddb name sanitization to include hypens

### DIFF
--- a/src/runtime/gateways/indexdb/gateway.ts
+++ b/src/runtime/gateways/indexdb/gateway.ts
@@ -63,7 +63,7 @@ export interface DbName {
 
 function joinDBName(...names: string[]): string {
   return names
-    .map((i) => i.replace(/^[^a-zA-Z0-9]+/g, "").replace(/[^a-zA-Z0-9]+/g, "_"))
+    .map((i) => i.replace(/^[^a-zA-Z0-9]+/g, "").replace(/[^a-zA-Z0-9-]+/g, "_"))
     .filter((i) => i.length)
     .join(".");
 }


### PR DESCRIPTION
Probably can include more characters but for now it would be nice to have at least hypen for a valid char since uuids are used for remote names by default.

on dashboard, indexeddb is used as source of truth for the database list