### PR TITLE
serdegateway and defSerdeGateway for 0.19 compatiblity

### DIFF
--- a/src/blockstore/gateway.ts
+++ b/src/blockstore/gateway.ts
@@ -1,100 +1,35 @@
 import { Result, URI } from "@adviser/cement";
 import { NotFoundError } from "../utils.js";
-import { FPEnvelope, FPEnvelopeMeta } from "./fp-envelope.js";
-import { Loadable } from "./types.js";
+import { UnsubscribeResult, VoidResult } from "./serde-gateway.js";
+import { SuperThis } from "@fireproof/core";
 
 export interface GatewayOpts {
   readonly gateway: Gateway;
 }
 
-export type GetResult<S> = Result<FPEnvelope<S>, NotFoundError | Error>;
-export type VoidResult = Result<void>;
+export type GetResult = Result<Uint8Array, NotFoundError | Error>;
+// export type VoidResult = Result<void>;
 
 // export interface TestGateway {
 //   get(url: URI, key: string): Promise<Uint8Array>;
 // }
 
-export type UnsubscribeResult = Result<() => void>;
+// export type UnsubscribeResult = Result<() => void>;
 
 export interface Gateway {
   // all the methods never throw!
   // an error is reported as a Result
-  buildUrl(baseUrl: URI, key: string, loader?: Loadable): Promise<Result<URI>>;
+  buildUrl(baseUrl: URI, key: string, sthis: SuperThis): Promise<Result<URI>>;
   // start updates URL --> hate this side effect
-  start(baseUrl: URI, loader?: Loadable): Promise<Result<URI>>;
-  close(baseUrl: URI, loader?: Loadable): Promise<VoidResult>;
-  put<T>(url: URI, body: FPEnvelope<T>, loader?: Loadable): Promise<VoidResult>;
+  start(baseUrl: URI, sthis: SuperThis): Promise<Result<URI>>;
+  close(baseUrl: URI, sthis: SuperThis): Promise<VoidResult>;
+  destroy(baseUrl: URI, sthis: SuperThis): Promise<VoidResult>;
+  put(url: URI, body: Uint8Array, sthis: SuperThis): Promise<VoidResult>;
   // get could return a NotFoundError if the key is not found
-  get<S>(url: URI, loader?: Loadable): Promise<GetResult<S>>;
-  delete(url: URI, loader?: Loadable): Promise<VoidResult>;
-
+  get(url: URI, sthis: SuperThis): Promise<GetResult>;
+  delete(url: URI, sthis: SuperThis): Promise<VoidResult>;
   // be notified of remote meta
-  subscribe?(url: URI, callback: (meta: FPEnvelopeMeta) => Promise<void>, loader?: Loadable): Promise<UnsubscribeResult>;
+  subscribe?(url: URI, callback: (meta: Uint8Array) => void, sthis: SuperThis): Promise<UnsubscribeResult>;
 
-  // this method is used to get the raw data mostly for testing
-  getPlain(url: URI, key: string, loader?: Loadable): Promise<Result<Uint8Array>>;
-  // this method is used for testing only
-  // to avoid any drama it should only enabled in test mode
-  destroy(baseUrl: URI, loader?: Loadable): Promise<VoidResult>;
-}
-
-export interface GatewayReturn<O, T> {
-  readonly op: O;
-  readonly value?: T; // result is pass
-  readonly stop?: boolean;
-}
-export interface GatewayBuildUrlOp {
-  readonly url: URI;
-  readonly key: string;
-}
-export type GatewayBuildUrlReturn = GatewayReturn<GatewayBuildUrlOp, Result<URI>>;
-
-export interface GatewayStartOp {
-  readonly url: URI;
-}
-export type GatewayStartReturn = GatewayReturn<GatewayStartOp, Result<URI>>;
-
-export interface GatewayCloseOp {
-  readonly url: URI;
-}
-export type GatewayCloseReturn = GatewayReturn<GatewayCloseOp, VoidResult>;
-
-export interface GatewayDestroyOp {
-  readonly url: URI;
-}
-export type GatewayDestroyReturn = GatewayReturn<GatewayDestroyOp, VoidResult>;
-
-export interface GatewayPutOp<T> {
-  readonly url: URI;
-  readonly body: FPEnvelope<T>;
-}
-
-export type GatewayPutReturn<T> = GatewayReturn<GatewayPutOp<T>, VoidResult>;
-
-export interface GatewayGetOp {
-  readonly url: URI;
-}
-export type GatewayGetReturn<S> = GatewayReturn<GatewayGetOp, GetResult<S>>;
-
-export interface GatewayDeleteOp {
-  readonly url: URI;
-}
-export type GatewayDeleteReturn = GatewayReturn<GatewayDeleteOp, VoidResult>;
-
-export interface GatewaySubscribeOp {
-  readonly url: URI;
-  readonly callback: (meta: FPEnvelopeMeta) => Promise<void>;
-}
-
-export type GatewaySubscribeReturn = GatewayReturn<GatewaySubscribeOp, UnsubscribeResult>;
-
-export interface GatewayInterceptor {
-  buildUrl(baseUrl: URI, key: string, loader: Loadable): Promise<Result<GatewayBuildUrlReturn>>;
-  start(baseUrl: URI, loader: Loadable): Promise<Result<GatewayStartReturn>>;
-  close(baseUrl: URI, loader: Loadable): Promise<Result<GatewayCloseReturn>>;
-  delete(baseUrl: URI, loader: Loadable): Promise<Result<GatewayDeleteReturn>>;
-  destroy(baseUrl: URI, loader: Loadable): Promise<Result<GatewayDestroyReturn>>;
-  put<T>(url: URI, body: FPEnvelope<T>, loader: Loadable): Promise<Result<GatewayPutReturn<T>>>;
-  get<S>(url: URI, loader: Loadable): Promise<Result<GatewayGetReturn<S>>>;
-  subscribe(url: URI, callback: (meta: FPEnvelopeMeta) => Promise<void>, loader: Loadable): Promise<Result<GatewaySubscribeReturn>>;
+  getPlain(url: URI, key: string, sthis: SuperThis): Promise<Result<Uint8Array>>;
 }

