### PR TITLE
use-fireproof gets a forwarding package

### DIFF
--- a/package-fireproof-core.json
+++ b/package-fireproof-core.json
@@ -25,6 +25,12 @@
       "require": "./web/index.cjs",
       "script": "./web/index.global.js",
       "types": "./web/index.d.ts"
+    },
+    "./react": {
+      "import": "./react/index.js",
+      "require": "./react/index.cjs",
+      "script": "./react/index.global.js",
+      "types": "./react/index.d.ts"
     }
   },
   "scripts": {},
@@ -42,7 +48,9 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "devDependencies": {},
-  "peerDependencies": {},
+  "peerDependencies": {
+    "react": "from-package-json"
+  },
   "dependencies": {
     "@adviser/cement": "from-package-json",
     "multiformats": "from-package-json",

--- a/package-use-fireproof.json
+++ b/package-use-fireproof.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "react": "from-package-json",
     "multiformats": "from-package-json",
+    "@fireproof/core": "from-package-json",
     "@adviser/cement": "from-package-json",
     "charwise": "from-package-json",
     "prolly-trees": "from-package-json",
@@ -44,7 +45,8 @@
     "@ipld/car": "from-package-json"
   },
   "peerDependencies": {
-    "react": ">=18.0.0"
+    "react": "from-package-json",
+    "@fireproof/core": "from-package-json"
   },
   "devDependencies": {},
   "keywords": ["react", "database", "json", "live", "sync"]

--- a/smoke/react/it.sh
+++ b/smoke/react/it.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 set -e
-cd smoke/react 
+cd smoke/react
 smokeDir=$(pwd)
 tmpDir=$(mktemp -d)
 rm -rf node_modules dist pnpm-lock.yaml
 cp -pr * $tmpDir
 cd $tmpDir
-cp package-template.json package.json
+fp_core=$(echo $smokeDir/../../dist/fireproof-core/fireproof-core-*.tgz)
+use_fp=$(echo $smokeDir/../../dist/use-fireproof/use-fireproof-*.tgz)
+sed -e "s|FIREPROOF_CORE|file://$fp_core|g" \
+    -e "s|USE_FIREPROOF|file://$use_fp|g" package-template.json > package.json
+# cp package-template.json package.json
 pnpm install
-pnpm install -f $smokeDir/../../dist/use-fireproof/use-fireproof-*.tgz
+# pnpm install -f "file://$smokeDir/../../dist/fireproof-core/fireproof-core-*.tgz"
+# pnpm install -f "file://$smokeDir/../../dist/use-fireproof/use-fireproof-*.tgz"
 # pnpm run test > /dev/null 2>&1 || true
 pnpm run test
 rm -rf $tmpDir

--- a/smoke/react/package-template.json
+++ b/smoke/react/package-template.json
@@ -16,7 +16,11 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.24.0"
+    "react-router-dom": "^6.24.0",
+    "use-fireproof": "USE_FIREPROOF"
+  },
+  "peerDependencies": {
+    "@fireproof/core": "FIREPROOF_CORE"
   },
   "devDependencies": {
     "@testing-library/react": "^16.0.0",

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -4,4 +4,4 @@ export { type TLUseLiveQuery, useLiveQuery } from "./useLiveQuery";
 export { type TLUseAllDocs, useAllDocs } from "./useAllDocs";
 export { type TLUseChanges, useChanges } from "./useChanges";
 // why is this there is should be a package system
-export * from "@fireproof/core";
+// export * from "@fireproof/core";

--- a/src/runtime/key-bag-indexdb.ts
+++ b/src/runtime/key-bag-indexdb.ts
@@ -2,7 +2,7 @@ import { IDBPDatabase, openDB } from "idb";
 import { KeyBagProvider, KeyItem } from "./key-bag.js";
 import { getPath } from "./gateways/file/utils.js";
 import { Logger, ResolveOnce, URI } from "@adviser/cement";
-import { SuperThis } from "use-fireproof";
+import type { SuperThis } from "../types.js";
 
 export class KeyBagProviderIndexDB implements KeyBagProvider {
   readonly _db: ResolveOnce<IDBPDatabase<unknown>> = new ResolveOnce<IDBPDatabase<unknown>>();

--- a/src/runtime/key-bag.ts
+++ b/src/runtime/key-bag.ts
@@ -202,6 +202,25 @@ export function registerKeyBagProviderFactory(item: KeyBagProviderFactoryItem) {
   });
 }
 
