### PR TITLE
fix: Add missing returns in `connection.loaded` Promise

### DIFF
--- a/src/blockstore/connection-base.ts
+++ b/src/blockstore/connection-base.ts
@@ -65,8 +65,8 @@ export abstract class ConnectionBase implements Connection {
     });
     this.loader.remoteMetaStore = remote;
     this.loaded = this.loader.ready().then(async () => {
-      remote.load().then(async () => {
-        (await throwFalsy(this.loader).WALStore()).process();
+      return remote.load().then(async () => {
+        return (await throwFalsy(this.loader).WALStore()).process();
       });
     });
   }


### PR DESCRIPTION
Fixes #402

Waits until the remote store is fully loaded so data can be fetched.