### PR TITLE
write multiple documents in a single operation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export * from "./crdt.js";
 
 export * from "./indexer.js";
 
+export { defaultWriteQueueOpts } from "./write-queue.js";
+
 export * as bs from "./blockstore/index.js";
 export * as blockstore from "./blockstore/index.js";
 

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -15,6 +15,7 @@ import {
   type IndexKeyType,
   type ListenerFn,
   type DocResponse,
+  type BulkResponse,
   type ChangesResponse,
   type DocTypes,
   type IndexRows,
@@ -73,6 +74,7 @@ export interface Ledger<DT extends DocTypes = NonNullable<unknown>> extends HasC
 
   get<T extends DocTypes>(id: string): Promise<DocWithId<T>>;
   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse>;
+  bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse>;
   del(id: string): Promise<DocResponse>;
   changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>>;
   allDocs<T extends DocTypes>(opts?: AllDocsQueryOpts): Promise<AllDocsResponse<T>>;
@@ -160,6 +162,9 @@ export class LedgerShell<DT extends DocTypes = NonNullable<unknown>> implements 
   }
   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse> {
     return this.ref.put(doc);
+  }
+  bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse> {
+    return this.ref.bulk(docs);
   }
   del(id: string): Promise<DocResponse> {
     return this.ref.del(id);
@@ -297,6 +302,23 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
       },
     })) as CRDTMeta;
     return { id: docId, clock: result?.head, name: this.name } as DocResponse;
+  }
+
+  async bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse> {
+    await this.ready();
+
+    const updates = docs.map((doc) => {
+      const id = doc._id || this.sthis.timeOrderedNextId().str;
+      return {
+        id,
+        value: {
+          ...(doc as unknown as DocSet<DT>),
+          _id: id,
+        },
+      };
+    });
+    const result = (await this._writeQueue.bulk(updates)) as CRDTMeta;
+    return { ids: updates.map((u) => u.id), clock: result.head, name: this.name } as BulkResponse;
   }
 
   async del(id: string): Promise<DocResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,6 +301,12 @@ export interface DocResponse {
   readonly name?: string;
 }
 
+export interface BulkResponse {
+  readonly ids: string[];
+  readonly clock: ClockHead;
+  readonly name?: string;
+}
+
 export type UpdateListenerFn<T extends DocTypes> = (docs: DocWithId<T>[]) => Promise<void> | void;
 export type NoUpdateListenerFn = () => Promise<void> | void;
 export type ListenerFn<T extends DocTypes> = UpdateListenerFn<T> | NoUpdateListenerFn;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import { EnvFactoryOpts, Env, Logger, CryptoRuntime, Result } from "@adviser/cem
 
 // import type { MakeDirectoryOptions, PathLike, Stats } from "fs";
 import { KeyBagOpts } from "./runtime/key-bag.js";
+import { WriteQueueParams } from "./write-queue.js";
 
 export type { DbMeta };
 