--- a/src/blockstore/index.ts
+++ b/src/blockstore/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.js";
 
 export * from "./store-factory.js";
+export * from "./serde-gateway.js";
 export * from "./gateway.js";
 
 export * from "./fp-envelope.js";

--- a/src/blockstore/register-store-protocol.ts
+++ b/src/blockstore/register-store-protocol.ts
@@ -70,6 +70,7 @@ export function registerStoreProtocol(item: SerdeOrGatewayFactoryItem): () => vo
     serdegateway = async (sthis) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const m = await item.gateway!(sthis);
+      // console.log("Gateway Plug in DefSerdeGateway", m);
       return new DefSerdeGateway(m);
     };
   } else {

--- a/src/blockstore/serde-gateway.ts
+++ b/src/blockstore/serde-gateway.ts
@@ -1,0 +1,111 @@
+import { Result, URI } from "@adviser/cement";
+import { NotFoundError } from "../utils.js";
+import { FPEnvelope, FPEnvelopeMeta } from "./fp-envelope.js";
+import { Loadable } from "./types.js";
+import { SuperThis } from "../types.js";
+
+export interface SerdeGatewayOpts {
+  readonly gateway: SerdeGateway;
+}
+
+export type SerdeGetResult<S> = Result<FPEnvelope<S>, NotFoundError | Error>;
+export type VoidResult = Result<void>;
+
+// export interface TestGateway {
+//   get(url: URI, key: string): Promise<Uint8Array>;
+// }
+
+export type UnsubscribeResult = Result<() => void>;
+
+export interface SerdeGateway {
+  // all the methods never throw!
+  // an error is reported as a Result
+  buildUrl(sthis: SuperThis, baseUrl: URI, key: string, loader?: Loadable): Promise<Result<URI>>;
+  // start updates URL --> hate this side effect
+  start(sthis: SuperThis, baseUrl: URI, loader?: Loadable): Promise<Result<URI>>;
+  close(sthis: SuperThis, baseUrl: URI, loader?: Loadable): Promise<VoidResult>;
+  put<T>(sthis: SuperThis, url: URI, body: FPEnvelope<T>, loader?: Loadable): Promise<VoidResult>;
+  // get could return a NotFoundError if the key is not found
+  get<S>(sthis: SuperThis, url: URI, loader?: Loadable): Promise<SerdeGetResult<S>>;
+  delete(sthis: SuperThis, url: URI, loader?: Loadable): Promise<VoidResult>;
+
+  // be notified of remote meta
+  subscribe?(
+    sthis: SuperThis,
+    url: URI,
+    callback: (meta: FPEnvelopeMeta) => Promise<void>,
+    loader?: Loadable,
+  ): Promise<UnsubscribeResult>;
+
+  // this method is used to get the raw data mostly for testing
+  getPlain(sthis: SuperThis, url: URI, key: string, loader?: Loadable): Promise<Result<Uint8Array>>;
+  // this method is used for testing only
+  // to avoid any drama it should only enabled in test mode
+  destroy(sthis: SuperThis, baseUrl: URI, loader?: Loadable): Promise<VoidResult>;
+}
+
+export interface SerdeGatewayReturn<O, T> {
+  readonly op: O;
+  readonly value?: T; // result is pass
+  readonly stop?: boolean;
+}
+export interface SerdeGatewayBuildUrlOp {
+  readonly url: URI;
+  readonly key: string;
+}
+export type SerdeGatewayBuildUrlReturn = SerdeGatewayReturn<SerdeGatewayBuildUrlOp, Result<URI>>;
+
+export interface SerdeGatewayStartOp {
+  readonly url: URI;
+}
+export type SerdeGatewayStartReturn = SerdeGatewayReturn<SerdeGatewayStartOp, Result<URI>>;
+
+export interface SerdeGatewayCloseOp {
+  readonly url: URI;
+}
+export type SerdeGatewayCloseReturn = SerdeGatewayReturn<SerdeGatewayCloseOp, VoidResult>;
+
+export interface SerdeGatewayDestroyOp {
+  readonly url: URI;
+}
+export type SerdeGatewayDestroyReturn = SerdeGatewayReturn<SerdeGatewayDestroyOp, VoidResult>;
+
+export interface SerdeGatewayPutOp<T> {
+  readonly url: URI;
+  readonly body: FPEnvelope<T>;
+}
+
+export type SerdeGatewayPutReturn<T> = SerdeGatewayReturn<SerdeGatewayPutOp<T>, VoidResult>;
+
+export interface SerdeGatewayGetOp {
+  readonly url: URI;
+}
+export type SerdeGatewayGetReturn<S> = SerdeGatewayReturn<SerdeGatewayGetOp, SerdeGetResult<S>>;
+
+export interface SerdeGatewayDeleteOp {
+  readonly url: URI;
+}
+export type SerdeGatewayDeleteReturn = SerdeGatewayReturn<SerdeGatewayDeleteOp, VoidResult>;
+
+export interface SerdeGatewaySubscribeOp {
+  readonly url: URI;
+  readonly callback: (meta: FPEnvelopeMeta) => Promise<void>;
+}
+
+export type SerdeGatewaySubscribeReturn = SerdeGatewayReturn<SerdeGatewaySubscribeOp, UnsubscribeResult>;
+
+export interface SerdeGatewayInterceptor {
+  buildUrl(sthis: SuperThis, baseUrl: URI, key: string, loader: Loadable): Promise<Result<SerdeGatewayBuildUrlReturn>>;
+  start(sthis: SuperThis, baseUrl: URI, loader: Loadable): Promise<Result<SerdeGatewayStartReturn>>;
+  close(sthis: SuperThis, baseUrl: URI, loader: Loadable): Promise<Result<SerdeGatewayCloseReturn>>;
+  delete(sthis: SuperThis, baseUrl: URI, loader: Loadable): Promise<Result<SerdeGatewayDeleteReturn>>;
+  destroy(sthis: SuperThis, baseUrl: URI, loader: Loadable): Promise<Result<SerdeGatewayDestroyReturn>>;
+  put<T>(sthis: SuperThis, url: URI, body: FPEnvelope<T>, loader: Loadable): Promise<Result<SerdeGatewayPutReturn<T>>>;
+  get<S>(sthis: SuperThis, url: URI, loader: Loadable): Promise<Result<SerdeGatewayGetReturn<S>>>;
+  subscribe(
+    sthis: SuperThis,
+    url: URI,
+    callback: (meta: FPEnvelopeMeta) => Promise<void>,
+    loader: Loadable,
+  ): Promise<Result<SerdeGatewaySubscribeReturn>>;
+}

--- a/src/blockstore/types.ts
+++ b/src/blockstore/types.ts
@@ -7,7 +7,7 @@ import { KeyBag, KeyBagRuntime } from "../runtime/key-bag.js";
 import { CoerceURI, CryptoRuntime, CTCryptoKey, Logger, Result, URI } from "@adviser/cement";
 import { EventBlock } from "@fireproof/vendor/@web3-storage/pail/clock";
 import { TaskManager } from "./task-manager.js";
-import { Gateway, GatewayInterceptor } from "./gateway.js";
+import { SerdeGateway, SerdeGatewayInterceptor } from "./serde-gateway.js";
 import { CarReader } from "@fireproof/vendor/@ipld/car";
 
 export type AnyLink = Link<unknown, number, number, Version>;
@@ -206,7 +206,7 @@ export interface StoreURIRuntime {
 export interface StoreFactoryItem {
   readonly sthis: SuperThis;
   readonly url: URI;
-  readonly gatewayInterceptor?: GatewayInterceptor;
+  readonly gatewayInterceptor?: SerdeGatewayInterceptor;
   // readonly keybag: KeyBag;
   readonly loader: Loadable;
 }
@@ -285,7 +285,7 @@ export interface Connection {
 
 export interface BaseStore {
   readonly storeType: StoreType;
-  readonly realGateway: Gateway;
+  readonly realGateway: SerdeGateway;
   // readonly url: URI
   url(): URI;
   // readonly name: string;
@@ -376,7 +376,7 @@ export interface StoreRuntimeUrls {
   readonly wal: URI;
 }
 
-export type BlockstoreOpts = Partial<{
+export interface BlockstoreParams {
   readonly logger: Logger;
   readonly applyMeta: (meta: TransactionMeta, snap?: boolean) => Promise<void>;
   readonly compact: CompactFn;
@@ -385,9 +385,14 @@ export type BlockstoreOpts = Partial<{
   readonly public: boolean;
   readonly meta: DbMeta;
   readonly threshold: number;
-  readonly gatewayInterceptor?: GatewayInterceptor;
+  readonly gatewayInterceptor?: SerdeGatewayInterceptor;
   readonly storeEnDeFile: Partial<StoreEnDeFile>;
-}> & {
+  readonly keyBag: KeyBagRuntime;
+  readonly storeUrls: StoreURIs;
+  readonly storeRuntime: StoreRuntime;
+}
+
+export type BlockstoreOpts = Partial<BlockstoreParams> & {
   readonly keyBag: KeyBagRuntime;
   readonly storeUrls: StoreURIs;
   readonly storeRuntime: StoreRuntime;
@@ -402,7 +407,7 @@ export interface BlockstoreRuntime {
   readonly storeRuntime: StoreRuntime;
   readonly keyBag: KeyBagRuntime;
   readonly storeUrls: StoreURIs;
-  readonly gatewayInterceptor?: GatewayInterceptor;
+  readonly gatewayInterceptor?: SerdeGatewayInterceptor;
   // readonly storeEnDeFile: StoreEnDeFile;
   // readonly public: boolean;
   readonly meta?: DbMeta;

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -27,7 +27,7 @@ import {
   type SuperThis,
   PARAM,
 } from "./types.js";
-import { DbMeta, StoreEnDeFile, StoreURIRuntime, StoreUrlsOpts, GatewayInterceptor } from "./blockstore/index.js";
+import { DbMeta, SerdeGatewayInterceptor, StoreEnDeFile, StoreURIRuntime, StoreUrlsOpts } from "./blockstore/index.js";
 import { ensureLogger, ensureSuperThis, NotFoundError, toSortedArray } from "./utils.js";
 
 import { decodeFile, encodeFile } from "./runtime/files.js";
@@ -49,7 +49,7 @@ export interface LedgerOpts {
   readonly name?: string;
   // readonly public?: boolean;
   readonly meta?: DbMeta;
-  readonly gatewayInterceptor?: GatewayInterceptor;
+  readonly gatewayInterceptor?: SerdeGatewayInterceptor;
 
   readonly writeQueue: WriteQueueParams;
   // readonly factoryUnreg?: () => void;

--- a/src/runtime/gateways/def-serde-gateway.ts
+++ b/src/runtime/gateways/def-serde-gateway.ts
@@ -1,0 +1,51 @@
+import { Result, URI } from "@adviser/cement";
+import { Gateway } from "../../blockstore/gateway.js";
+import { FPEnvelope } from "../../blockstore/fp-envelope.js";
+import { fpDeserialize, fpSerialize } from "./fp-envelope-serialize.js";
+import { SerdeGateway, SerdeGetResult } from "../../blockstore/serde-gateway.js";
+import { SuperThis } from "../../types.js";
+
+export class DefSerdeGateway implements SerdeGateway {
+  // abstract readonly storeType: StoreType;
+  readonly gw: Gateway;
+
+  constructor(gw: Gateway) {
+    this.gw = gw;
+  }
+
+  start(sthis: SuperThis, baseURL: URI): Promise<Result<URI>> {
+    return this.gw.start(baseURL, sthis);
+  }
+
+  async buildUrl(sthis: SuperThis, baseUrl: URI, key: string): Promise<Result<URI>> {
+    return this.gw.buildUrl(baseUrl, key, sthis);
+  }
+
+  async close(sthis: SuperThis, uri: URI): Promise<Result<void>> {
+    return this.gw.close(uri, sthis);
+  }
+
+  async put<T>(sthis: SuperThis, url: URI, env: FPEnvelope<T>): Promise<Result<void>> {
+    const rUint8 = await fpSerialize(sthis, env);
+    if (rUint8.isErr()) return rUint8;
+    return this.gw.put(url, rUint8.Ok(), sthis);
+  }
+
+  async get<S>(sthis: SuperThis, url: URI): Promise<SerdeGetResult<S>> {
+    const res = await this.gw.get(url, sthis);
+    if (res.isErr()) return Result.Err(res.Err());
+    return fpDeserialize(sthis, url, res) as Promise<SerdeGetResult<S>>;
+  }
+
+  async delete(sthis: SuperThis, url: URI): Promise<Result<void>> {
+    return this.gw.delete(url, sthis);
+  }
+
+  async destroy(sthis: SuperThis, baseURL: URI): Promise<Result<void>> {
+    return this.gw.destroy(baseURL, sthis);
+  }
+
+  async getPlain(sthis: SuperThis, iurl: URI, key: string) {
+    return this.gw.getPlain(iurl, key, sthis);
+  }
+}

--- a/src/runtime/gateways/file/gateway-impl.ts
+++ b/src/runtime/gateways/file/gateway-impl.ts
@@ -62,15 +62,15 @@ export class FileGateway implements Gateway {
   getFilePath(url: URI, sthis: SuperThis): string {
     const key = url.getParam(PARAM.KEY);
     if (!key) throw sthis.logger.Error().Url(url).Msg(`key not found`).AsError();
-    const urlGen = url.getParam(PARAM.URL_GEN);
-    switch (urlGen) {
-      case "default":
-        return sthis.pathOps.join(getPath(url, sthis), getFileName(url, sthis));
-      case "fromEnv":
-        return sthis.pathOps.join(getPath(url, sthis), key);
-      default:
-        break;
-    }
+    // const urlGen = url.getParam(PARAM.URL_GEN);
+    // switch (urlGen) {
+    //   case "default":
+    //     return sthis.pathOps.join(getPath(url, sthis), getFileName(url, sthis));
+    //   case "fromEnv":
+    //     return sthis.pathOps.join(getPath(url, sthis), getFileName(url, sthis));
+    //   default:
+    //     break;
+    // }
     return sthis.pathOps.join(getPath(url, sthis), getFileName(url, sthis));
   }
 

--- a/src/runtime/gateways/memory/gateway.ts
+++ b/src/runtime/gateways/memory/gateway.ts
@@ -1,10 +1,9 @@
 import { Result, URI } from "@adviser/cement";
-import { Gateway, GetResult, VoidResult } from "../../../blockstore/gateway.js";
+import { Gateway, GetResult } from "../../../blockstore/gateway.js";
 import { PARAM, SuperThis } from "../../../types.js";
 import { MEMORY_VERSION } from "./version.js";
 import { NotFoundError } from "../../../utils.js";
-import { FPEnvelope } from "../../../blockstore/fp-envelope.js";
-import { fpSerialize, fpDeserialize } from "../fp-envelope-serialize.js";
+import { VoidResult } from "../../../blockstore/serde-gateway.js";
 
 export class MemoryGateway implements Gateway {
   readonly memorys: Map<string, Uint8Array>;
@@ -29,17 +28,17 @@ export class MemoryGateway implements Gateway {
     this.memorys.clear();
     return Promise.resolve(Result.Ok(undefined));
   }
-  async put<T>(url: URI, enve: FPEnvelope<T>): Promise<VoidResult> {
-    this.memorys.set(url.toString(), (await fpSerialize(this.sthis, enve)).Ok());
+  async put(url: URI, bytes: Uint8Array): Promise<VoidResult> {
+    this.memorys.set(url.toString(), bytes);
     return Result.Ok(undefined);
   }
   // get could return a NotFoundError if the key is not found
-  get<S>(url: URI): Promise<GetResult<S>> {
+  get(url: URI): Promise<GetResult> {
     const x = this.memorys.get(url.toString());
     if (!x) {
       return Promise.resolve(Result.Err(new NotFoundError("not found")));
     }
-    return fpDeserialize(this.sthis, url, x) as Promise<GetResult<S>>;
+    return Promise.resolve(Result.Ok(x));
   }
   delete(url: URI): Promise<VoidResult> {
     this.memorys.delete(url.toString());

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { EventLink } from "@fireproof/vendor/@web3-storage/pail/clock/api";
 import type { Operation } from "@fireproof/vendor/@web3-storage/pail/crdt/api";
 
-import type { DbMeta, AnyLink, StoreUrlsOpts, StoreEnDeFile, GatewayInterceptor } from "./blockstore/index.js";
+import type { DbMeta, AnyLink, StoreUrlsOpts, StoreEnDeFile, SerdeGatewayInterceptor } from "./blockstore/index.js";
 import { EnvFactoryOpts, Env, Logger, CryptoRuntime, Result } from "@adviser/cement";
 
 // import type { MakeDirectoryOptions, PathLike, Stats } from "fs";
@@ -122,7 +122,7 @@ export interface ConfigOpts extends Partial<SuperThisOpts> {
   readonly meta?: DbMeta;
   // readonly persistIndexes?: boolean;
   readonly writeQueue?: Partial<WriteQueueParams>;
-  readonly gatewayInterceptor?: GatewayInterceptor;
+  readonly gatewayInterceptor?: SerdeGatewayInterceptor;
   readonly autoCompact?: number;
   readonly storeUrls?: StoreUrlsOpts;
   readonly storeEnDe?: StoreEnDeFile;

--- a/tests/blockstore/interceptor-gateway.test.ts
+++ b/tests/blockstore/interceptor-gateway.test.ts
@@ -1,47 +1,51 @@
 import { Result, URI } from "@adviser/cement";
-import { bs, fireproof } from "@fireproof/core";
+import { bs, fireproof, SuperThis } from "@fireproof/core";
 
 class TestInterceptor extends bs.PassThroughGateway {
   readonly fn = vitest.fn();
 
-  async buildUrl(baseUrl: URI, key: string): Promise<Result<bs.GatewayBuildUrlReturn>> {
-    const ret = await super.buildUrl(baseUrl, key);
+  async buildUrl(sthis: SuperThis, baseUrl: URI, key: string): Promise<Result<bs.SerdeGatewayBuildUrlReturn>> {
+    const ret = await super.buildUrl(sthis, baseUrl, key);
     this.fn("buildUrl", ret);
     return ret;
   }
 
-  async start(baseUrl: URI): Promise<Result<bs.GatewayStartReturn>> {
-    const ret = await super.start(baseUrl);
+  async start(sthis: SuperThis, baseUrl: URI): Promise<Result<bs.SerdeGatewayStartReturn>> {
+    const ret = await super.start(sthis, baseUrl);
     this.fn("start", ret);
     return ret;
   }
-  async close(baseUrl: URI): Promise<Result<bs.GatewayCloseReturn>> {
-    const ret = await super.close(baseUrl);
+  async close(sthis: SuperThis, baseUrl: URI): Promise<Result<bs.SerdeGatewayCloseReturn>> {
+    const ret = await super.close(sthis, baseUrl);
     this.fn("close", ret);
     return ret;
   }
-  async delete(baseUrl: URI): Promise<Result<bs.GatewayDeleteReturn>> {
-    const ret = await super.delete(baseUrl);
+  async delete(sthis: SuperThis, baseUrl: URI): Promise<Result<bs.SerdeGatewayDeleteReturn>> {
+    const ret = await super.delete(sthis, baseUrl);
     this.fn("delete", ret);
     return ret;
   }
-  async destroy(baseUrl: URI): Promise<Result<bs.GatewayDestroyReturn>> {
-    const ret = await super.destroy(baseUrl);
+  async destroy(sthis: SuperThis, baseUrl: URI): Promise<Result<bs.SerdeGatewayDestroyReturn>> {
+    const ret = await super.destroy(sthis, baseUrl);
     this.fn("destroy", ret);
     return ret;
   }
-  async put<T>(url: URI, body: bs.FPEnvelope<T>): Promise<Result<bs.GatewayPutReturn<T>>> {
-    const ret = await super.put<T>(url, body);
+  async put<T>(sthis: SuperThis, url: URI, body: bs.FPEnvelope<T>): Promise<Result<bs.SerdeGatewayPutReturn<T>>> {
+    const ret = await super.put<T>(sthis, url, body);
     this.fn("put", ret);
     return ret;
   }
-  async get<S>(url: URI): Promise<Result<bs.GatewayGetReturn<S>>> {
-    const ret = await super.get<S>(url);
+  async get<S>(sthis: SuperThis, url: URI): Promise<Result<bs.SerdeGatewayGetReturn<S>>> {
+    const ret = await super.get<S>(sthis, url);
     this.fn("get", ret);
     return ret;
   }
-  async subscribe(url: URI, callback: (meta: bs.FPEnvelopeMeta) => Promise<void>): Promise<Result<bs.GatewaySubscribeReturn>> {
-    const ret = await super.subscribe(url, callback);
+  async subscribe(
+    sthis: SuperThis,
+    url: URI,
+    callback: (meta: bs.FPEnvelopeMeta) => Promise<void>,
+  ): Promise<Result<bs.SerdeGatewaySubscribeReturn>> {
+    const ret = await super.subscribe(sthis, url, callback);
     this.fn("subscribe", ret);
     return ret;
   }

--- a/tests/blockstore/store.test.ts
+++ b/tests/blockstore/store.test.ts
@@ -45,7 +45,7 @@ describe("DataStore", function () {
       bytes: new Uint8Array([55, 56, 57]),
     };
     await store.save(car);
-    const data = (await store.realGateway.getPlain(store.url(), car.cid.toString())).Ok();
+    const data = (await store.realGateway.getPlain(sthis, store.url(), car.cid.toString())).Ok();
     expect(sthis.txt.decode(data)).toEqual(sthis.txt.decode(car.bytes));
   });
 });
@@ -73,7 +73,7 @@ describe("DataStore with a saved car", function () {
   });
 
   it("should have a car", async function () {
-    const data = (await store.realGateway.getPlain(store.url(), car.cid.toString())).Ok();
+    const data = (await store.realGateway.getPlain(sthis, store.url(), car.cid.toString())).Ok();
     expect(sthis.txt.decode(data)).toEqual(sthis.txt.decode(car.bytes));
   });
 
@@ -118,7 +118,7 @@ describe("MetaStore", function () {
       // key: undefined,
     };
     await store.save(h);
-    const file = await store.realGateway.getPlain(store.url(), "main");
+    const file = await store.realGateway.getPlain(sthis, store.url(), "main");
     const blockMeta = (await rt.gw.fpDeserialize(sthis, store.url(), file)) as Result<bs.FPEnvelopeMeta>;
     expect(blockMeta.Ok()).toBeTruthy();
     expect(blockMeta.Ok().payload.length).toEqual(1);
@@ -154,7 +154,7 @@ describe("MetaStore with a saved header", function () {
   // });
 
   it("should have a header", async function () {
-    const bytes = await store.realGateway.getPlain(store.url(), "main");
+    const bytes = await store.realGateway.getPlain(sthis, store.url(), "main");
     const data = sthis.txt.decode(bytes.Ok());
     expect(data).toMatch(/parents/);
     const header = JSON.parse(data)[0];

--- a/tests/fireproof/all-gateway.test.ts
+++ b/tests/fireproof/all-gateway.test.ts
@@ -35,10 +35,10 @@ describe("noop Gateway", function () {
   let metaStore: bs.MetaStore;
   let fileStore: bs.DataStore;
   let walStore: bs.WALStore;
-  let carGateway: bs.Gateway;
-  let metaGateway: bs.Gateway;
-  let fileGateway: bs.Gateway;
-  let walGateway: bs.Gateway;
+  let carGateway: bs.SerdeGateway;
+  let metaGateway: bs.SerdeGateway;
+  let fileGateway: bs.SerdeGateway;
+  let walGateway: bs.SerdeGateway;
   const sthis = ensureSuperThis();
 
   afterEach(async function () {
@@ -111,19 +111,19 @@ describe("noop Gateway", function () {
 
   it("should build CAR Gateway URL", async function () {
     const testKey = "bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i";
-    const carUrl = await carGateway.buildUrl(carStore.url(), testKey);
+    const carUrl = await carGateway.buildUrl(sthis, carStore.url(), testKey);
     expect(carUrl.Ok().hasParam("key")).toBeTruthy();
   });
 
   it("should start CAR Gateway", async function () {
-    const url = await carGateway.start(carStore.url());
+    const url = await carGateway.start(sthis, carStore.url());
     expect(url.Ok().asObj()).toEqual(carStore.url().asObj());
   });
 
   it("should put data in CAR Gateway", async function () {
-    const carUrl = await carGateway.buildUrl(carStore.url(), fileContent.cid);
-    await carGateway.start(carStore.url());
-    const carPutResult = await carGateway.put(carUrl.Ok(), {
+    const carUrl = await carGateway.buildUrl(sthis, carStore.url(), fileContent.cid);
+    await carGateway.start(sthis, carStore.url());
+    const carPutResult = await carGateway.put(sthis, carUrl.Ok(), {
       type: bs.FPEnvelopeType.CAR,
       payload: fileContent.block,
     });
@@ -131,59 +131,59 @@ describe("noop Gateway", function () {
   });
 
   it("should get data from CAR Gateway", async function () {
-    const carUrl = await carGateway.buildUrl(carStore.url(), fileContent.cid);
-    await carGateway.start(carStore.url());
-    await carGateway.put(carUrl.Ok(), {
+    const carUrl = await carGateway.buildUrl(sthis, carStore.url(), fileContent.cid);
+    await carGateway.start(sthis, carStore.url());
+    await carGateway.put(sthis, carUrl.Ok(), {
       type: bs.FPEnvelopeType.CAR,
       payload: fileContent.block,
     });
-    const carGetResult = await carGateway.get(carUrl.Ok());
+    const carGetResult = await carGateway.get(sthis, carUrl.Ok());
     expect(carGetResult.Ok().type).toEqual("car");
     expect(carGetResult.Ok().payload).toEqual(fileContent.block);
     // customExpect(carGetResult.Ok(), (v) => expect(v).toEqual(testData), "carGetResult should match testData");
   });
 
   it("should delete data from CAR Gateway", async function () {
-    const carUrl = await carGateway.buildUrl(carStore.url(), fileContent.cid);
-    await carGateway.start(carStore.url());
-    await carGateway.put(carUrl.Ok(), {
+    const carUrl = await carGateway.buildUrl(sthis, carStore.url(), fileContent.cid);
+    await carGateway.start(sthis, carStore.url());
+    await carGateway.put(sthis, carUrl.Ok(), {
       type: bs.FPEnvelopeType.CAR,
       payload: fileContent.block,
     });
-    const carDeleteResult = await carGateway.delete(carUrl.Ok());
+    const carDeleteResult = await carGateway.delete(sthis, carUrl.Ok());
     expect(carDeleteResult.isOk()).toBeTruthy();
   });
 
   it("should close CAR Gateway", async function () {
-    await carGateway.close(carStore.url());
+    await carGateway.close(sthis, carStore.url());
   });
   it("should build Meta Gateway URL", async function () {
-    const metaUrl = await metaGateway.buildUrl(metaStore.url(), "main");
+    const metaUrl = await metaGateway.buildUrl(sthis, metaStore.url(), "main");
     expect(metaUrl.Ok()).toBeTruthy();
   });
 
   it("should start Meta Gateway", async function () {
-    await metaGateway.start(metaStore.url());
+    await metaGateway.start(sthis, metaStore.url());
   });
 
   it("should close Meta Gateway", async function () {
-    await metaGateway.start(metaStore.url());
-    await metaGateway.close(metaStore.url());
+    await metaGateway.start(sthis, metaStore.url());
+    await metaGateway.close(sthis, metaStore.url());
   });
 
   it("should build File Gateway URL", async function () {
-    const fileUrl = await fileGateway.buildUrl(fileStore.url(), fileContent.cid);
+    const fileUrl = await fileGateway.buildUrl(sthis, fileStore.url(), fileContent.cid);
     expect(fileUrl.Ok()).toBeTruthy();
   });
 
   it("should start File Gateway", async function () {
-    await fileGateway.start(fileStore.url());
+    await fileGateway.start(sthis, fileStore.url());
   });
 
   it("should put data to File Gateway", async function () {
-    const fileUrl = await fileGateway.buildUrl(fileStore.url(), fileContent.cid);
-    await fileGateway.start(fileStore.url());
-    const filePutResult = await fileGateway.put(fileUrl.Ok(), {
+    const fileUrl = await fileGateway.buildUrl(sthis, fileStore.url(), fileContent.cid);
+    await fileGateway.start(sthis, fileStore.url());
+    const filePutResult = await fileGateway.put(sthis, fileUrl.Ok(), {
       type: bs.FPEnvelopeType.FILE,
       payload: fileContent.block,
     });
@@ -191,48 +191,48 @@ describe("noop Gateway", function () {
   });
 
   it("should get data from File Gateway", async function () {
-    const fileUrl = await fileGateway.buildUrl(fileStore.url(), fileContent.cid);
-    await fileGateway.start(fileStore.url());
-    await fileGateway.put(fileUrl.Ok(), {
+    const fileUrl = await fileGateway.buildUrl(sthis, fileStore.url(), fileContent.cid);
+    await fileGateway.start(sthis, fileStore.url());
+    await fileGateway.put(sthis, fileUrl.Ok(), {
       type: bs.FPEnvelopeType.FILE,
       payload: fileContent.block,
     });
-    const fileGetResult = await fileGateway.get(fileUrl.Ok());
+    const fileGetResult = await fileGateway.get(sthis, fileUrl.Ok());
     expect(fileGetResult.Ok().type).toEqual("file");
     expect(fileGetResult.Ok().payload).toEqual(fileContent.block);
   });
 
   it("should delete data from File Gateway", async function () {
-    const fileUrl = await fileGateway.buildUrl(fileStore.url(), fileContent.cid);
-    await fileGateway.start(fileStore.url());
-    await fileGateway.put(fileUrl.Ok(), {
+    const fileUrl = await fileGateway.buildUrl(sthis, fileStore.url(), fileContent.cid);
+    await fileGateway.start(sthis, fileStore.url());
+    await fileGateway.put(sthis, fileUrl.Ok(), {
       type: bs.FPEnvelopeType.FILE,
       payload: fileContent.block,
     });
-    const fileDeleteResult = await fileGateway.delete(fileUrl.Ok());
+    const fileDeleteResult = await fileGateway.delete(sthis, fileUrl.Ok());
     expect(fileDeleteResult.isOk()).toBeTruthy();
   });
 
   it("should close File Gateway", async function () {
-    await fileGateway.close(fileStore.url());
+    await fileGateway.close(sthis, fileStore.url());
   });
   it("should build WAL Gateway URL", async function () {
     const testKey = "bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i";
-    const walUrl = await walGateway.buildUrl(walStore.url(), testKey);
+    const walUrl = await walGateway.buildUrl(sthis, walStore.url(), testKey);
     expect(walUrl.Ok()).toBeTruthy();
   });
 
   it("should start WAL Gateway", async function () {
-    await walGateway.start(walStore.url());
+    await walGateway.start(sthis, walStore.url());
   });
 
   it("should put data to WAL Gateway", async function () {
     const testKey = "bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i";
-    const walUrl = await walGateway.buildUrl(walStore.url(), testKey);
-    await walGateway.start(walStore.url());
+    const walUrl = await walGateway.buildUrl(sthis, walStore.url(), testKey);
+    await walGateway.start(sthis, walStore.url());
     // const walTestDataString = JSON.stringify();
     // const walTestData = sthis.txt.encode(walTestDataString);
-    const walPutResult = await walGateway.put(walUrl.Ok(), {
+    const walPutResult = await walGateway.put(sthis, walUrl.Ok(), {
       type: bs.FPEnvelopeType.WAL,
       payload: {
         operations: [],
@@ -245,8 +245,8 @@ describe("noop Gateway", function () {
 
   it("should get data from WAL Gateway", async function () {
     const testKey = "bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i";
-    const walUrl = await walGateway.buildUrl(walStore.url(), testKey);
-    await walGateway.start(walStore.url());
+    const walUrl = await walGateway.buildUrl(sthis, walStore.url(), testKey);
+    await walGateway.start(sthis, walStore.url());
     const ref: bs.WALState = {
       operations: [
         {
@@ -271,11 +271,11 @@ describe("noop Gateway", function () {
     //   fileOperations: [],
     // });
     // const walTestData = sthis.txt.encode(walTestDataString);
-    await walGateway.put(walUrl.Ok(), {
+    await walGateway.put(sthis, walUrl.Ok(), {
       type: bs.FPEnvelopeType.WAL,
       payload: ref,
     });
-    const walGetResult = await walGateway.get(walUrl.Ok());
+    const walGetResult = await walGateway.get(sthis, walUrl.Ok());
     expect(walGetResult.isOk()).toBeTruthy();
     // const okResult = walGetResult.Ok();
     // const decodedResult = sthis.txt.decode(okResult);
@@ -284,8 +284,8 @@ describe("noop Gateway", function () {
 
   it("should delete data from WAL Gateway", async function () {
     const testKey = "bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i";
-    const walUrl = await walGateway.buildUrl(walStore.url(), testKey);
-    await walGateway.start(walStore.url());
+    const walUrl = await walGateway.buildUrl(sthis, walStore.url(), testKey);
+    await walGateway.start(sthis, walStore.url());
     const ref: bs.WALState = {
       operations: [
         {
@@ -304,17 +304,17 @@ describe("noop Gateway", function () {
         },
       ],
     };
-    await walGateway.put(walUrl.Ok(), {
+    await walGateway.put(sthis, walUrl.Ok(), {
       type: bs.FPEnvelopeType.WAL,
       payload: ref,
     });
-    const walDeleteResult = await walGateway.delete(walUrl.Ok());
+    const walDeleteResult = await walGateway.delete(sthis, walUrl.Ok());
     expect(walDeleteResult.isOk()).toBeTruthy();
   });
 
   it("should close WAL Gateway", async function () {
-    await walGateway.start(walStore.url());
-    await walGateway.close(walStore.url());
+    await walGateway.start(sthis, walStore.url());
+    await walGateway.close(sthis, walStore.url());
   });
 
   // it("should have correct CAR Gateway properties", async function () {
@@ -367,7 +367,7 @@ describe("noop Gateway subscribe", function () {
 
   let metaStore: bs.MetaStore;
 
-  let metaGateway: bs.Gateway;
+  let metaGateway: bs.SerdeGateway;
   const sthis = ensureSuperThis();
 
   afterEach(async function () {
@@ -383,8 +383,8 @@ describe("noop Gateway subscribe", function () {
     metaGateway = metaStore.realGateway;
   });
   it("should subscribe to meta Gateway", async function () {
-    const metaUrl = await metaGateway.buildUrl(metaStore.url(), "main");
-    await metaGateway.start(metaStore.url());
+    const metaUrl = await metaGateway.buildUrl(sthis, metaStore.url(), "main");
+    await metaGateway.start(sthis, metaStore.url());
 
     let resolve: () => void;
     let didCall = false;
@@ -392,7 +392,7 @@ describe("noop Gateway subscribe", function () {
       resolve = r;
     });
     if (metaGateway.subscribe) {
-      const metaSubscribeResult = (await metaGateway.subscribe(metaUrl.Ok(), async (data: bs.FPEnvelopeMeta) => {
+      const metaSubscribeResult = (await metaGateway.subscribe(sthis, metaUrl.Ok(), async (data: bs.FPEnvelopeMeta) => {
         // const decodedData = sthis.txt.decode(data);
         expect(data.payload).toContain("[]");
         didCall = true;
@@ -415,7 +415,7 @@ describe("Gateway", function () {
   // let fileStore: ExtendedStore;
   // let walStore: ExtendedStore;
   // let carGateway: ExtendedGateway;
-  let metaGateway: bs.Gateway;
+  let metaGateway: bs.SerdeGateway;
   // let fileGateway: ExtendedGateway;
   // let walGateway: ExtendedGateway;
   const sthis = ensureSuperThis();
@@ -444,9 +444,9 @@ describe("Gateway", function () {
   });
 
   it("should get data from Meta Gateway", async function () {
-    const metaUrl = await metaGateway.buildUrl(metaStore.url(), "main");
-    await metaGateway.start(metaStore.url());
-    const metaGetResult = await metaGateway.get(metaUrl.Ok());
+    const metaUrl = await metaGateway.buildUrl(sthis, metaStore.url(), "main");
+    await metaGateway.start(sthis, metaStore.url());
+    const metaGetResult = await metaGateway.get(sthis, metaUrl.Ok());
     expect(metaGetResult.isOk()).toBeTruthy();
     const meta = metaGetResult.Ok().payload as bs.DbMetaEvent[];
     // const metaGetResultOk = metaGetResult.Ok();
@@ -456,10 +456,10 @@ describe("Gateway", function () {
   });
 
   it("should delete data from Meta Gateway", async function () {
-    const metaUrl = await metaGateway.buildUrl(metaStore.url(), "main");
-    await metaGateway.start(metaStore.url());
+    const metaUrl = await metaGateway.buildUrl(sthis, metaStore.url(), "main");
+    await metaGateway.start(sthis, metaStore.url());
     // should we be testing .destroy() instead?
-    const metaDeleteResult = await metaGateway.delete(metaUrl.Ok());
+    const metaDeleteResult = await metaGateway.delete(sthis, metaUrl.Ok());
     expect(metaDeleteResult.isOk()).toBeTruthy();
   });
 });


### PR DESCRIPTION
Now the Serialization push is compatible with the old Binary Gateway implementation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `SerdeGateway` interface for enhanced serialization and deserialization operations.
	- Added support for more flexible gateway handling with improved type safety.

- **Breaking Changes**
	- Replaced `Gateway` and `GatewayInterceptor` with `SerdeGateway` and `SerdeGatewayInterceptor`.
	- Updated method signatures across gateway implementations to include `sthis` parameter.
	- Modified data handling to work directly with `Uint8Array` instead of `FPEnvelope`.

- **Improvements**
	- Streamlined gateway method signatures.
	- Enhanced type consistency across blockstore and gateway implementations.
	- Simplified data serialization and deserialization processes.

- **Refactoring**
	- Restructured gateway-related interfaces and types.
	- Updated import statements and type definitions.
	- Removed deprecated code and simplified method implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->