+export function defaultKeyBagUrl(sthis: SuperThis): URI {
+  let bagFnameOrUrl = sthis.env.get("FP_KEYBAG_URL");
+  let url: URI;
+  if (runtimeFn().isBrowser) {
+    url = URI.from(bagFnameOrUrl || "indexdb://fp-keybag");
+  } else {
+    if (!bagFnameOrUrl) {
+      const home = sthis.env.get("HOME");
+      bagFnameOrUrl = `${home}/.fireproof/keybag`;
+      url = URI.from(`file://${bagFnameOrUrl}`);
+    } else {
+      url = URI.from(bagFnameOrUrl);
+    }
+  }
+  const logger = ensureLogger(sthis, "defaultKeyBagUrl");
+  logger.Debug().Url(url).Msg("from env");
+  return url;
+}
+
 function defaultKeyBagOpts(sthis: SuperThis, kbo: Partial<KeyBagOpts>): KeyBagRuntime {
   if (kbo.keyRuntime) {
     return kbo.keyRuntime;
@@ -212,19 +231,7 @@ function defaultKeyBagOpts(sthis: SuperThis, kbo: Partial<KeyBagOpts>): KeyBagRu
     url = URI.from(kbo.url);
     logger.Debug().Url(url).Msg("from opts");
   } else {
-    let bagFnameOrUrl = sthis.env.get("FP_KEYBAG_URL");
-    if (runtimeFn().isBrowser) {
-      url = URI.from(bagFnameOrUrl || "indexdb://fp-keybag");
-    } else {
-      if (!bagFnameOrUrl) {
-        const home = sthis.env.get("HOME");
-        bagFnameOrUrl = `${home}/.fireproof/keybag`;
-        url = URI.from(`file://${bagFnameOrUrl}`);
-      } else {
-        url = URI.from(bagFnameOrUrl);
-      }
-    }
-    logger.Debug().Url(url).Msg("from env");
+    url = defaultKeyBagUrl(sthis);
   }
   const kitem = keyBagProviderFactories.get(url.protocol);
   if (!kitem) {

--- a/src/use-fireproof/index.ts
+++ b/src/use-fireproof/index.ts
@@ -1,0 +1,2 @@
+export * from "@fireproof/core/react";
+export * from "@fireproof/core";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,9 +31,8 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "@fireproof/core": ["./src/index.js"],
-      // "@fireproof/core/node": ["./src/"],
-      "use-fireproof": ["./src/react/index.ts"]
-      // "multiformats/block": ["src/runtime/multiformats/block.ts"],
+      "@fireproof/core/react": ["./src/react/index.js"],
+      "use-fireproof": ["./src/use-fireproof/index.js"]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": ["./src", "./src-generated"],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -106,7 +106,7 @@ const LIBRARY_BUNDLES: readonly Options[] = [
       }),
       skipper([...nodeInternals, ...webInternals], `${__dirname}/src/bundle-not-impl.js`),
       skipper(["./get-file-system-static.js"], "./get-file-system-dynamic.js"),