@@ -118,6 +119,7 @@ export interface ConfigOpts extends Partial<SuperThisOpts> {
   readonly public?: boolean;
   readonly meta?: DbMeta;
   // readonly persistIndexes?: boolean;
+  readonly writeQueue?: Partial<WriteQueueParams>;
   readonly gatewayInterceptor?: GatewayInterceptor;
   readonly autoCompact?: number;
   readonly storeUrls?: StoreUrlsOpts;

--- a/src/write-queue.ts
+++ b/src/write-queue.ts
@@ -72,7 +72,7 @@ class WriteQueueImpl<T extends DocTypes> implements WriteQueue<T> {
     await Promise.allSettled(promises);
     this.logger.Debug().Any("opts", this.opts).Len(this.queue).Msg("Processed tasks");
     this.isProcessing = false;
-    void this.process();
+    setImmediate(() => this.process());
   }
 
   bulk(tasks: DocUpdate<T>[]): Promise<MetaType> {

--- a/src/write-queue.ts
+++ b/src/write-queue.ts
@@ -1,10 +1,13 @@
-import { DocTypes, MetaType, DocUpdate } from "./types.js";
+import { ensureLogger } from "./utils.js";
+import { DocTypes, MetaType, DocUpdate, SuperThis } from "./types.js";
+import { Future, Logger } from "@adviser/cement";
 
 type WorkerFunction<T extends DocTypes> = (tasks: DocUpdate<T>[]) => Promise<MetaType>;
 
 export interface WriteQueue<T extends DocTypes> {
   push(task: DocUpdate<T>): Promise<MetaType>;
   bulk(tasks: DocUpdate<T>[]): Promise<MetaType>;
+  close(): Promise<void>;
 }
 
 interface WriteQueueItem<T extends DocTypes> {
@@ -14,58 +17,83 @@ interface WriteQueueItem<T extends DocTypes> {
   reject(error: Error): void;
 }
 
-export function writeQueue<T extends DocTypes>(
-  worker: WorkerFunction<T>,
-  payload = Infinity /*, unbounded = false*/,
-): WriteQueue<T> {
-  const queue: WriteQueueItem<T>[] = [];
-  let isProcessing = false;
+export interface WriteQueueParams {
+  // default 32
+  // if chunkSize is 1 the result will be ordered in time
+  readonly chunkSize: number;
+}
 
-  async function process() {
-    if (isProcessing || queue.length === 0) return;
-    isProcessing = true;
+export function defaultWriteQueueOpts(opts: Partial<WriteQueueParams> = {}): WriteQueueParams {
+  return {
+    // ordered: false,
+    chunkSize: 32,
+    ...opts,
+  };
+}
 
-    const tasksToProcess = queue.splice(0, payload);
-    const updates = tasksToProcess.map((item) => item.tasks || []);
+class WriteQueueImpl<T extends DocTypes> implements WriteQueue<T> {
+  private readonly opts: WriteQueueParams;
 
-    // if (unbounded) {
-    // Run all updates in parallel and resolve/reject them individually
-    const promises = updates.map(async (update, index) => {
-      try {
-        const result = await worker(update);
-        tasksToProcess[index].resolve(result);
-      } catch (error) {
-        tasksToProcess[index].reject(error as Error);
-      }
-    });
-    // might better to limit the number of concurrent promises
-    await Promise.allSettled(promises);
-    // } else {
-    // Original logic: Run updates in a batch and resolve/reject them together
-    //     try {
-    //       const result = await worker(updates);
-    //       tasksToProcess.forEach((task) => task.resolve(result));
-    //     } catch (error) {
-    //       tasksToProcess.forEach((task) => task.reject(error as Error));
-    //     }
-    // }
+  private readonly queue: WriteQueueItem<T>[] = [];
+  private readonly worker: WorkerFunction<T>;
+  private isProcessing = false;
+  private readonly logger: Logger;
 
-    isProcessing = false;
-    void process();
+  constructor(sthis: SuperThis, worker: WorkerFunction<T>, opts: WriteQueueParams) {
+    this.logger = ensureLogger(sthis, "WriteQueueImpl");
+    this.worker = worker;
+    this.opts = opts;
   }
 
-  return {
-    bulk(tasks: DocUpdate<T>[]): Promise<MetaType> {
-      return new Promise<MetaType>((resolve, reject) => {
-        queue.push({ tasks, resolve, reject });
-        void process();
-      });
-    },
-    push(task: DocUpdate<T>): Promise<MetaType> {
-      return new Promise<MetaType>((resolve, reject) => {
-        queue.push({ tasks: [task], resolve, reject });
-        void process();
-      });
-    },
-  };
+  private waitForEmptyQueue?: Future<void>;
+  private testEmptyQueue() {
+    if (this.waitForEmptyQueue && this.queue.length === 0) {
+      this.waitForEmptyQueue.resolve();
+    }
+  }
+
+  private async process() {
+    if (this.isProcessing || this.queue.length === 0) {
+      this.testEmptyQueue();
+      return;
+    }
+    this.isProcessing = true;
+    this.logger.Debug().Any("opts", this.opts).Len(this.queue).Msg("Processing tasks");
+    const tasksToProcess = this.queue.splice(0, this.opts.chunkSize);
+    const updates = tasksToProcess.map((item) => item.tasks).filter((item) => item) as DocUpdate<T>[][];
+    const promises = updates.map(async (update, index) => {
+      try {
+        const result = await this.worker(update);
+        tasksToProcess[index].resolve(result);
+      } catch (error) {
+        tasksToProcess[index].reject(this.logger.Error().Err(error).Msg("Error processing task").AsError());
+      }
+    });
+    await Promise.allSettled(promises);
+    this.logger.Debug().Any("opts", this.opts).Len(this.queue).Msg("Processed tasks");
+    this.isProcessing = false;
+    void this.process();
+  }
+
+  bulk(tasks: DocUpdate<T>[]): Promise<MetaType> {
+    return new Promise<MetaType>((resolve, reject) => {
+      this.queue.push({ tasks, resolve, reject });
+      this.process();
+    });
+  }
+  push(task: DocUpdate<T>): Promise<MetaType> {
+    return new Promise<MetaType>((resolve, reject) => {
+      this.queue.push({ tasks: [task], resolve, reject });
+      this.process();
+    });
+  }
+  close(): Promise<void> {
+    this.waitForEmptyQueue = new Future();
+    this.testEmptyQueue();
+    return this.waitForEmptyQueue.asPromise();
+  }
+}
+
+export function writeQueue<T extends DocTypes>(sthis: SuperThis, worker: WorkerFunction<T>, opts: WriteQueueParams): WriteQueue<T> {
+  return new WriteQueueImpl<T>(sthis, worker, opts);
 }

--- a/tests/fireproof/crdt.test.ts
+++ b/tests/fireproof/crdt.test.ts
@@ -1,4 +1,4 @@
-import { CRDT, LedgerOpts, toStoreURIRuntime } from "@fireproof/core";
+import { CRDT, defaultWriteQueueOpts, LedgerOpts, toStoreURIRuntime } from "@fireproof/core";
 import { bs } from "@fireproof/core";
 import { CRDTMeta, DocValue } from "@fireproof/core";
 import { Index, index } from "@fireproof/core";
@@ -15,6 +15,7 @@ describe("Fresh crdt", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -57,6 +58,7 @@ describe("CRDT with one record", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `test@${sthis.nextId()}`),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -112,6 +114,7 @@ describe("CRDT with a multi-write", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -182,6 +185,7 @@ describe("CRDT with two multi-writes", function () {
   beforeEach(async () => {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `test-multiple-writes@${sthis.nextId()}`),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -235,6 +239,7 @@ describe("Compact a named CRDT with writes", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `named-crdt-compaction`),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -296,6 +301,7 @@ describe("CRDT with an index", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -347,6 +353,7 @@ describe("Loader with a committed transaction", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, dbname),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -400,6 +407,7 @@ describe("Loader with two committed transactions", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-loader"),
       storeEnDe: bs.ensureStoreEnDeFile({}),
@@ -455,6 +463,7 @@ describe("Loader with many committed transactions", function () {
   beforeEach(async function () {
     await sthis.start();
     const dbOpts: LedgerOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-loader-many"),
       storeEnDe: bs.ensureStoreEnDeFile({}),

--- a/tests/fireproof/fireproof.test.ts
+++ b/tests/fireproof/fireproof.test.ts
@@ -139,6 +139,15 @@ describe("basic ledger", function () {
     const got = await db.get<Doc>(ok.id);
     expect(got.foo).toBe("bam");
   });
+  it("can bulk an array", async function () {
+    const ok = await db.bulk([{ foo: "cool" }, { foo: "dude" }]);
+    expect(ok).toBeTruthy();
+    expect(ok.ids.length).toBe(2);
+    const got = await db.get<Doc>(ok.ids[0]);
+    expect(got.foo).toBe("cool");
+    const got2 = await db.get<Doc>(ok.ids[1]);
+    expect(got2.foo).toBe("dude");
+  });
   it("can define an index", async function () {
     const ok = await db.put({ _id: "test", foo: "bar" });
     expect(ok).toBeTruthy();

--- a/tests/fireproof/indexer.test.ts
+++ b/tests/fireproof/indexer.test.ts
@@ -1,4 +1,16 @@
-import { Index, index, Ledger, CRDT, IndexRows, LedgerOpts, toStoreURIRuntime, bs, rt, LedgerFactory } from "@fireproof/core";
+import {
+  Index,
+  index,
+  Ledger,
+  CRDT,
+  IndexRows,
+  LedgerOpts,
+  toStoreURIRuntime,
+  bs,
+  rt,
+  LedgerFactory,
+  defaultWriteQueueOpts,
+} from "@fireproof/core";
 import { mockSuperThis } from "../helpers.js";
 
 interface TestType {
@@ -278,6 +290,7 @@ describe("basic Index upon cold start", function () {
     const logger = sthis.logger.With().Module("IndexerTest").Logger();
     logger.Debug().Msg("enter beforeEach");
     dbOpts = {
+      writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.kb.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-indexer-cold"),
       storeEnDe: bs.ensureStoreEnDeFile({}),

--- a/tests/fireproof/ledger.test.ts
+++ b/tests/fireproof/ledger.test.ts
@@ -284,8 +284,10 @@ describe("basic Ledger parallel writes / public", () => {
     }
     await Promise.all(writes);
   });
-  it("should have one head", () => {
+  it("should resolve to one head", async () => {
     const crdt = db.crdt;
+    expect(crdt.clock.head.length).toBe(9);
+    await db.put({ _id: "id-10", hello: "world" });
     expect(crdt.clock.head.length).toBe(1);
   });
   it("should write all", async () => {


### PR DESCRIPTION
this allows inserting multiple records into a single CRDT operation. For some workloads it may see a benefit, as larger datasets can have fewer log entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `bulk` method for processing multiple documents in the ledger.
  - Enhanced `WriteQueue` with bulk processing capabilities and improved error handling.
  - Added new configuration options for the write queue.

- **Bug Fixes**
  - Improved resource management in the `shellClose` method.

- **Tests**
  - Added a test case for the new `bulk` method in the ledger.
  - Restructured and renamed test cases for clarity in the `Ledger` functionality tests.
  - Standardized write queue configuration across multiple `CRDT` test cases.
  - Updated test configurations in the indexer test suite to utilize default write queue options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->