### PR TITLE
Rebuild the query and allDocs API

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "charwise": "^3.0.1",
     "esbuild-plugin-replace": "^1.4.0",
     "idb": "^8.0.1",
+    "iterator-helpers-polyfill": "^3.0.1",
     "multiformats": "^13.3.1",
     "p-limit": "^6.2.0",
     "p-map": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       idb:
         specifier: ^8.0.1
         version: 8.0.1
+      iterator-helpers-polyfill:
+        specifier: ^3.0.1
+        version: 3.0.1
       multiformats:
         specifier: ^13.3.1
         version: 13.3.1
@@ -1900,6 +1903,10 @@ packages:
 
   it-stream-types@2.0.2:
     resolution: {integrity: sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==}
+
+  iterator-helpers-polyfill@3.0.1:
+    resolution: {integrity: sha512-9uSoKErC0+TG7uoXlv5k7rs196/l/VGr9hb9KbptpMhszsSksxJCwetp0p7FvgM3SwxlxgEkvokmeOi02PARlQ==}
+    engines: {chrome: '>=63', firefox: '>=57', node: '>=10.0.0', safari: '>=11'}
 
   jackspeak@3.4.0:
     resolution: {integrity: sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==}
@@ -4767,6 +4774,8 @@ snapshots:
       p-defer: 4.0.1
 
   it-stream-types@2.0.2: {}
+
+  iterator-helpers-polyfill@3.0.1: {}
 
   jackspeak@3.4.0:
     dependencies:

--- a/src/crdt-clock.ts
+++ b/src/crdt-clock.ts
@@ -72,10 +72,12 @@ export class CRDTClock<T extends DocTypes> {
 
   onTick(fn: (updates: DocUpdate<T>[]) => void) {
     this.watchers.add(fn);
+    return () => this.watchers.delete(fn);
   }
 
   onTock(fn: () => void) {
     this.emptyWatchers.add(fn);
+    return () => this.emptyWatchers.delete(fn);
   }
 
   onZoom(fn: () => void) {

--- a/src/crdt-helpers.ts
+++ b/src/crdt-helpers.ts
@@ -86,6 +86,10 @@ export async function applyBulkUpdateToCrdt<T extends DocTypes>(
   return { head: result.head } as CRDTMeta;
 }
 
+export function docUpdateToDocWithId<T extends DocTypes>({ id, del, value }: DocUpdate<T>): DocWithId<T> {
+  return (del ? { _id: id, _deleted: true } : { _id: id, ...value }) as DocWithId<T>;
+}
+
 // this whole thing can get pulled outside of the write queue
 async function writeDocContent<T extends DocTypes>(
   store: StoreRuntime,

--- a/src/crdt.ts
+++ b/src/crdt.ts
@@ -175,24 +175,18 @@ export class CRDT<T extends DocTypes> {
       //   return clockChangesSince<T>(this.blockstore, this.clock.head, since || [], opts, this.logger).then((a) => a.result);
       // }
 
-      const iterator = getAllEntries<T>(this.blockstore, this.clock.head, this.logger);
-      return iterator;
+      return getAllEntries<T>(this.blockstore, this.clock.head, this.logger);
     };
 
     const snapshot = async () => {
       await waitFor;
       await this.ready();
-      // TODO: Map over async iterable
-      // return currentDocs().map(docUpdateToDocWithId)
 
-      // NOTE:
-      // return Array.fromAsync(currentDocs()).then((a) => a.map(docUpdateToDocWithId));
-
-      const docs: DocWithId<T>[] = [];
-      for await (const update of currentDocs()) {
-        docs.push(docUpdateToDocWithId(update));
-      }
-      return docs;
+      return await Array.fromAsync(
+        currentDocs().map((doc: DocUpdate<T>) => {
+          return docUpdateToDocWithId(doc);
+        }),
+      );
     };
 
     const stream = (opts: { futureOnly: boolean; since?: ClockHead }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+import { installIntoGlobal } from "iterator-helpers-polyfill";
+
+// Polyfill for (async) iterator helpers (eg. map)
+// https://github.com/tc39/proposal-iterator-helpers
+// TODO: Not entirely sure yet we need this, may delete when finishing PR.
+//       See `allDocs().snapshot()` function
+installIntoGlobal();
+
 export * from "./ledger.js";
 export * from "./types.js";
 

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -238,11 +238,13 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
     this.logger = ensureLogger(this.sthis, "Ledger");
     this.crdt = new CRDT(this.sthis, this.opts);
     // this.blockstore = this._crdt.blockstore; // for connector compatibility
-    this._writeQueue = writeQueue(async (updates: DocUpdate<DT>[]) => {
-      return await this.crdt.bulk(updates);
-    }); //, Infinity)
-    // TODO: Rebase conflict:
-    // this._writeQueue = writeQueue(this.sthis, async (updates: DocUpdate<DT>[]) => this.crdt.bulk(updates), this.opts.writeQueue);
+    this._writeQueue = writeQueue(
+      this.sthis,
+      async (updates: DocUpdate<DT>[]) => {
+        return await this.crdt.bulk(updates);
+      },
+      this.opts.writeQueue,
+    );
     // this.crdt.clock.onTock(() => this._no_update_notify());
   }
 

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -5,27 +5,21 @@ import { CRDT, HasCRDT } from "./crdt.js";
 import { index } from "./indexer.js";
 import {
   type DocUpdate,
-  type ClockHead,
   type ConfigOpts,
   type MapFn,
   type QueryOpts,
-  type ChangesOptions,
   type DocSet,
   type DocWithId,
   type IndexKeyType,
-  type ListenerFn,
   type DocResponse,
   type BulkResponse,
-  type ChangesResponse,
   type DocTypes,
   type IndexRows,
   type DocFragment,
-  type ChangesResponseRow,
   type CRDTMeta,
-  type AllDocsQueryOpts,
-  type AllDocsResponse,
   type SuperThis,
   PARAM,
+  QueryResponse,
 } from "./types.js";
 import { DbMeta, SerdeGatewayInterceptor, StoreEnDeFile, StoreURIRuntime, StoreUrlsOpts } from "./blockstore/index.js";
 import { ensureLogger, ensureSuperThis, NotFoundError, toSortedArray } from "./utils.js";
@@ -79,16 +73,8 @@ export interface Ledger<DT extends DocTypes = NonNullable<unknown>> extends HasC
   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse>;
   bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse>;
   del(id: string): Promise<DocResponse>;
-  changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>>;
-  allDocs<T extends DocTypes>(opts?: AllDocsQueryOpts): Promise<AllDocsResponse<T>>;
-  allDocuments<T extends DocTypes>(): Promise<{
-    rows: {
-      key: string;
-      value: DocWithId<T>;
-    }[];
-    clock: ClockHead;
-  }>;
-  subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void;
+  allDocs<T extends DocTypes>(): QueryResponse<T>;
+  allDocuments<T extends DocTypes>(): QueryResponse<T>;
 
   query<K extends IndexKeyType, T extends DocTypes, R extends DocFragment = T>(
     field: string | MapFn<T>,
@@ -145,7 +131,6 @@ export class LedgerShell<DT extends DocTypes = NonNullable<unknown>> implements 
   get crdt(): CRDT<DT> {
     return this.ref.crdt;
   }
-
   get name(): string {
     return this.ref.name;
   }
@@ -173,23 +158,11 @@ export class LedgerShell<DT extends DocTypes = NonNullable<unknown>> implements 
   del(id: string): Promise<DocResponse> {
     return this.ref.del(id);
   }
-  changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>> {
-    return this.ref.changes(since, opts);
+  allDocs<T extends DocTypes>(): QueryResponse<T> {
+    return this.ref.allDocs();
   }
-  allDocs<T extends DocTypes>(opts?: AllDocsQueryOpts): Promise<AllDocsResponse<T>> {
-    return this.ref.allDocs(opts);
-  }
-  allDocuments<T extends DocTypes>(): Promise<{
-    rows: {
-      key: string;
-      value: DocWithId<T>;
-    }[];
-    clock: ClockHead;
-  }> {
+  allDocuments<T extends DocTypes>(): QueryResponse<T> {
     return this.ref.allDocuments();
-  }
-  subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void {
-    return this.ref.subscribe(listener, updates);
   }
   query<K extends IndexKeyType, T extends DocTypes, R extends DocFragment = T>(
     field: string | MapFn<T>,
@@ -206,9 +179,6 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
   // readonly name: string;
   readonly opts: LedgerOpts;
 
-  _listening = false;
-  readonly _listeners = new Set<ListenerFn<DT>>();
-  readonly _noupdate_listeners = new Set<ListenerFn<DT>>();
   readonly crdt: CRDT<DT>;
   readonly _writeQueue: WriteQueue<DT>;
   // readonly blockstore: BaseBlockstore;
@@ -267,8 +237,13 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
     this.id = sthis.timeOrderedNextId().str;
     this.logger = ensureLogger(this.sthis, "Ledger");
     this.crdt = new CRDT(this.sthis, this.opts);
-    this._writeQueue = writeQueue(this.sthis, async (updates: DocUpdate<DT>[]) => this.crdt.bulk(updates), this.opts.writeQueue);
-    this.crdt.clock.onTock(() => this._no_update_notify());
+    // this.blockstore = this._crdt.blockstore; // for connector compatibility
+    this._writeQueue = writeQueue(async (updates: DocUpdate<DT>[]) => {
+      return await this.crdt.bulk(updates);
+    }); //, Infinity)
+    // TODO: Rebase conflict:
+    // this._writeQueue = writeQueue(this.sthis, async (updates: DocUpdate<DT>[]) => this.crdt.bulk(updates), this.opts.writeQueue);
+    // this.crdt.clock.onTock(() => this._no_update_notify());
   }
 
   get name(): string {
@@ -327,59 +302,13 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
     return { id, clock: result?.head, name: this.name } as DocResponse;
   }
 
-  async changes<T extends DocTypes>(since: ClockHead = [], opts: ChangesOptions = {}): Promise<ChangesResponse<T>> {
-    await this.ready();
-    this.logger.Debug().Any("since", since).Any("opts", opts).Msg("changes");
-    const { result, head } = await this.crdt.changes(since, opts);
-    const rows: ChangesResponseRow<T>[] = result.map(({ id: key, value, del, clock }) => ({
-      key,
-      value: (del ? { _id: key, _deleted: true } : { _id: key, ...value }) as DocWithId<T>,
-      clock,
-    }));
-    return { rows, clock: head, name: this.name };
-  }
-
-  async allDocs<T extends DocTypes>(opts: AllDocsQueryOpts = {}): Promise<AllDocsResponse<T>> {
-    await this.ready();
-    void opts;
+  allDocs<T extends DocTypes>(): QueryResponse<T> {
     this.logger.Debug().Msg("allDocs");
-    const { result, head } = await this.crdt.allDocs();
-    const rows = result.map(({ id: key, value, del }) => ({
-      key,
-      value: (del ? { _id: key, _deleted: true } : { _id: key, ...value }) as DocWithId<T>,
-    }));
-    return { rows, clock: head, name: this.name };
+    return this.crdt.allDocs({ waitFor: this.ready() });
   }
 
-  async allDocuments<T extends DocTypes>(): Promise<{
-    rows: {
-      key: string;
-      value: DocWithId<T>;
-    }[];
-    clock: ClockHead;
-  }> {
+  allDocuments<T extends DocTypes>(): QueryResponse<T> {
     return this.allDocs<T>();
-  }
-
-  subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void {
-    this.logger.Debug().Bool("updates", updates).Msg("subscribe");
-    if (updates) {
-      if (!this._listening) {
-        this._listening = true;
-        this.crdt.clock.onTick((updates: DocUpdate<NonNullable<unknown>>[]) => {
-          void this._notify(updates);
-        });
-      }
-      this._listeners.add(listener as ListenerFn<NonNullable<unknown>>);
-      return () => {
-        this._listeners.delete(listener as ListenerFn<NonNullable<unknown>>);
-      };
-    } else {
-      this._noupdate_listeners.add(listener as ListenerFn<NonNullable<unknown>>);
-      return () => {
-        this._noupdate_listeners.delete(listener as ListenerFn<NonNullable<unknown>>);
-      };
-    }
   }
 
   // todo if we add this onto dbs in fireproof.ts then we can make index.ts a separate package
@@ -400,29 +329,6 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
   async compact() {
     await this.ready();
     await this.crdt.compact();
-  }
-
-  async _notify(updates: DocUpdate<NonNullable<unknown>>[]) {
-    await this.ready();
-    if (this._listeners.size) {
-      const docs: DocWithId<NonNullable<unknown>>[] = updates.map(({ id, value }) => ({ ...value, _id: id }));
-      for (const listener of this._listeners) {
-        await (async () => await listener(docs as DocWithId<DT>[]))().catch((e: Error) => {
-          this.logger.Error().Err(e).Msg("subscriber error");
-        });
-      }
-    }
-  }
-
-  async _no_update_notify() {
-    await this.ready();
-    if (this._noupdate_listeners.size) {
-      for (const listener of this._noupdate_listeners) {
-        await (async () => await listener([]))().catch((e: Error) => {
-          this.logger.Error().Err(e).Msg("subscriber error");
-        });
-      }
-    }
   }
 }
 

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -245,7 +245,6 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
       },
       this.opts.writeQueue,
     );
-    // this.crdt.clock.onTock(() => this._no_update_notify());
   }
 
   get name(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,7 +274,7 @@ export type QueryStreamMarker = { kind: "preexisting"; done: boolean } | { kind:
 
 export interface QueryResponse<T extends DocTypes> {
   snapshot(): Promise<DocWithId<T>[]>;
-  live(opts: { since?: ClockHead }): ReadableStream<{ doc: DocWithId<T>; marker: QueryStreamMarker }>;
+  live(opts?: { since?: ClockHead }): ReadableStream<{ doc: DocWithId<T>; marker: QueryStreamMarker }>;
   future(): ReadableStream<{ doc: DocWithId<T>; marker: QueryStreamMarker }>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,13 +270,12 @@ export interface AllDocsQueryOpts extends QueryOpts<string> {
   prefix?: string;
 }
 
-export interface AllDocsResponse<T extends DocTypes> {
-  readonly rows: {
-    readonly key: string;
-    readonly value: DocWithId<T>;
-  }[];
-  readonly clock: ClockHead;
-  readonly name?: string;
+export type QueryStreamMarker = { kind: "preexisting"; done: boolean } | { kind: "new" };
+
+export interface QueryResponse<T extends DocTypes> {
+  snapshot(): Promise<DocWithId<T>[]>;
+  live(opts: { since?: ClockHead }): ReadableStream<{ doc: DocWithId<T>; marker: QueryStreamMarker }>;
+  future(): ReadableStream<{ doc: DocWithId<T>; marker: QueryStreamMarker }>;
 }
 
 type EmitFn = (k: IndexKeyType, v?: DocFragment) => void;

--- a/tests/fireproof/streaming-api.test.ts
+++ b/tests/fireproof/streaming-api.test.ts
@@ -80,8 +80,8 @@ describe("query api", () => {
       const docs = await lr.allDocs().snapshot();
       expect(docs.length).toBe(AMOUNT_OF_DOCS);
     });
-    it("test `future` method", async () => {
-      const stream = lr.allDocs<DocType>().future();
+    it("test `live` method", async () => {
+      const stream = lr.allDocs<DocType>().live();
       let docCount = 0;
 
       for await (const { doc, marker } of stream) {

--- a/tests/fireproof/streaming-api.test.ts
+++ b/tests/fireproof/streaming-api.test.ts
@@ -97,5 +97,23 @@ describe("query api", () => {
 
       expect(docCount).toBe(AMOUNT_OF_DOCS + 1);
     });
+    it("test `future` method", async () => {
+      const stream = lr.allDocs<DocType>().future();
+      let docCount = 0;
+
+      // NOTE: Test could probably be written in a better way.
+      //       We want to start listening before we add the documents.
+      lr.put({ _id: `doc-${AMOUNT_OF_DOCS + 0}`, name: `doc-${AMOUNT_OF_DOCS + 0}` });
+      lr.put({ _id: `doc-${AMOUNT_OF_DOCS + 1}`, name: `doc-${AMOUNT_OF_DOCS + 1}` });
+
+      for await (const { doc, marker } of stream) {
+        void doc;
+
+        if (marker.kind === "new") docCount++;
+        if (docCount === 2) break;
+      }
+
+      expect(docCount).toBe(2);
+    });
   });
 });

--- a/tests/fireproof/streaming-api.test.ts
+++ b/tests/fireproof/streaming-api.test.ts
@@ -1,0 +1,83 @@
+/*
+ * The streaming API to come to query and allDocs in Database class
+ *
+ * we should incorporate the changes of this PR into this:
+ *   https://github.com/fireproof-storage/fireproof/pull/315
+ *
+ * We need new Methods or a structure return value like this:
+ * Due to that we need to harmonize the return values of both methods to
+ * return the same structure. I think we should go with an approach like
+ * the Response object in the fetch API.
+ * interface QueryResponse {
+ *  rows(): Promise<DocWithId[]>;
+ *  iterator(): AsyncIterableIterator<DocWithId>;
+ *  stream(): ReadableStream<DocWithId>;
+ *  subscribe(callback: (doc: DocWithId) => void): unsubscribe() => void;
+ * }
+ * it should only possible to call every method once.
+ * if you call it twice it should throw an error
+ * Keep in mind that the iterator and stream should be able to
+ * substitute the changes method. So we need the possibility to
+ * pass options to allDocs and or query to change the behavior:
+ * - SNAPSHOT default -> means it returns the current state of the database and
+ *   closes the stream after that.
+ * - LIVE -> means it returns the current state of the database and keeps the stream open
+ * - FUTURE -> means it keeps the stream open for new records which meet the query arguments
+ *   (this might be dropped and simulated with the startpoint option in LIVE mode)
+ *
+ * the rows method will only behave in SNAPSHOT mode.
+ * We should be able to extend in future implemenation pass a startpoint to LIVE.
+ *
+ * The first group of tests should verify that query and allDocs both return the same
+ * QueryResponse object and implement rows method. The test should check if rows
+ * returns empty arrays if the database is empty and if it returns the correct # documents
+ * in the database. There should be a test to check for the double call error.
+ *
+ * The second group of tests should verify that the iterator and stream method works as expected in
+ * SNAPSHOT mode. Both should pass the same tests as the rows method. These tests should verify that
+ * we are able to stream documents from the database without loosing memory. We should test if
+ * close/unsubscribe of the stream works as expected.
+ *
+ * Future milestone:
+ * The third group of tests should verify that the iterator and stream method works as expected in
+ * LIVE and FUTURE mode. In this mode we need to check if the stream receives new documents which
+ * are written to the database after the stream was created. We should think about the raise condition
+ * of loosing document events between the allDocs and query call and the creation of the stream.
+ *
+ */
+
+import { fireproof, Ledger } from '@fireproof/core';
+
+describe('query api', () => {
+    let lr: Ledger
+    beforeEach(async () => {
+        lr = fireproof("name")
+        await Promise.all(Array(10).fill(0).map((_, i) => {
+            lr.put({ id: `doc-${i}`, name: `doc-${i}` })
+        }))
+    })
+    afterEach(async () => {
+        await lr.destroy()
+    })
+    for (const method of [
+        {
+            name: "query",
+            fn: () => lr.query("name")
+        },
+        {
+            name: "allDocs",
+            fn: () => lr.allDocs()
+        }]) {
+        describe(`${method.name} method`, () => {
+            it("double call error", async () => {
+                const q = await method.fn()
+                expect(() => q.rows()).not.toThrowError()
+                expect(async () => method.fn()).toThrowError()
+            })
+            it("test rows method", () => {
+                method.fn().then(r => r.rows()).then((docs) => {
+                })
+            })
+        })
+    }
+})

--- a/tests/fireproof/streaming-api.test.ts
+++ b/tests/fireproof/streaming-api.test.ts
@@ -54,7 +54,7 @@ interface DocType {
   name: string;
 }
 
-describe("query api", () => {
+describe("Streaming API", () => {
   let lr: Ledger;
 
   const AMOUNT_OF_DOCS = 10;
@@ -75,11 +75,16 @@ describe("query api", () => {
     await lr.destroy();
   });
 
+  //////////////
+  // ALL DOCS //
+  //////////////
+
   describe("allDocs", () => {
     it("test `snapshot` method", async () => {
       const docs = await lr.allDocs().snapshot();
       expect(docs.length).toBe(AMOUNT_OF_DOCS);
     });
+
     it("test `live` method", async () => {
       const stream = lr.allDocs<DocType>().live();
       let docCount = 0;
@@ -97,6 +102,7 @@ describe("query api", () => {
 
       expect(docCount).toBe(AMOUNT_OF_DOCS + 1);
     });
+
     it("test `future` method", async () => {
       const stream = lr.allDocs<DocType>().future();
       let docCount = 0;
@@ -116,4 +122,12 @@ describe("query api", () => {
       expect(docCount).toBe(2);
     });
   });
+
+  ///////////
+  // QUERY //
+  ///////////
+
+  // describe("query", () => {
+  //   //
+  // });
 });


### PR DESCRIPTION
see in
tests/fireproof/streaming-api.test.ts

overrules:

https://github.com/fireproof-storage/fireproof/pull/315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced document retrieval with a new streaming API.
	- Introduced a utility function for converting document updates into documents with IDs.

- **Improvements**
	- Simplified type system for document management.
	- More flexible event listener management.
	- Streamlined document tracking capabilities.

- **Changes**
	- Removed legacy change tracking methods.
	- Updated method signatures for `allDocs` and related functions.
	- Introduced new `QueryResponse` and `QueryStreamMarker` types.

- **Dependencies**
	- Added `iterator-helpers-polyfill` to support iterator functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->