-      skipper(["./gateway-import-static.js"], "././gateway-import-dynamic.js"),
+      // skipper(["./gateway-import-static.js"], "././gateway-import-dynamic.js"),
       resolve({
         ...skipIife,
         ...ourMultiformat,
@@ -131,7 +131,7 @@ const LIBRARY_BUNDLES: readonly Options[] = [
       }),
       skipper([...nodeInternals, ...webInternals], `${__dirname}/src/bundle-not-impl.js`),
       skipper(["./get-file-system-static.js"], "./get-file-system-dynamic.js"),
-      skipper(["./gateway-import-static.js"], "././gateway-import-dynamic.js"),
+      // skipper(["./gateway-import-static.js"], "././gateway-import-dynamic.js"),
       resolve({
         ...ourMultiformat,
       }),
@@ -184,11 +184,33 @@ const LIBRARY_BUNDLES: readonly Options[] = [
   },
   {
     ...LIBRARY_BUNDLE_OPTIONS,
-    external: [...(LIBRARY_BUNDLE_OPTIONS.external || [])],
+    external: [...(LIBRARY_BUNDLE_OPTIONS.external || []), "@fireproof/core"],
+    format: ["esm", "cjs"],
+    name: "@fireproof/core/react",
+    entry: ["src/react/index.ts"],
+    platform: "browser",
+    outDir: "dist/fireproof-core/react",
+    esbuildPlugins: [
+      replace({
+        __packageVersion__: packageVersion(),
+        include: /version/,
+      }),
+      // skipper('@skip-iife', `${__dirname}/src/bundle-not-impl.js`),
+      resolve({
+        ...ourMultiformat,
+      }),
+    ],
+    dts: {
+      footer: "declare module '@fireproof/core/web'",
+    },
+  },
+  {
+    ...LIBRARY_BUNDLE_OPTIONS,
+    external: [...(LIBRARY_BUNDLE_OPTIONS.external || []), "@fireproof/core", "@fireproof/core/react"],
     treeshake: true,
     //    minify: true,
     name: "use-fireproof",
-    entry: ["src/react/index.ts"],
+    entry: ["src/use-fireproof/index.ts"],
     target: ["esnext"],
     platform: "browser",
     outDir: "dist/use-fireproof",

--- a/version-copy-package.ts
+++ b/version-copy-package.ts
@@ -10,12 +10,16 @@ async function copyFilesToDist(destDir: string) {
   }
 }
 
-async function patchVersion(packageJson: Record<string, unknown>) {
+function getVersion() {
   let version = "refs/tags/v0.0.0-smoke";
   if (process.env.GITHUB_REF && process.env.GITHUB_REF.startsWith("refs/tags/v")) {
     version = process.env.GITHUB_REF;
   }
-  version = version.split("/").slice(-1)[0].replace(/^v/, "");
+  return version.split("/").slice(-1)[0].replace(/^v/, "");
+}
+
+async function patchVersion(packageJson: Record<string, unknown>) {
+  const version = getVersion();
   console.log(`Patch version ${version} in package.json`);
   packageJson.version = version;
 }
@@ -32,6 +36,16 @@ async function createDenoJson(destDir: string, packageJson: Record<string, unkno
   }
   const denoJsonFile = path.join(destDir, "deno.json");
   await fs.writeFile(denoJsonFile, JSON.stringify(denoJson, null, 2));
+}
+
+async function transferVersionsFromPackageJson(srcDeps: Record<string, string>, destDeps: Record<string, string>) {
+  for (const dep of Object.keys(destDeps)) {
+    if (!srcDeps[dep]) {
+      console.error(`Dependency ${dep} not found in main package.json`);
+    } else {
+      destDeps[dep] = srcDeps[dep];
+    }
+  }
 }
 
 async function main() {
@@ -51,13 +65,13 @@ async function main() {
   const templateFile = path.basename(buildDest);
   const destPackageJson = JSON.parse(await fs.readFile(templateFile, "utf-8"));
   // copy version from package.json
-  for (const destDeps of Object.keys(destPackageJson.dependencies)) {
-    if (!mainPackageJson.dependencies[destDeps]) {
-      console.error(`Dependency ${destDeps} not found in main package.json`);
-    } else {
-      destPackageJson.dependencies[destDeps] = mainPackageJson.dependencies[destDeps];
-    }
-  }
+  const withCoreVersion = {
+    "@fireproof/core": `^${getVersion()}`,
+    ...mainPackageJson.dependencies,
+  };
+  transferVersionsFromPackageJson(withCoreVersion, destPackageJson.dependencies);
+  transferVersionsFromPackageJson(withCoreVersion, destPackageJson.peerDependencies);
+
   patchVersion(destPackageJson);
 
   await createDenoJson(destDir, destPackageJson);


### PR DESCRIPTION
This is needed due to the runtime problems caused by doubling the code if you
use use-fireproof and fireproof/core at the same time.