### PR TITLE
rename ledger to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ What are the breaking changes in the 0.20 series?
   from passing Uint8Arrays and Url to passing a runtime Object which
   discribes the data on a semantic level. This give the gateway the
   ability to serialize and deserialize the data and enhance if needed.
-- We rename from Database to Ledger with no functional changes.
+- We rename from Database to Database with no functional changes.
 - a new memory implementation is replacing the memfs implementation.
   The prev use was to add to file:// the parameter fs=memfs now just use
-  memory:// works for Ledger as KeyBags.
+  memory:// works for Database as KeyBags.
 - The opts parameter of fireproof changed so that it's now possible
   to specify a every persitence like data/file/meta/wal or index-data/index-file/index-meta/index-wal a own URL. In the internals we also
   prevents the multiple instanciation of Gateways and Stores with results

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://fireproof.storage/static/img/flame.svg" alt="Fireproof logo" width="25"> [Fireproof](https://fireproof.storage) realtime ledger
+# <img src="https://fireproof.storage/static/img/flame.svg" alt="Fireproof logo" width="25"> [Fireproof](https://fireproof.storage) realtime database
 
 <p align="right">
   <img src="https://img.shields.io/bundlephobia/minzip/%40fireproof%2Fcore" alt="Package size">
@@ -9,11 +9,11 @@
 
 ### No setup: write features first, access your data anywhere
 
-Add collaboration to any app with Fireproof. Access data from JavaScript servers and edge functions. Use live queries to update your UI automatically when the ledger changes. [Connect realtime sync](https://www.npmjs.com/package/@fireproof/connect) and those changes will sync between browsers and backend functions. Apps built this way are multi-player by default.
+Add collaboration to any app with Fireproof. Access data from JavaScript servers and edge functions. Use live queries to update your UI automatically when the database changes. [Connect realtime sync](https://www.npmjs.com/package/@fireproof/connect) and those changes will sync between browsers and backend functions. Apps built this way are multi-player by default.
 
 ### JavaScript quick start
 
-The document ledger API will feel familiar. Queries use dynamic indexes, and the ledger can refresh your UI, as seen in the `db.subscribe` call below, as well as the React liveQuery hook.
+The document database API will feel familiar. Queries use dynamic indexes, and the database can refresh your UI, as seen in the `db.subscribe` call below, as well as the React liveQuery hook.
 
 ```js
 import { fireproof } from "@fireproof/core";
@@ -32,7 +32,7 @@ beyonceDoc.hitSingles += 1;
 await db.put(beyonceDoc);
 ```
 
-Jump to the docs site [for JavaScript API basics.](https://use-fireproof.com/docs/ledger-api/basics)
+Jump to the docs site [for JavaScript API basics.](https://use-fireproof.com/docs/database-api/basics)
 
 ### Live data hooks for React
 
@@ -50,7 +50,7 @@ Read the [step-by-step React tutorial](https://use-fireproof.com/docs/react-tuto
 
 ## Why choose Fireproof
 
-Compared to other embedded ledgers, Fireproof:
+Compared to other embedded databases, Fireproof:
 
 - is network aware, encrypted, and multi-writer safe
 - is designed for real-time collaboration with CRDTs
@@ -59,7 +59,7 @@ Compared to other embedded ledgers, Fireproof:
 
 Deliver interactive experiences without waiting on the backend. Fireproof runs in any cloud, browser, or edge environment, so your application can access data anywhere.
 
-[Get the latest roadmap updates on our blog](https://fireproof.storage/blog/) or join our [Discord](https://discord.gg/cCryrNHePH) to collaborate. Read the docs to learn more about the ledger [architecture](https://use-fireproof.com/docs/architecture).
+[Get the latest roadmap updates on our blog](https://fireproof.storage/blog/) or join our [Discord](https://discord.gg/cCryrNHePH) to collaborate. Read the docs to learn more about the database [architecture](https://use-fireproof.com/docs/architecture).
 
 ### Use cases
 
@@ -83,7 +83,7 @@ Get started with the React hooks:
 npm install use-fireproof
 ```
 
-or install the ledger in any JavaScript environment:
+or install the database in any JavaScript environment:
 
 ```sh
 npm install @fireproof/core
@@ -95,7 +95,7 @@ The default build is optimized for browsers, to load the node build add `/node`:
 import { fireproof } from "@fireproof/core/node";
 ```
 
-Add the ledger to any web page via HTML script tag (global is `Fireproof`):
+Add the database to any web page via HTML script tag (global is `Fireproof`):
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@fireproof/core/dist/browser/fireproof.global.js"></script>
@@ -165,7 +165,7 @@ pnpm run build:doc
 
 ## Thanks 🙏
 
-Fireproof is a synthesis of work done by people in the web community over the years. I couldn't even begin to name all the folks who made pivotal contributions. Without npm, React, and VS Code all this would have taken so much longer. Thanks to everyone who supported me getting into ledger development via Apache CouchDB, one of the original document ledgers. The distinguishing work on immutable data-structures comes from the years of consideration [IPFS](https://ipfs.tech), [IPLD](https://ipld.io), and the [Filecoin APIs](https://docs.filecoin.io) have enjoyed.
+Fireproof is a synthesis of work done by people in the web community over the years. I couldn't even begin to name all the folks who made pivotal contributions. Without npm, React, and VS Code all this would have taken so much longer. Thanks to everyone who supported me getting into database development via Apache CouchDB, one of the original document databases. The distinguishing work on immutable data-structures comes from the years of consideration [IPFS](https://ipfs.tech), [IPLD](https://ipld.io), and the [Filecoin APIs](https://docs.filecoin.io) have enjoyed.
 
 Thanks to Alan Shaw and Mikeal Rogers without whom this project would have never got started. The core Merkle hash-tree clock is based on [Alan's Pail](https://github.com/alanshaw/pail), and you can see the repository history goes all the way back to work begun as a branch of that repo. Mikeal wrote [the prolly trees implementation](https://github.com/mikeal/prolly-trees).
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -10,7 +10,7 @@ cp .git/config ./dist/fireproof-docs/.git/
   git rm -rf docs
 )
 mkdir -p dist/fireproof-docs/docs
-npx typedoc --out dist/fireproof-docs/docs  src/ledger.ts
+npx typedoc --out dist/fireproof-docs/docs  src/database.ts
 
 cd ./dist/fireproof-docs
 git add docs

--- a/examples/next-app/src/app/page.tsx
+++ b/examples/next-app/src/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Ledger, fireproof } from "@fireproof/core";
+import { Database, fireproof } from "@fireproof/core";
 import { connect } from "@fireproof/ucan";
 import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -12,7 +12,7 @@ interface AuthFormValues {
 
 export default function Home() {
   const [email, setEmail] = useLocalStorageState<string>("example-email");
-  const [db] = useState<Ledger>(fireproof("example"));
+  const [db] = useState<Database>(fireproof("example"));
   const [connection] = useState(connect.ucan(db, "example-sync"));
   const { register, handleSubmit } = useForm<AuthFormValues>();
   const { data: docs, mutate: mutateTestThings } = useSWR("test things", async () => db.query("test"), {

--- a/examples/playground/src/app.jsx
+++ b/examples/playground/src/app.jsx
@@ -8,14 +8,14 @@ import { Fireproof } from "use-fireproof";
 // import { useFireproof } from 'use-fireproof'
 // console.log(Fireproof, useFireproof)
 
-const ledger = Fireproof.storage("tomato-park");
+const database = Fireproof.storage("tomato-park");
 
-window.fireproof = ledger;
+window.fireproof = database;
 
 const App = () => {
   //   console.log('App')
-  //   const { ledger, useLiveQuery, useDocument } = useFireproof()
-  //   console.log('ledger', ledger)
+  //   const { database, useLiveQuery, useDocument } = useFireproof()
+  //   console.log('database', database)
 
   const [items, setItems] = useState([]);
 
@@ -23,13 +23,13 @@ const App = () => {
 
   useEffect(() => {
     const onChange = async () => {
-      const docs = await ledger.allDocuments();
+      const docs = await database.allDocuments();
       //   console.log('docs', docs)
       setItems(docs.rows);
     };
     onChange();
-    return ledger.subscribe(onChange);
-  }, [ledger]);
+    return database.subscribe(onChange);
+  }, [database]);
 
   //   const items = useLiveQuery('type', { key: 'todo' }).docs
   //   const [doc, setDoc, saveDoc] = useDocument({ message: 'new todo', type: 'todo' })
@@ -42,7 +42,7 @@ const App = () => {
         <button
           onClick={(e) => {
             e.preventDefault();
-            ledger.put({ message, type: "todo" });
+            database.put({ message, type: "todo" });
             setMessage("");
           }}
         >

--- a/examples/solid-js/src/databases.tsx
+++ b/examples/solid-js/src/databases.tsx
@@ -1,4 +1,4 @@
 import { createFireproof } from "@fireproof/solid-js";
 
-// You can have a global ledger that any component can import in Solid
+// You can have a global database that any component can import in Solid
 export const TodoListDB = createFireproof("TodoListDB");

--- a/examples/solid-js/src/pages/TodoList.tsx
+++ b/examples/solid-js/src/pages/TodoList.tsx
@@ -1,5 +1,5 @@
 import { For } from "solid-js";
-import { TodoListDB } from "../ledgers";
+import { TodoListDB } from "../databases";
 import { Todo } from "../types";
 
 export default function TodoList() {

--- a/examples/solid-js/src/pages/TodoListEditor.tsx
+++ b/examples/solid-js/src/pages/TodoListEditor.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createSignal, onCleanup } from "solid-js";
-import { TodoListDB } from "../ledgers";
+import { TodoListDB } from "../databases";
 import { Todo } from "../types";
 
 const [selectedTodo, setSelectedTodo] = createSignal("");

--- a/examples/todomvc/src/App.tsx
+++ b/examples/todomvc/src/App.tsx
@@ -70,17 +70,17 @@ declare global {
     fireproof: Fireproof;
   }
 }
-const defineIndexes = (ledger) => {
-  ledger.allLists = new Index(
-    ledger,
+const defineIndexes = (database) => {
+  database.allLists = new Index(
+    database,
     function (doc, map) {
       if (doc.type === "list") map(doc.type, doc);
     },
     null,
     { name: "allLists" },
   );
-  ledger.todosByList = new Index(
-    ledger,
+  database.todosByList = new Index(
+    database,
     function (doc, map) {
       if (doc.type === "todo" && doc.listId) {
         map([doc.listId, doc.createdAt], doc);
@@ -89,8 +89,8 @@ const defineIndexes = (ledger) => {
     null,
     { name: "todosByList" },
   );
-  window.fireproof = ledger;
-  return ledger;
+  window.fireproof = database;
+  return database;
 };
 
 /**
@@ -101,7 +101,7 @@ function App(): JSX.Element {
   console.log("render App");
   const fp = useFireproof("todomvc", defineIndexes, loadFixtures);
   const { fetchListWithTodos, fetchAllLists } = makeQueryFunctions(fp);
-  // const up = useUploader(fp.ledger) // is required to be in a KeyringProvider
+  // const up = useUploader(fp.database) // is required to be in a KeyringProvider
   const listLoader = async ({ params: { listId } }: LoaderFunctionArgs): Promise<ListLoaderData> =>
     await fetchListWithTodos(listId);
   const allListLoader = async ({ params }: LoaderFunctionArgs): Promise<ListDoc[]> => await fetchAllLists();

--- a/examples/todomvc/src/components/AllLists.tsx
+++ b/examples/todomvc/src/components/AllLists.tsx
@@ -41,8 +41,8 @@ const todoItems = ({ title, _id }: ListDoc, i: number) => {
  */
 export function AllLists(): JSX.Element {
   // first data stuff
-  const { ready, ledger, addSubscriber } = useContext(FireproofCtx) as FireproofCtxValue;
-  const { addList } = makeQueryFunctions({ ready, ledger });
+  const { ready, database, addSubscriber } = useContext(FireproofCtx) as FireproofCtxValue;
+  const { addList } = makeQueryFunctions({ ready, database });
 
   const revalidator = useRevalidator();
   addSubscriber("AllLists", () => {
@@ -64,7 +64,7 @@ export function AllLists(): JSX.Element {
       <div className="listNav">
         <button
           onClick={async () => {
-            console.log("await ledger.changesSince()", await ledger.changesSince());
+            console.log("await database.changesSince()", await database.changesSince());
           }}
         >
           Choose a list.
@@ -74,7 +74,7 @@ export function AllLists(): JSX.Element {
       <ul className="todo-list">{lists.map(todoItems)}</ul>
       <InputArea onSubmit={addList} placeholder="Create a new list or choose one" />
       <div className="dbInfo">
-        <TimeTravel ledger={ledger} />
+        <TimeTravel database={database} />
         {/* <UploadManager registered={registered} /> */}
       </div>
     </div>

--- a/examples/todomvc/src/components/List.tsx
+++ b/examples/todomvc/src/components/List.tsx
@@ -16,15 +16,15 @@ const sleep = async (t: number) => new Promise((resolve) => setTimeout(resolve, 
 
 export function List(): JSX.Element {
   // first data stuff
-  const { ledger } = useFireproof();
+  const { database } = useFireproof();
   const { addTodo, toggle, destroy, clearCompleted, updateTitle } = makeQueryFunctions({
     ready: true,
-    ledger,
+    database,
   });
   const { list, todos } = useLoaderData() as ListLoaderData;
   const [editing, setEditing] = useState("");
   const revalidator = useRevalidator();
-  ledger.subscribe(async () => {
+  database.subscribe(async () => {
     revalidator.revalidate();
   });
 
@@ -80,7 +80,7 @@ export function List(): JSX.Element {
         nowShowing={nowShowing}
       />
       <div className="dbInfo">
-        <TimeTravel ledger={ledger} />
+        <TimeTravel database={database} />
         {/* <UploadManager registered={registered} /> */}
       </div>
     </div>

--- a/examples/todomvc/src/components/TimeTravel.tsx
+++ b/examples/todomvc/src/components/TimeTravel.tsx
@@ -1,8 +1,8 @@
 const shortLink = (l: string) => `${String(l).slice(0, 4)}..${String(l).slice(-4)}`;
 const clockLog = new Set<string>();
 
-export const TimeTravel = ({ ledger }) => {
-  ledger.clock && ledger.clock.length && clockLog.add(ledger.clock.toString());
+export const TimeTravel = ({ database }) => {
+  database.clock && database.clock.length && clockLog.add(database.clock.toString());
   const diplayClocklog = Array.from(clockLog).reverse();
   return (
     <div className="timeTravel">
@@ -11,7 +11,7 @@ export const TimeTravel = ({ ledger }) => {
       {/* <InputArea
             onSubmit={
               async (tex: string) => {
-                await ledger.setClock(tex.split(','))
+                await database.setClock(tex.split(','))
               }
             }
             placeholder='Copy a CID from below to rollback in time.'
@@ -26,7 +26,7 @@ export const TimeTravel = ({ ledger }) => {
           <li key={entry}>
             <button
               onClick={async () => {
-                // await Fireproof.zoom(ledger, [entry])
+                // await Fireproof.zoom(database, [entry])
                 console.log("todo zoom", entry);
               }}
             >

--- a/examples/todomvc/src/hooks/useUploader.tsx
+++ b/examples/todomvc/src/hooks/useUploader.tsx
@@ -23,7 +23,7 @@ async function fetchWithRetries(url: string, retries: number): Promise<Response>
   throw new Error(`Failed to fetch ${url} after ${retries} retries`);
 }
 
-export function useUploader(ledger: Fireproof) {
+export function useUploader(database: Fireproof) {
   const [{ agent, space }, { getProofs, loadAgent }] = useKeyring();
   const registered = Boolean(space?.registered());
   const [uploaderReady, setUploaderReady] = useState(false);
@@ -31,7 +31,7 @@ export function useUploader(ledger: Fireproof) {
 
   useEffect(() => {
     if (!remoteBlockReaderReady) {
-      ledger.setRemoteBlockReader(async (cid: any) => {
+      database.setRemoteBlockReader(async (cid: any) => {
         const response = await fetchWithRetries(`https://${cid}.ipfs.w3s.link/`, 2);
         const buffer = await response.arrayBuffer();
         return new Uint8Array(buffer);
@@ -48,7 +48,7 @@ export function useUploader(ledger: Fireproof) {
         with: delegz.with,
         proofs: await getProofs([delegz]),
       };
-      ledger.setCarUploader(async (carCid: any, carBytes: Uint8Array) => {
+      database.setCarUploader(async (carCid: any, carBytes: Uint8Array) => {
         await uploadCarBytes(conf, carCid, carBytes);
       });
       setUploaderReady(true);

--- a/examples/todomvc/src/loadFixtures.tsx
+++ b/examples/todomvc/src/loadFixtures.tsx
@@ -8,7 +8,7 @@ function mulberry32(a: number) {
 }
 const rand = mulberry32(1); // determinstic fixtures
 
-export default async function loadFixtures(ledger: {
+export default async function loadFixtures(database: {
   put: (arg0: any) => any;
   allLists: { query: (opts) => Promise<any> };
   todosByList: { query: (opts) => Promise<any> };
@@ -29,9 +29,9 @@ export default async function loadFixtures(ledger: {
   ];
   let ok: { id: any };
   for (let j = 0; j < 3; j++) {
-    ok = await ledger.put({ title: listTitles[j], type: "list", _id: nextId("" + j) });
+    ok = await database.put({ title: listTitles[j], type: "list", _id: nextId("" + j) });
     for (let i = 0; i < todoTitles[j].length; i++) {
-      await ledger.put({
+      await database.put({
         _id: nextId(),
         title: todoTitles[j][i],
         listId: ok.id,
@@ -41,5 +41,5 @@ export default async function loadFixtures(ledger: {
       });
     }
   }
-  await ledger.allLists.query({ range: [0, 1] });
+  await database.allLists.query({ range: [0, 1] });
 }

--- a/package-fireproof-core.json
+++ b/package-fireproof-core.json
@@ -1,7 +1,7 @@
 {
   "name": "@fireproof/core",
   "version": "must-set",
-  "description": "Live ledger for the web.",
+  "description": "Live database for the web.",
   "type": "module",
   "module": "./index.js",
   "main": "./index.cjs",
@@ -45,7 +45,7 @@
     }
   },
   "scripts": {},
-  "keywords": ["ledger", "JSON", "document", "IPLD", "CID", "IPFS"],
+  "keywords": ["database", "JSON", "document", "IPLD", "CID", "IPFS"],
   "contributors": ["J Chris Anderson", "Alan Shaw", "Travis Vachon", "Mikeal Rogers", "Meno Abels"],
   "author": "J Chris Anderson",
   "license": "Apache-2.0 OR MIT",

--- a/package-use-fireproof.json
+++ b/package-use-fireproof.json
@@ -1,7 +1,7 @@
 {
   "name": "use-fireproof",
   "version": "must-set",
-  "description": "Fireproof live ledger, JavaScript API and React hooks",
+  "description": "Fireproof live database, JavaScript API and React hooks",
   "type": "module",
   "module": "./index.js",
   "main": "./index.cjs",
@@ -26,7 +26,7 @@
   "scripts": {},
   "author": "J Chris Anderson",
   "license": "Apache-2.0 OR MIT",
-  "gptdoc": "Fireproof/React/Usage: import { useLiveQuery, useDocument } from 'use-fireproof'; function App() { const result = useLiveQuery(doc => doc.word, { limit: 10 }); const [{ count }, setDoc, saveDoc] = useDocument({_id: 'count', count: 0}); return (<><p>{count} changes</p><input type='text' onChange={() => saveDoc({count: count + 1})} onSubmit={e => useLiveQuery.ledger.put({word: e.target.value})} /><ul>{result.map(row => (<li key={row.id}>{row.key}</li>))}</ul></>)}",
+  "gptdoc": "Fireproof/React/Usage: import { useLiveQuery, useDocument } from 'use-fireproof'; function App() { const result = useLiveQuery(doc => doc.word, { limit: 10 }); const [{ count }, setDoc, saveDoc] = useDocument({_id: 'count', count: 0}); return (<><p>{count} changes</p><input type='text' onChange={() => saveDoc({count: count + 1})} onSubmit={e => useLiveQuery.database.put({word: e.target.value})} /><ul>{result.map(row => (<li key={row.id}>{row.key}</li>))}</ul></>)}",
   "dependencies": {
     "react": "from-package-json",
     "@fireproof/core": "from-package-json"
@@ -36,5 +36,5 @@
     "@fireproof/core": "from-package-json"
   },
   "devDependencies": {},
-  "keywords": ["react", "ledger", "json", "live", "sync"]
+  "keywords": ["react", "database", "json", "live", "sync"]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fireproof/monorepo",
   "version": "0.0.0-dev",
   "private": true,
-  "description": "Live ledger for the web",
+  "description": "Live database for the web",
   "type": "module",
   "scripts": {
     "prepublish": "pnpm run build",
@@ -32,7 +32,7 @@
     "lint": "eslint"
   },
   "keywords": [
-    "ledger",
+    "database",
     "database",
     "JSON",
     "immutable",

--- a/scripts/fireproof/browser-test.js
+++ b/scripts/fireproof/browser-test.js
@@ -23,7 +23,7 @@ void (async () => {
 
   await page.goto(url);
 
-  // Wait for some time to ensure the ledger operation is complete
+  // Wait for some time to ensure the database operation is complete
   // await page.waitForTimeout(1000)
 
   // Click the button to run onButtonClick

--- a/scripts/fireproof/types.js
+++ b/scripts/fireproof/types.js
@@ -4,7 +4,7 @@ import path from "path";
 
 // Get the entry points from your build settings
 
-// const entryPoints = ['ledger', 'index', 'types']// createBuildSettings({}).map(config => path.basename(config.entryPoints[0], '.ts'))
+// const entryPoints = ['database', 'index', 'types']// createBuildSettings({}).map(config => path.basename(config.entryPoints[0], '.ts'))
 
 function generateIndexFile() {
   const typesDir = path.resolve("dist/types");

--- a/scripts/react/package.json
+++ b/scripts/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-fireproof",
   "version": "0.18.0",
-  "description": "Fireproof live ledger, JavaScript API and React hooks",
+  "description": "Fireproof live database, JavaScript API and React hooks",
   "type": "module",
   "module": "dist/index.js",
   "main": "dist/index.js",
@@ -43,7 +43,7 @@
   },
   "author": "J Chris Anderson",
   "license": "Apache-2.0 OR MIT",
-  "gptdoc": "Fireproof/React/Usage: import { useLiveQuery, useDocument } from 'use-fireproof'; function App() { const result = useLiveQuery(doc => doc.word, { limit: 10 }); const [{ count }, setDoc, saveDoc] = useDocument({_id: 'count', count: 0}); return (<><p>{count} changes</p><input type='text' onChange={() => saveDoc({count: count + 1})} onSubmit={e => useLiveQuery.ledger.put({word: e.target.value})} /><ul>{result.map(row => (<li key={row.id}>{row.key}</li>))}</ul></>)}",
+  "gptdoc": "Fireproof/React/Usage: import { useLiveQuery, useDocument } from 'use-fireproof'; function App() { const result = useLiveQuery(doc => doc.word, { limit: 10 }); const [{ count }, setDoc, saveDoc] = useDocument({_id: 'count', count: 0}); return (<><p>{count} changes</p><input type='text' onChange={() => saveDoc({count: count + 1})} onSubmit={e => useLiveQuery.database.put({word: e.target.value})} /><ul>{result.map(row => (<li key={row.id}>{row.key}</li>))}</ul></>)}",
   "dependencies": {
     "@fireproof/core": "workspace:^"
   },
@@ -70,7 +70,7 @@
   },
   "keywords": [
     "react",
-    "ledger",
+    "database",
     "json",
     "live",
     "sync"

--- a/scripts/react/src/useDocument.tsx
+++ b/scripts/react/src/useDocument.tsx
@@ -1,15 +1,15 @@
-import { Ledger, Doc, DocRecord } from "@fireproof/core";
+import { Database, Doc, DocRecord } from "@fireproof/core";
 
 import { UseDocument, UseDocumentResult, useFireproof } from "./useFireproof";
 
 export interface TLUseDocument {
   <T extends DocTypes>(initialDoc: Doc<T>): UseDocumentResult<T>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseDocument(...args: Parameters<UseDocument>) {
-  const { useDocument, ledger } = useFireproof();
-  (topLevelUseDocument as TLUseDocument).ledger = ledger;
+  const { useDocument, database } = useFireproof();
+  (topLevelUseDocument as TLUseDocument).database = database;
   return useDocument(...args);
 }
 
@@ -17,9 +17,9 @@ function topLevelUseDocument(...args: Parameters<UseDocument>) {
  * ## Summary
  *
  * React hook that provides the ability to create new Fireproof documents. The creation occurs when
- * you do not pass in an `_id` as part of your initial document -- the ledger will assign a new one when
- * you call the provided `save` handler This uses the default ledger named `useFireproof` under the hood which you can also
- * access via the `ledger` accessor.
+ * you do not pass in an `_id` as part of your initial document -- the database will assign a new one when
+ * you call the provided `save` handler This uses the default database named `useFireproof` under the hood which you can also
+ * access via the `database` accessor.
  *
  * ## Usage
  *
@@ -37,7 +37,7 @@ function topLevelUseDocument(...args: Parameters<UseDocument>) {
  *   startedAt: Date.now()
  * }))
  *
- * const ledger = useDocument.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useDocument.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/scripts/react/src/useLiveQuery.tsx
+++ b/scripts/react/src/useLiveQuery.tsx
@@ -1,29 +1,29 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { Ledger, DocRecord } from "@fireproof/core";
+import { Database, DocRecord } from "@fireproof/core";
 
 import { LiveQueryResult, useFireproof, UseLiveQuery } from "./useFireproof";
 
 export interface TLUseLiveQuery {
   <T extends DocTypes>(...args: Parameters<UseLiveQuery>): LiveQueryResult<T>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseLiveQuery(...args: Parameters<UseLiveQuery>) {
-  const { useLiveQuery, ledger } = useFireproof();
-  (topLevelUseLiveQuery as TLUseLiveQuery).ledger = ledger;
+  const { useLiveQuery, database } = useFireproof();
+  (topLevelUseLiveQuery as TLUseLiveQuery).database = database;
   return useLiveQuery(...args);
 }
 
 /**
  * ## Summary
  * React hook that provides access to live query results, enabling real-time updates in your app. This uses
- * the default ledger named "useFireproof" under the hood which you can also access via the `ledger` accessor.
+ * the default database named "useFireproof" under the hood which you can also access via the `database` accessor.
  *
  * ## Usage
  * ```tsx
  * const results = useLiveQuery("date"); // using string
  * const results = useLiveQuery((doc) => doc.date)); // using map function
- * const ledger = useLiveQuery.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useLiveQuery.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/scripts/solid-js/README.md
+++ b/scripts/solid-js/README.md
@@ -6,9 +6,9 @@
   </a>
 </p>
 
-Simplify your SolidJS application state with a live ledger. Automatically update your UI based on local or remote changes, and optionally integrate with any cloud for replication and sharing.
+Simplify your SolidJS application state with a live database. Automatically update your UI based on local or remote changes, and optionally integrate with any cloud for replication and sharing.
 
-Fireproof is an embedded JavaScript document ledger designed to streamline app development. Data resides locally, with optional encrypted cloud storage and real-time sync and collaboration. Features like live queries, ledger branches and snapshots, and file attachments make Fireproof ideal for browser-based apps big or small.
+Fireproof is an embedded JavaScript document database designed to streamline app development. Data resides locally, with optional encrypted cloud storage and real-time sync and collaboration. Features like live queries, database branches and snapshots, and file attachments make Fireproof ideal for browser-based apps big or small.
 
 Fireproof works in the browser, server, edge function, and any other JavaScript environment, with [connectors for popular backend services like AWS, Netlify, and PartyKit.]()
 
@@ -36,12 +36,12 @@ import { createFireproof } from "@fireproof/solid-js";
 
 type Todo = { text: string; date: number; completed: boolean };
 
-// You can have a global ledger that any Solid component can import
+// You can have a global database that any Solid component can import
 const TodoListDB = createFireproof('TodoListDB');
 
 /*
  Or you can destructure the hook
- const { ledger, createDocument, createLiveQuery } = createFireproof('TodoListDB');
+ const { database, createDocument, createLiveQuery } = createFireproof('TodoListDB');
 */
 
 export default function TodoList() {
@@ -64,22 +64,22 @@ The primary export of the `@fireproof/solid-js` package is the `createFireproof`
 function createFireproof(dbName?: string, config?: ConfigOpts): CreateFireproof;
 ```
 
-Using the hook without specifying a name for the ledger will default the name to `FireproofDB` under the hood. Aside from receiving an accessor to the ledger, you will also receive two supporting SolidJS hooks `createDocument` and `createLiveQuery` which act against said ledger.
+Using the hook without specifying a name for the database will default the name to `FireproofDB` under the hood. Aside from receiving an accessor to the database, you will also receive two supporting SolidJS hooks `createDocument` and `createLiveQuery` which act against said database.
 
 ```ts
 // non-destructured vs destructured
 const FireproofDB = createFireproof();
-const { createDocument, createLiveQuery, ledger } = createFireproof();
+const { createDocument, createLiveQuery, database } = createFireproof();
 
 const AwesomeDB = createFireproof("AwesomeDB");
-const { createDocument, createLiveQuery, ledger } = createFireproof("AwesomeDB");
+const { createDocument, createLiveQuery, database } = createFireproof("AwesomeDB");
 ```
 
-We will go over the optional `config` parameter for `createFireproof` later to talk further about `createDocument`, `createLiveQuery` and the `ledger`.
+We will go over the optional `config` parameter for `createFireproof` later to talk further about `createDocument`, `createLiveQuery` and the `database`.
 
 ### createDocument
 
-Create (or modify) a document in your Fireproof ledger.
+Create (or modify) a document in your Fireproof database.
 
 ```ts
 // API Signature
@@ -102,7 +102,7 @@ The `createDocument` API will return to you a tuple containing three things:
 
 - the document getter
 - the document setter
-- save/write function to ledger
+- save/write function to database
 
 As you can see, the hook supports TypeScript generics, so all the functions you receive in the tuple will be type-scoped to the custom type you injected as part of the invocation.
 
@@ -138,7 +138,7 @@ console.log(todo());
 setTodo({ text: "anotherTodo", count: 2, completed: false }, { replace: true });
 ```
 
-The last function from the tuple is the save/write to ledger function. It has the following signature:
+The last function from the tuple is the save/write to database function. It has the following signature:
 
 ```ts
 type StoreDocFn<T extends DocTypes> = (existingDoc?: Doc<T>) => Promise<DocResponse>;
@@ -146,13 +146,13 @@ type StoreDocFn<T extends DocTypes> = (existingDoc?: Doc<T>) => Promise<DocRespo
 
 This function has two modes of use:
 
-- Save/update the current document to the ledger
-- Save/update an _existing_ document in the ledger
+- Save/update the current document to the database
+- Save/update an _existing_ document in the database
 
 The first mode is executed by simply invoking the function like so:
 
 ```ts
-await saveTodo(); // save/write the current document state to the ledger
+await saveTodo(); // save/write the current document state to the database
 ```
 
 The second mode can only be exercised via complementing `createDocument` with the results from the second support hook `createLiveQuery` which we can now segue into.
@@ -182,50 +182,50 @@ const result = createLiveQuery("date"); // find docs with a 'date' field
 const result = createLiveQuery<Todo>("date", { limit: 10, descending: true }); // key + options + generics
 ```
 
-The `createLiveQuery` hook is responsibile for subscribing for document updates against the ledger. If any changes have been made, then the query results will be updated triggering a re-render of contents on your web application.
+The `createLiveQuery` hook is responsibile for subscribing for document updates against the database. If any changes have been made, then the query results will be updated triggering a re-render of contents on your web application.
 
 You can specify your function as a string and Fireproof will interpret it as indexing that field on all documents. You can also pass a function for more control:
 
 The same mechanism that powers the built-in indexes can all be used to connect secondary [vector indexers](https://github.com/tantaraio/voy) or fulltext indexes to Fireproof. [Follow this tutorial to connect a secondary index](https://fireproof.storage/documentation/external-indexers/).
 
-### ledger
+### database
 
-The last thing you receive from `createFireproof` is the accessor to the underlying Fireproof ledger. We provide this getter as something of an "escape hatch" if you find that you are unable to achieve some outcome you are looking for due to some limitations in the `createDocument` and `createLiveQuery` hook interfaces.
+The last thing you receive from `createFireproof` is the accessor to the underlying Fireproof database. We provide this getter as something of an "escape hatch" if you find that you are unable to achieve some outcome you are looking for due to some limitations in the `createDocument` and `createLiveQuery` hook interfaces.
 
 ```ts
-const { id } = await ledger().put({
+const { id } = await database().put({
     _id: 'three-thousand'
     name: 'André',
     age: 47
 });
 
-const doc = await ledger().get('three-thousand')
+const doc = await database().get('three-thousand')
 // {
 //    _id  : 'three-thousand'
 //    name : 'André',
 //    age  : 47
 // }
 
-const result = await ledger().query("age", { range: [40, 52] })
+const result = await database().query("age", { range: [40, 52] })
 ```
 
-Jump to the docs site [for JavaScript API basics.](https://use-fireproof.com/docs/ledger-api/basics) You can [find a real-world JavaScript app here.](https://github.com/mlc-ai/web-stable-diffusion/pull/52)
+Jump to the docs site [for JavaScript API basics.](https://use-fireproof.com/docs/database-api/basics) You can [find a real-world JavaScript app here.](https://github.com/mlc-ai/web-stable-diffusion/pull/52)
 
-## Ledger Features
+## Database Features
 
-The core features of the ledger are available on any platform in a compact JavaScript package and a foundational cloud storage service.
+The core features of the database are available on any platform in a compact JavaScript package and a foundational cloud storage service.
 
-- **JSON Documents** - Encrypted changes are persisted locally and to any connected storage. Store any JSON object using a familiar document ledger API.
-- **File Attachments** - Share social media or manage uploads within Fireproof's [file attachment API](https://use-fireproof.com/docs/ledger-api/documents#put-with-files). Attachments are stored locally and in the cloud, and can be encrypted or public.
-- **Live Query** - Sort and filter any ledger with CouchDB-style `map` functions. The `createFireproof` Solid hook integrates so cleanly your code doesn't even have to import `createSignal` or `createEffect`, instead, [`createLiveQuery`](https://use-fireproof.com/docs/react-hooks/use-live-query) makes dynamic renders easy.
-- **Realtime Updates** - [Subscribe to query changes in your application](https://use-fireproof.com/docs/ledger-api/ledger#subscribing-to-changes), so your UI updates automatically. This makes vanilla JS apps super easy to build -- the `createFireproof` Solid hook handles this so you won't need `db.subscribe()` there.
+- **JSON Documents** - Encrypted changes are persisted locally and to any connected storage. Store any JSON object using a familiar document database API.
+- **File Attachments** - Share social media or manage uploads within Fireproof's [file attachment API](https://use-fireproof.com/docs/database-api/documents#put-with-files). Attachments are stored locally and in the cloud, and can be encrypted or public.
+- **Live Query** - Sort and filter any database with CouchDB-style `map` functions. The `createFireproof` Solid hook integrates so cleanly your code doesn't even have to import `createSignal` or `createEffect`, instead, [`createLiveQuery`](https://use-fireproof.com/docs/react-hooks/use-live-query) makes dynamic renders easy.
+- **Realtime Updates** - [Subscribe to query changes in your application](https://use-fireproof.com/docs/database-api/database#subscribing-to-changes), so your UI updates automatically. This makes vanilla JS apps super easy to build -- the `createFireproof` Solid hook handles this so you won't need `db.subscribe()` there.
 - **Cryptographic Proofs** - Fireproof's Merkle clocks and hash trees are immutable and self-validating, making all query results into offline-capable data slices. Fireproof makes cryptographic proofs available for all of its operations, accelerating replication and making trustless index sharing possible. This makes it a great choice for building custom document approval workflows or other situations where provenance is important.
 
 Learn more about the [architecture](https://use-fireproof.com/docs/architecture) behind Fireproof.
 
 ### Cryptographic Proofs
 
-Fireproof's Merkle clocks and hash trees are immutable and self-validating, and all query results are offline-capable data slices. Fireproof makes cryptographic proofs available for all of its operations, accelerating replication and making trustless index sharing possible. If you are making a "DocuSign for **\_**", [proofs make Fireproof the ideal verifiable document ledger](https://fireproof.storage/posts/from-mlops-to-point-of-sale:-merkle-proofs-and-data-locality/) for smart contracts and other applications where unique, verifiable, and trustworthy data is required. [Proof chains provide performance benefits as well](https://purrfect-tracker-45c.notion.site/Data-Routing-23c37b269b4c4c3dacb60d0077113bcb), by allowing recipients to skip costly I/O operations and instead cryptographically verify that changes contain all of the required context.
+Fireproof's Merkle clocks and hash trees are immutable and self-validating, and all query results are offline-capable data slices. Fireproof makes cryptographic proofs available for all of its operations, accelerating replication and making trustless index sharing possible. If you are making a "DocuSign for **\_**", [proofs make Fireproof the ideal verifiable document database](https://fireproof.storage/posts/from-mlops-to-point-of-sale:-merkle-proofs-and-data-locality/) for smart contracts and other applications where unique, verifiable, and trustworthy data is required. [Proof chains provide performance benefits as well](https://purrfect-tracker-45c.notion.site/Data-Routing-23c37b269b4c4c3dacb60d0077113bcb), by allowing recipients to skip costly I/O operations and instead cryptographically verify that changes contain all of the required context.
 
 ## Use Cases
 
@@ -237,7 +237,7 @@ The six-month roadmap for Fireproof includes these features to make it a complet
 
 ### Automatic Replication
 
-Documents changes are persisted to [Filecoin](https://filecoin.io) via [web3.storage](https://web3.storage), and made available over IPFS and on a global content delivery network. All you need to do to sync state is send a link to the latest ledger head, and Fireproof will take care of the rest.
+Documents changes are persisted to [Filecoin](https://filecoin.io) via [web3.storage](https://web3.storage), and made available over IPFS and on a global content delivery network. All you need to do to sync state is send a link to the latest database head, and Fireproof will take care of the rest.
 
 ### Peer-to-peer Sync
 
@@ -245,11 +245,11 @@ Application instances can be connected using WebRTC or any other stream API libr
 
 ### Self-sovereign Identity
 
-Fireproof is so easy to integrate with any site or app because you can get started right away, and set up an account later. By default users write to their own ledger copy, so you can get pretty far before you even have to think about API keys. [Authorization is via non-extractable keypair](https://ucan.xyz), like TouchID / FaceID.
+Fireproof is so easy to integrate with any site or app because you can get started right away, and set up an account later. By default users write to their own database copy, so you can get pretty far before you even have to think about API keys. [Authorization is via non-extractable keypair](https://ucan.xyz), like TouchID / FaceID.
 
 ## Thanks 🙏
 
-Fireproof is a synthesis of work done by people in the web community over the years. I couldn't even begin to name all the folks who made pivotal contributions. Without npm, React, and VS Code all this would have taken so much longer. Thanks to everyone who supported me getting into ledger development via Apache CouchDB, one of the original document ledgers. The distinguishing work on immutable data-structures comes from the years of consideration [IPFS](https://ipfs.tech), [IPLD](https://ipld.io), and the [Filecoin APIs](https://docs.filecoin.io) have enjoyed.
+Fireproof is a synthesis of work done by people in the web community over the years. I couldn't even begin to name all the folks who made pivotal contributions. Without npm, React, and VS Code all this would have taken so much longer. Thanks to everyone who supported me getting into database development via Apache CouchDB, one of the original document databases. The distinguishing work on immutable data-structures comes from the years of consideration [IPFS](https://ipfs.tech), [IPLD](https://ipld.io), and the [Filecoin APIs](https://docs.filecoin.io) have enjoyed.
 
 Thanks to Alan Shaw and Mikeal Rogers without whom this project would have never got started. The core Merkle hash-tree clock is based on [Alan's Pail](https://github.com/alanshaw/pail), and you can see the repository history goes all the way back to work begun as a branch of that repo. Mikeal wrote [the prolly trees implementation](https://github.com/mikeal/prolly-trees).
 

--- a/scripts/solid-js/package.json
+++ b/scripts/solid-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fireproof/solid-js",
   "version": "0.18.0",
-  "description": "The official SolidJS adapter for Fireproof. Light up your data with an embedded live ledger for your SolidJS web app.",
+  "description": "The official SolidJS adapter for Fireproof. Light up your data with an embedded live database for your SolidJS web app.",
   "type": "module",
   "module": "./dist/server.js",
   "main": "./dist/server.js",
@@ -97,7 +97,7 @@
   },
   "keywords": [
     "solid",
-    "ledger",
+    "database",
     "json",
     "live",
     "sync"

--- a/scripts/solid-js/src/createFireproof.tsx
+++ b/scripts/solid-js/src/createFireproof.tsx
@@ -1,5 +1,5 @@
 import type { ConfigOpts, DocResponse, Doc, DocRecord, IndexRow, MapFn, QueryOpts } from "@fireproof/core";
-import { Ledger, fireproof } from "@fireproof/core";
+import { Database, fireproof } from "@fireproof/core";
 import { deepmerge } from "deepmerge-ts";
 import { Accessor, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
@@ -27,13 +27,13 @@ export type CreateDocumentResult<T extends DocTypes> = [Accessor<Doc<T>>, Update
 export type CreateDocument = <T extends DocTypes>(initialDocFn: Accessor<Doc<T>>) => CreateDocumentResult<T>;
 
 export interface CreateFireproof {
-  /** The Fireproof ledger */
-  readonly ledger: Accessor<Ledger>;
+  /** The Fireproof database */
+  readonly database: Accessor<Database>;
   /**
    * ## Summary
    *
-   * Creates a new Fireproof document into your custom-named Fireproof ledger. The creation occurs when you do not
-   * pass in an `_id` as part of your initial document -- the ledger will assign a new one when you call the provided
+   * Creates a new Fireproof document into your custom-named Fireproof database. The creation occurs when you do not
+   * pass in an `_id` as part of your initial document -- the database will assign a new one when you call the provided
    * `save` handler. The hook also provides generics support so you can inline your custom type into the invocation to
    * receive type-safety and auto-complete support in your IDE.
    *
@@ -85,27 +85,27 @@ export interface CreateFireproof {
  *
  * ## Summary
  *
- * Create a Fireproof ledger and the utility hooks to work against it. If no name is
+ * Create a Fireproof database and the utility hooks to work against it. If no name is
  * provided, then it will default to `FireproofDB`.
  *
  * ## Usage
  * ```tsx
- * const { ledger, createLiveQuery, createDocument } = createFireproof();
- * const { ledger, createLiveQuery, createDocument } = createFireproof("AwesomeDB");
- * const { ledger, createLiveQuery, createDocument } = createFireproof("AwesomeDB", { ...options });
+ * const { database, createLiveQuery, createDocument } = createFireproof();
+ * const { database, createLiveQuery, createDocument } = createFireproof("AwesomeDB");
+ * const { database, createLiveQuery, createDocument } = createFireproof("AwesomeDB", { ...options });
  *
- * // As global ledgers -- can put these in a file and import them where you need them
+ * // As global databases -- can put these in a file and import them where you need them
  * export const FireproofDB = createFireproof();
  * export const AwesomeDB = createFireproof("AwesomeDB");
  * ```
  *
  */
 export function createFireproof(dbName?: string, config: ConfigOpts = {}): CreateFireproof {
-  // The ledger connection is cached, so subsequent calls to fireproof with the same name will
-  // return the same ledger object. This makes it safe to invoke the getter function many times
+  // The database connection is cached, so subsequent calls to fireproof with the same name will
+  // return the same database object. This makes it safe to invoke the getter function many times
   // without needing to wrap it with createMemo. An added perk of not needing createMemo is this
   // allows use of this hook at the global scope without needing to wrap it with createRoot from SolidJS.
-  const ledger = () => fireproof(dbName || "FireproofDB", config);
+  const database = () => fireproof(dbName || "FireproofDB", config);
 
   function createDocument<T extends DocTypes>(initialDocFn: Accessor<Doc<T>>): CreateDocumentResult<T> {
     const [doc, setDoc] = createSignal(initialDocFn());
@@ -122,14 +122,14 @@ export function createFireproof(dbName?: string, config: ConfigOpts = {}): Creat
     };
 
     const saveDoc: StoreDocFn<T> = async (existingDoc) => {
-      const response = await ledger().put(existingDoc ?? doc());
+      const response = await database().put(existingDoc ?? doc());
       if (!existingDoc && !doc()._id) setDoc((d) => ({ ...d, _id: response.id }));
       return response;
     };
 
-    const refreshDoc = async (db: Ledger, docId = "") => {
+    const refreshDoc = async (db: Database, docId = "") => {
       // TODO: Add option for MVCC (Multi-version concurrency control) checks
-      // https://use-fireproof.com/docs/ledger-api/documents/#multi-version-concurrency-control-mvcc-available-in-alpha-coming-soon-in-beta
+      // https://use-fireproof.com/docs/database-api/documents/#multi-version-concurrency-control-mvcc-available-in-alpha-coming-soon-in-beta
       const storedDoc = await db.get<T>(docId).catch(initialDocFn);
       setDoc(() => storedDoc);
     };
@@ -138,7 +138,7 @@ export function createFireproof(dbName?: string, config: ConfigOpts = {}): Creat
       const subscriptionId = docId();
       if (!subscriptionId) return;
 
-      const db = ledger();
+      const db = database();
 
       const unsubscribe = db.subscribe(async (updatedDocs) => {
         if (updatedDocs.find((c) => c._id === subscriptionId)) {
@@ -152,7 +152,7 @@ export function createFireproof(dbName?: string, config: ConfigOpts = {}): Creat
     });
 
     createEffect(() => {
-      void refreshDoc(ledger(), initialDocFn()._id);
+      void refreshDoc(database(), initialDocFn()._id);
     });
 
     return [doc, updateDoc, saveDoc];
@@ -165,13 +165,13 @@ export function createFireproof(dbName?: string, config: ConfigOpts = {}): Creat
       rows: initialRows,
     });
 
-    const refreshRows = async (db: Ledger) => {
+    const refreshRows = async (db: Database) => {
       const res = await db.query<T>(strOrFn, query);
       setResult({ ...res, docs: res.rows.map((r) => r.doc as Doc<T>) });
     };
 
     createEffect(() => {
-      const db = ledger();
+      const db = database();
 
       void refreshRows(db);
 
@@ -187,5 +187,5 @@ export function createFireproof(dbName?: string, config: ConfigOpts = {}): Creat
     return result;
   }
 
-  return { ledger, createDocument, createLiveQuery };
+  return { database, createDocument, createLiveQuery };
 }

--- a/scripts/storage-engine/browser-test.js
+++ b/scripts/storage-engine/browser-test.js
@@ -23,7 +23,7 @@ void (async () => {
 
   await page.goto(url);
 
-  // Wait for some time to ensure the ledger operation is complete
+  // Wait for some time to ensure the database operation is complete
   // await page.waitForTimeout(1000)
 
   // Click the button to run onButtonClick

--- a/scripts/storage-engine/types.js
+++ b/scripts/storage-engine/types.js
@@ -4,7 +4,7 @@ import path from "path";
 
 // Get the entry points from your build settings
 
-// const entryPoints = ['ledger', 'index', 'types']// createBuildSettings({}).map(config => path.basename(config.entryPoints[0], '.ts'))
+// const entryPoints = ['database', 'index', 'types']// createBuildSettings({}).map(config => path.basename(config.entryPoints[0], '.ts'))
 
 function generateIndexFile() {
   const typesDir = path.resolve("dist/types");

--- a/smoke/react/src/routes/todo-list.test.tsx
+++ b/smoke/react/src/routes/todo-list.test.tsx
@@ -3,10 +3,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import TodoList from "./Todo.js";
 
 import { expect, describe, it } from "vitest";
-import { Ledger, fireproof } from "use-fireproof";
+import { Database, fireproof } from "use-fireproof";
 
 describe("<TodoList />", () => {
-  let fp: Ledger;
+  let fp: Database;
   afterEach(async () => {
     console.log("ae-pre-destroy");
     await fp.destroy();

--- a/src/blockstore/README.md
+++ b/src/blockstore/README.md
@@ -82,7 +82,7 @@ In shared storage situations, just because compaction has removed references to 
 
 ## Encryption
 
-Encrypted Blockstore uses symmetric keys, and each blockstore generates its own key. This means that files are opaque to storage providers, but the key is broadcast on the metadata channel, so it's up to you how secure you want to make it. [Read about the encryption model in the Fireproof docs here](https://use-fireproof.com/docs/ledger-api/encryption). The blockstore was extracted from Fireproof, so for the first releases you'll want to read the Fireproof docs for more information.
+Encrypted Blockstore uses symmetric keys, and each blockstore generates its own key. This means that files are opaque to storage providers, but the key is broadcast on the metadata channel, so it's up to you how secure you want to make it. [Read about the encryption model in the Fireproof docs here](https://use-fireproof.com/docs/database-api/encryption). The blockstore was extracted from Fireproof, so for the first releases you'll want to read the Fireproof docs for more information.
 
 ## Connectors
 

--- a/src/blockstore/connection-base.ts
+++ b/src/blockstore/connection-base.ts
@@ -115,9 +115,9 @@ export abstract class ConnectionBase implements Connection {
   //   //   await this.compact()
   //   // }
   //   const currents = await this.loader?.metaStore?.load()
-  //   if (!currents) throw new Error("Can't sync empty ledger: save data first")
+  //   if (!currents) throw new Error("Can't sync empty database: save data first")
   //   if (currents.length > 1)
-  //     throw new Error("Can't sync ledger with split heads: make an update first")
+  //     throw new Error("Can't sync database with split heads: make an update first")
   //   const current = currents[0]
   //   const params = {
   //     car: current.car.toString()

--- a/src/blockstore/transaction.ts
+++ b/src/blockstore/transaction.ts
@@ -240,7 +240,7 @@ export class EncryptedBlockstore extends BaseBlockstore {
 
   async getFile(car: AnyLink, cid: AnyLink /*, isPublic = false*/): Promise<Uint8Array> {
     await this.ready();
-    if (!this.loader) throw this.logger.Error().Msg("loader required to get file, ledger must be named").AsError();
+    if (!this.loader) throw this.logger.Error().Msg("loader required to get file, database must be named").AsError();
     const reader = await this.loader.loadFileCar(car /*, isPublic */);
     const block = await reader.get(cid as CID);
     if (!block) throw this.logger.Error().Str("cid", cid.toString()).Msg(`Missing block`).AsError();

--- a/src/blockstore/types.ts
+++ b/src/blockstore/types.ts
@@ -217,7 +217,7 @@ export interface StoreRuntime {
   // the factories should produce ready-to-use stores
   // which means they have to call start() on the store
   // to fullfill lifecycle requirements
-  // to release resources, like one ledger connection
+  // to release resources, like one database connection
   // for all stores a refcount on close() should be used
   makeMetaStore(sfi: StoreFactoryItem): Promise<MetaStore>;
   makeDataStore(sfi: StoreFactoryItem): Promise<DataStore>;

--- a/src/crdt-helpers.ts
+++ b/src/crdt-helpers.ts
@@ -122,7 +122,7 @@ async function processFileset(
   files: DocFiles /*, publicFiles = false */,
 ) {
   const dbBlockstore = blocks.parent as EncryptedBlockstore;
-  if (!dbBlockstore.loader) throw logger.Error().Msg("Missing loader, ledger name is required").AsError();
+  if (!dbBlockstore.loader) throw logger.Error().Msg("Missing loader, database name is required").AsError();
   const t = new CarTransaction(dbBlockstore); // maybe this should move to encrypted-blockstore
   const didPut = [];
   // let totalSize = 0
@@ -166,7 +166,7 @@ export async function getValueFromCrdt<T extends DocTypes>(
   key: string,
   logger: Logger,
 ): Promise<DocValue<T>> {
-  if (!head.length) throw logger.Debug().Msg("Getting from an empty ledger").AsError();
+  if (!head.length) throw logger.Debug().Msg("Getting from an empty database").AsError();
   const link = await get(blocks, head, key);
   if (!link) throw logger.Error().Str("key", key).Msg(`Missing key`).AsError();
   return await getValueFromLink(blocks, link, logger);

--- a/src/crdt.ts
+++ b/src/crdt.ts
@@ -35,14 +35,14 @@ import { index, type Index } from "./indexer.js";
 import { CRDTClock } from "./crdt-clock.js";
 // import { blockstoreFactory } from "./blockstore/transaction.js";
 import { ensureLogger } from "./utils.js";
-import { LedgerOpts } from "./ledger.js";
+import { DatabaseOpts } from "./database.js";
 
 export interface HasCRDT<T extends DocTypes> {
   readonly crdt: CRDT<T> | CRDT<NonNullable<unknown>>;
 }
 
 export class CRDT<T extends DocTypes> {
-  readonly opts: LedgerOpts;
+  readonly opts: DatabaseOpts;
 
   readonly blockstore: BaseBlockstore;
   readonly indexBlockstore: BaseBlockstore;
@@ -55,7 +55,7 @@ export class CRDT<T extends DocTypes> {
   readonly logger: Logger;
   readonly sthis: SuperThis;
 
-  constructor(sthis: SuperThis, opts: LedgerOpts) {
+  constructor(sthis: SuperThis, opts: DatabaseOpts) {
     this.sthis = sthis;
     this.logger = ensureLogger(sthis, "CRDT");
     this.opts = opts;

--- a/src/database.ts
+++ b/src/database.ts
@@ -34,7 +34,7 @@ import { decodeFile, encodeFile } from "./runtime/files.js";
 import { defaultKeyBagOpts, KeyBagRuntime } from "./runtime/key-bag.js";
 import { getDefaultURI } from "./blockstore/register-store-protocol.js";
 
-const ledgers = new KeyedResolvOnce<Ledger>();
+const databases = new KeyedResolvOnce<Database>();
 
 export function keyConfigOpts(sthis: SuperThis, name?: string, opts?: ConfigOpts): string {
   return JSON.stringify(
@@ -45,7 +45,7 @@ export function keyConfigOpts(sthis: SuperThis, name?: string, opts?: ConfigOpts
   );
 }
 
-export interface LedgerOpts {
+export interface DatabaseOpts {
   readonly name?: string;
   // readonly public?: boolean;
   readonly meta?: DbMeta;
@@ -61,7 +61,7 @@ export interface LedgerOpts {
   // readonly threshold?: number;
 }
 
-export interface Ledger<DT extends DocTypes = NonNullable<unknown>> extends HasCRDT<DT> {
+export interface Database<DT extends DocTypes = NonNullable<unknown>> extends HasCRDT<DT> {
   // readonly name: string;
   readonly logger: Logger;
   readonly sthis: SuperThis;
@@ -97,15 +97,15 @@ export interface Ledger<DT extends DocTypes = NonNullable<unknown>> extends HasC
   compact(): Promise<void>;
 }
 
-export function isLedger<T extends DocTypes = NonNullable<unknown>>(db: unknown): db is Ledger<T> {
-  return db instanceof LedgerImpl || db instanceof LedgerShell;
+export function isDatabase<T extends DocTypes = NonNullable<unknown>>(db: unknown): db is Database<T> {
+  return db instanceof DatabaseImpl || db instanceof DatabaseShell;
 }
 
-export function LedgerFactory<T extends DocTypes = NonNullable<unknown>>(name: string | undefined, opts?: ConfigOpts): Ledger<T> {
+export function DatabaseFactory<T extends DocTypes = NonNullable<unknown>>(name: string | undefined, opts?: ConfigOpts): Database<T> {
   const sthis = ensureSuperThis(opts);
-  return new LedgerShell<T>(
-    ledgers.get(keyConfigOpts(sthis, name, opts)).once((key) => {
-      const db = new LedgerImpl<T>(sthis, {
+  return new DatabaseShell<T>(
+    databases.get(keyConfigOpts(sthis, name, opts)).once((key) => {
+      const db = new DatabaseImpl<T>(sthis, {
         name,
         meta: opts?.meta,
         keyBag: defaultKeyBagOpts(sthis, opts?.keyBag),
@@ -119,16 +119,16 @@ export function LedgerFactory<T extends DocTypes = NonNullable<unknown>>(name: s
         },
       });
       db.onClosed(() => {
-        ledgers.unget(key);
+        databases.unget(key);
       });
       return db;
     }),
   );
 }
 
-export class LedgerShell<DT extends DocTypes = NonNullable<unknown>> implements Ledger<DT> {
-  readonly ref: LedgerImpl<DT>;
-  constructor(ref: LedgerImpl<DT>) {
+export class DatabaseShell<DT extends DocTypes = NonNullable<unknown>> implements Database<DT> {
+  readonly ref: DatabaseImpl<DT>;
+  constructor(ref: DatabaseImpl<DT>) {
     this.ref = ref;
     ref.addShell(this);
   }
@@ -202,9 +202,9 @@ export class LedgerShell<DT extends DocTypes = NonNullable<unknown>> implements 
   }
 }
 
-class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<DT> {
+class DatabaseImpl<DT extends DocTypes = NonNullable<unknown>> implements Database<DT> {
   // readonly name: string;
-  readonly opts: LedgerOpts;
+  readonly opts: DatabaseOpts;
 
   _listening = false;
   readonly _listeners = new Set<ListenerFn<DT>>();
@@ -213,9 +213,9 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
   readonly _writeQueue: WriteQueue<DT>;
   // readonly blockstore: BaseBlockstore;
 
-  readonly shells: Set<LedgerShell<DT>> = new Set<LedgerShell<DT>>();
+  readonly shells: Set<DatabaseShell<DT>> = new Set<DatabaseShell<DT>>();
 
-  addShell(shell: LedgerShell<DT>) {
+  addShell(shell: DatabaseShell<DT>) {
     this.shells.add(shell);
   }
 
@@ -226,9 +226,9 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
   async close() {
     throw this.logger.Error().Str("db", this.name).Msg(`use shellClose`).AsError();
   }
-  async shellClose(db: LedgerShell<DT>) {
+  async shellClose(db: DatabaseShell<DT>) {
     if (!this.shells.has(db)) {
-      throw this.logger.Error().Str("db", this.name).Msg(`LedgerShell mismatch`).AsError();
+      throw this.logger.Error().Str("db", this.name).Msg(`DatabaseShell mismatch`).AsError();
     }
     this.shells.delete(db);
     if (this.shells.size === 0) {
@@ -260,12 +260,12 @@ class LedgerImpl<DT extends DocTypes = NonNullable<unknown>> implements Ledger<D
   readonly sthis: SuperThis;
   readonly id: string;
 
-  constructor(sthis: SuperThis, opts: LedgerOpts) {
+  constructor(sthis: SuperThis, opts: DatabaseOpts) {
     this.opts = opts; // || this.opts;
     // this.name = opts.storeUrls.data.data.getParam(PARAM.NAME) || "default";
     this.sthis = sthis;
     this.id = sthis.timeOrderedNextId().str;
-    this.logger = ensureLogger(this.sthis, "Ledger");
+    this.logger = ensureLogger(this.sthis, "Database");
     this.crdt = new CRDT(this.sthis, this.opts);
     this._writeQueue = writeQueue(this.sthis, async (updates: DocUpdate<DT>[]) => this.crdt.bulk(updates), this.opts.writeQueue);
     this.crdt.clock.onTock(() => this._no_update_notify());
@@ -441,7 +441,7 @@ function defaultURI(
   if (!ret.hasParam(PARAM.NAME)) {
     const name = sthis.pathOps.basename(ret.URI().pathname);
     if (!name) {
-      throw sthis.logger.Error().Url(ret).Any("ctx", ctx).Msg("Ledger name is required").AsError();
+      throw sthis.logger.Error().Url(ret).Any("ctx", ctx).Msg("Database name is required").AsError();
     }
     ret.setParam(PARAM.NAME, name);
   }
@@ -497,8 +497,8 @@ export function toStoreURIRuntime(sthis: SuperThis, name?: string, sopts?: Store
   };
 }
 
-export function fireproof(name: string, opts?: ConfigOpts): Ledger {
-  return LedgerFactory(name, opts);
+export function fireproof(name: string, opts?: ConfigOpts): Database {
+  return DatabaseFactory(name, opts);
 }
 
 function makeName(fnString: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./ledger.js";
+export * from "./database.js";
 export * from "./types.js";
 
 export * from "./crdt.js";

--- a/src/react/useAllDocs.ts
+++ b/src/react/useAllDocs.ts
@@ -1,27 +1,27 @@
-import { Ledger, DocTypes } from "@fireproof/core";
+import { Database, DocTypes } from "@fireproof/core";
 
 import { AllDocsResult, useFireproof, UseAllDocs } from "./useFireproof.js";
 
 export interface TLUseAllDocs {
   <T extends DocTypes>(...args: Parameters<UseAllDocs>): AllDocsResult<T>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseAllDocs(...args: Parameters<UseAllDocs>) {
-  const { useAllDocs, ledger } = useFireproof();
-  (topLevelUseAllDocs as TLUseAllDocs).ledger = ledger;
+  const { useAllDocs, database } = useFireproof();
+  (topLevelUseAllDocs as TLUseAllDocs).database = database;
   return useAllDocs(...args);
 }
 
 /**
  * ## Summary
- * React hook that provides access to all documents in the ledger, sorted by `_id`.
+ * React hook that provides access to all documents in the database, sorted by `_id`.
  *
  * ## Usage
  * ```tsx
  * const result = useAllDocs({ limit: 10, descending: true }); // with options
  * const result = useAllDocs(); // without options
- * const ledger = useAllDocs.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useAllDocs.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/src/react/useChanges.ts
+++ b/src/react/useChanges.ts
@@ -1,27 +1,27 @@
-import { Ledger, DocTypes } from "@fireproof/core";
+import { Database, DocTypes } from "@fireproof/core";
 
 import { ChangesResult, useFireproof, UseChanges } from "./useFireproof.js";
 
 export interface TLUseChanges {
   <T extends DocTypes>(...args: Parameters<UseChanges>): ChangesResult<T>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseChanges(...args: Parameters<UseChanges>) {
-  const { useChanges, ledger } = useFireproof();
-  (topLevelUseChanges as TLUseChanges).ledger = ledger;
+  const { useChanges, database } = useFireproof();
+  (topLevelUseChanges as TLUseChanges).database = database;
   return useChanges(...args);
 }
 
 /**
  * ## Summary
- * React hook that provides access to all new documents in the ledger added since the last time the changes was called
+ * React hook that provides access to all new documents in the database added since the last time the changes was called
  *
  * ## Usage
  * ```tsx
  * const result = useChanges(prevresult.clock,{limit:10}); // with options
  * const result = useChanges(); // without options
- * const ledger = useChanges.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useChanges.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/src/react/useDocument.ts
+++ b/src/react/useDocument.ts
@@ -1,15 +1,15 @@
-import { Ledger, DocTypes, DocWithId } from "@fireproof/core";
+import { Database, DocTypes, DocWithId } from "@fireproof/core";
 
 import { UseDocument, UseDocumentResult, useFireproof } from "./useFireproof.js";
 
 export interface TLUseDocument {
   <T extends DocTypes>(initialDoc: DocWithId<T>): UseDocumentResult<T>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseDocument(...args: Parameters<UseDocument>) {
-  const { useDocument, ledger } = useFireproof();
-  (topLevelUseDocument as TLUseDocument).ledger = ledger;
+  const { useDocument, database } = useFireproof();
+  (topLevelUseDocument as TLUseDocument).database = database;
   return useDocument(...args);
 }
 
@@ -17,9 +17,9 @@ function topLevelUseDocument(...args: Parameters<UseDocument>) {
  * ## Summary
  *
  * React hook that provides the ability to create new Fireproof documents. The creation occurs when
- * you do not pass in an `_id` as part of your initial document -- the ledger will assign a new one when
- * you call the provided `save` handler This uses the default ledger named `useFireproof` under the hood which you can also
- * access via the `ledger` accessor.
+ * you do not pass in an `_id` as part of your initial document -- the database will assign a new one when
+ * you call the provided `save` handler This uses the default database named `useFireproof` under the hood which you can also
+ * access via the `database` accessor.
  *
  * ## Usage
  *
@@ -37,7 +37,7 @@ function topLevelUseDocument(...args: Parameters<UseDocument>) {
  *   startedAt: Date.now()
  * }))
  *
- * const ledger = useDocument.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useDocument.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/src/react/useFireproof.ts
+++ b/src/react/useFireproof.ts
@@ -7,7 +7,7 @@ import type {
   DocWithId,
   IndexKeyType,
   IndexRow,
-  Ledger,
+  Database,
   MapFn,
   QueryOpts,
 } from "@fireproof/core";
@@ -55,12 +55,12 @@ export type UseDocumentInitialDocOrFn<T extends DocTypes> = DocSet<T> | (() => D
 export type UseDocument = <T extends DocTypes>(initialDocOrFn: UseDocumentInitialDocOrFn<T>) => UseDocumentResult<T>;
 
 export interface UseFireproof {
-  readonly ledger: Ledger;
+  readonly database: Database;
   /**
    * ## Summary
    *
-   * React hook that provides the ability to create/update/save new Fireproof documents into your custom Fireproof ledger.
-   * The creation occurs when you do not pass in an `_id` as part of your initial document -- the ledger will assign a new
+   * React hook that provides the ability to create/update/save new Fireproof documents into your custom Fireproof database.
+   * The creation occurs when you do not pass in an `_id` as part of your initial document -- the database will assign a new
    * one when you call the provided `save` handler. The hook also provides generics support so you can inline your custom type into
    * the invocation to receive type-safety and auto-complete support in your IDE.
    *
@@ -108,7 +108,7 @@ export interface UseFireproof {
   readonly useLiveQuery: UseLiveQuery;
   /**
    * ## Summary
-   * React hook that provides access to all documents in the ledger, sorted by `_id`.
+   * React hook that provides access to all documents in the database, sorted by `_id`.
    *
    * ## Usage
    * ```tsx
@@ -124,13 +124,13 @@ export interface UseFireproof {
   readonly useAllDocs: UseAllDocs;
   /**
    * ## Summary
-   * React hook that provides access to all new documents in the ledger added since the last time the changes was called
+   * React hook that provides access to all new documents in the database added since the last time the changes was called
    *
    * ## Usage
    * ```tsx
    * const result = useChanges(prevresult.clock,{limit:10}); // with options
    * const result = useChanges(); // without options
-   * const ledger = useChanges.ledger; // underlying "useFireproof" ledger accessor
+   * const database = useChanges.database; // underlying "useFireproof" database accessor
    * ```
    *
    * ## Overview
@@ -150,28 +150,28 @@ export const FireproofCtx = {} as UseFireproof;
  *
  * ## Summary
  *
- * React hook to create a custom-named Fireproof ledger and provides the utility hooks to query against it.
+ * React hook to create a custom-named Fireproof database and provides the utility hooks to query against it.
  *
  * ## Usage
  * ```tsx
- * const { ledger, useLiveQuery, useDocument } = useFireproof("dbname");
- * const { ledger, useLiveQuery, useDocument } = useFireproof("dbname", { ...options });
+ * const { database, useLiveQuery, useDocument } = useFireproof("dbname");
+ * const { database, useLiveQuery, useDocument } = useFireproof("dbname", { ...options });
  * ```
  *
  * ## Overview
  *
- * TL;DR: Only use this hook if you need to configure a ledger name other than the default `useFireproof`.
+ * TL;DR: Only use this hook if you need to configure a database name other than the default `useFireproof`.
  *
  * For most applications, using the `useLiveQuery` or `useDocument` hooks exported from `use-fireproof` should
- * suffice for the majority of use-cases. Under the hood, they act against a ledger named `useFireproof` instantiated with
- * default configurations. However, if you need to do a custom ledger setup or configure a ledger name more to your liking
+ * suffice for the majority of use-cases. Under the hood, they act against a database named `useFireproof` instantiated with
+ * default configurations. However, if you need to do a custom database setup or configure a database name more to your liking
  * than the default `useFireproof`, then use `useFireproof` as it exists for that purpose. It will provide you with the
- * custom ledger accessor and *lexically scoped* versions of `useLiveQuery` and `useDocument` that act against said
- * custom ledger.
+ * custom database accessor and *lexically scoped* versions of `useLiveQuery` and `useDocument` that act against said
+ * custom database.
  *
  */
-export function useFireproof(name: string | Ledger = "useFireproof", config: ConfigOpts = {}): UseFireproof {
-  const ledger = typeof name === "string" ? fireproof(name, config) : name;
+export function useFireproof(name: string | Database = "useFireproof", config: ConfigOpts = {}): UseFireproof {
+  const database = typeof name === "string" ? fireproof(name, config) : name;
 
   function useDocument<T extends DocTypes>(initialDocOrFn: UseDocumentInitialDocOrFn<T>): UseDocumentResult<T> {
     let initialDoc: DocSet<T>;
@@ -191,13 +191,13 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
 
     const refreshDoc = useCallback(async () => {
       // todo add option for mvcc checks
-      const doc = docId ? await ledger.get<T>(docId).catch(() => initialDoc) : initialDoc;
+      const doc = docId ? await database.get<T>(docId).catch(() => initialDoc) : initialDoc;
       setDoc(doc);
     }, [docId]);
 
     const saveDoc: StoreDocFn<T> = useCallback(
       async (existingDoc) => {
-        const res = await ledger.put(existingDoc ?? doc);
+        const res = await database.put(existingDoc ?? doc);
         // If the document was created, then we need to update the local state with the new `_id`
         if (!existingDoc && !doc._id) setDoc((d) => ({ ...d, _id: res.id }));
         return res;
@@ -208,9 +208,9 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
     const deleteDoc: DeleteDocFn<T> = useCallback(
       async (existingDoc) => {
         const id = existingDoc?._id ?? docId;
-        const doc = await ledger.get<T>(id).catch(() => undefined);
-        if (!doc) throw ledger.logger.Error().Str("id", id).Msg(`Document not found`).AsError();
-        const res = await ledger.del(id);
+        const doc = await database.get<T>(id).catch(() => undefined);
+        if (!doc) throw database.logger.Error().Str("id", id).Msg(`Document not found`).AsError();
+        const res = await database.del(id);
         setDoc(initialDoc);
         return res;
       },
@@ -227,7 +227,7 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
 
     useEffect(() => {
       if (!docId) return;
-      return ledger.subscribe((changes) => {
+      return database.subscribe((changes) => {
         if (changes.find((c) => c._id === docId)) {
           void refreshDoc(); // todo use change.value
         }
@@ -255,13 +255,13 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
     const mapFnString = useMemo(() => mapFn.toString(), [mapFn]);
 
     const refreshRows = useCallback(async () => {
-      const res = await ledger.query<K, T, R>(mapFn, query);
+      const res = await database.query<K, T, R>(mapFn, query);
       setResult({ ...res, docs: res.rows.map((r) => r.doc as DocWithId<T>) });
     }, [mapFnString, queryString]);
 
     useEffect(() => {
       refreshRows(); // Initial data fetch
-      return ledger.subscribe(refreshRows);
+      return database.subscribe(refreshRows);
     }, [refreshRows]);
 
     return result;
@@ -275,13 +275,13 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
     const queryString = useMemo(() => JSON.stringify(query), [query]);
 
     const refreshRows = useCallback(async () => {
-      const res = await ledger.allDocs<T>(query);
+      const res = await database.allDocs<T>(query);
       setResult({ ...res, docs: res.rows.map((r) => r.value as DocWithId<T>) });
     }, [queryString]);
 
     useEffect(() => {
       refreshRows(); // Initial data fetch
-      return ledger.subscribe(refreshRows);
+      return database.subscribe(refreshRows);
     }, [refreshRows]);
 
     return result;
@@ -295,17 +295,17 @@ export function useFireproof(name: string | Ledger = "useFireproof", config: Con
     const queryString = useMemo(() => JSON.stringify(opts), [opts]);
 
     const refreshRows = useCallback(async () => {
-      const res = await ledger.changes<T>(since, opts);
+      const res = await database.changes<T>(since, opts);
       setResult({ ...res, docs: res.rows.map((r) => r.value as DocWithId<T>) });
     }, [since, queryString]);
 
     useEffect(() => {
       refreshRows(); // Initial data fetch
-      return ledger.subscribe(refreshRows);
+      return database.subscribe(refreshRows);
     }, [refreshRows]);
 
     return result;
   }
 
-  return { ledger, useLiveQuery, useDocument, useAllDocs, useChanges };
+  return { database, useLiveQuery, useDocument, useAllDocs, useChanges };
 }

--- a/src/react/useLiveQuery.ts
+++ b/src/react/useLiveQuery.ts
@@ -1,4 +1,4 @@
-import { Ledger, DocFragment, DocTypes, IndexKeyType } from "@fireproof/core";
+import { Database, DocFragment, DocTypes, IndexKeyType } from "@fireproof/core";
 
 import { LiveQueryResult, useFireproof, UseLiveQuery } from "./useFireproof.js";
 
@@ -6,25 +6,25 @@ export interface TLUseLiveQuery {
   <T extends DocTypes, K extends IndexKeyType, R extends DocFragment = T>(
     ...args: Parameters<UseLiveQuery>
   ): LiveQueryResult<T, K, R>;
-  ledger: Ledger;
+  database: Database;
 }
 
 function topLevelUseLiveQuery(...args: Parameters<UseLiveQuery>) {
-  const { useLiveQuery, ledger } = useFireproof();
-  (topLevelUseLiveQuery as TLUseLiveQuery).ledger = ledger;
+  const { useLiveQuery, database } = useFireproof();
+  (topLevelUseLiveQuery as TLUseLiveQuery).database = database;
   return useLiveQuery(...args);
 }
 
 /**
  * ## Summary
  * React hook that provides access to live query results, enabling real-time updates in your app. This uses
- * the default ledger named "useFireproof" under the hood which you can also access via the `ledger` accessor.
+ * the default database named "useFireproof" under the hood which you can also access via the `database` accessor.
  *
  * ## Usage
  * ```tsx
  * const results = useLiveQuery("date"); // using string
  * const results = useLiveQuery((doc) => doc.date)); // using map function
- * const ledger = useLiveQuery.ledger; // underlying "useFireproof" ledger accessor
+ * const database = useLiveQuery.database; // underlying "useFireproof" database accessor
  * ```
  *
  * ## Overview

--- a/tests/fireproof/all-gateway.test.ts
+++ b/tests/fireproof/all-gateway.test.ts
@@ -1,4 +1,4 @@
-import { Ledger, LedgerFactory, PARAM, bs, ensureSuperThis } from "@fireproof/core";
+import { Database, DatabaseFactory, PARAM, bs, ensureSuperThis } from "@fireproof/core";
 
 import { fileContent } from "./cars/bafkreidxwt2nhvbl4fnqfw3ctlt6zbrir4kqwmjo5im6rf4q5si27kgo2i.js";
 import { simpleCID } from "../helpers.js";
@@ -30,7 +30,7 @@ import { simpleCID } from "../helpers.js";
 // }
 
 describe("noop Gateway", function () {
-  let db: Ledger;
+  let db: Database;
   let carStore: bs.DataStore;
   let metaStore: bs.MetaStore;
   let fileStore: bs.DataStore;
@@ -46,7 +46,7 @@ describe("noop Gateway", function () {
     await db.destroy();
   });
   beforeEach(async function () {
-    db = LedgerFactory("test-gateway-" + sthis.nextId().str, {
+    db = DatabaseFactory("test-gateway-" + sthis.nextId().str, {
       logger: sthis.logger,
     });
 
@@ -363,7 +363,7 @@ describe("noop Gateway", function () {
 });
 
 describe("noop Gateway subscribe", function () {
-  let db: Ledger;
+  let db: Database;
 
   let metaStore: bs.MetaStore;
 
@@ -375,7 +375,7 @@ describe("noop Gateway subscribe", function () {
     await db.destroy();
   });
   beforeEach(async function () {
-    db = LedgerFactory("test-gateway-" + sthis.nextId().str);
+    db = DatabaseFactory("test-gateway-" + sthis.nextId().str);
 
     // Extract stores from the loader
     metaStore = (await db.crdt.blockstore.loader?.metaStore()) as bs.MetaStore;
@@ -409,7 +409,7 @@ describe("noop Gateway subscribe", function () {
 });
 
 describe("Gateway", function () {
-  let db: Ledger;
+  let db: Database;
   // let carStore: ExtendedStore;
   let metaStore: bs.MetaStore;
   // let fileStore: ExtendedStore;
@@ -425,7 +425,7 @@ describe("Gateway", function () {
     await db.destroy();
   });
   beforeEach(async function () {
-    db = LedgerFactory("test-gateway-" + sthis.nextId().str);
+    db = DatabaseFactory("test-gateway-" + sthis.nextId().str);
     const ok = await db.put({ _id: "test", foo: "bar" });
     expect(ok).toBeTruthy();
     expect(ok.id).toBe("test");

--- a/tests/fireproof/crdt.test.ts
+++ b/tests/fireproof/crdt.test.ts
@@ -1,4 +1,4 @@
-import { CRDT, defaultWriteQueueOpts, ensureSuperThis, LedgerOpts, toStoreURIRuntime, rt } from "@fireproof/core";
+import { CRDT, defaultWriteQueueOpts, ensureSuperThis, DatabaseOpts, toStoreURIRuntime, rt } from "@fireproof/core";
 import { bs } from "@fireproof/core";
 import { CRDTMeta, DocValue } from "@fireproof/core";
 import { Index, index } from "@fireproof/core";
@@ -12,7 +12,7 @@ describe("Fresh crdt", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
@@ -55,7 +55,7 @@ describe("CRDT with one record", function () {
 
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `test@${sthis.nextId().str}`),
@@ -111,7 +111,7 @@ describe("CRDT with a multi-write", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
@@ -182,7 +182,7 @@ describe("CRDT with two multi-writes", function () {
   });
   beforeEach(async () => {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `test-multiple-writes@${sthis.nextId().str}`),
@@ -236,7 +236,7 @@ describe("Compact a named CRDT with writes", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, `named-crdt-compaction`),
@@ -298,7 +298,7 @@ describe("CRDT with an index", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-crdt-cold"),
@@ -350,7 +350,7 @@ describe("Loader with a committed transaction", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, dbname),
@@ -404,7 +404,7 @@ describe("Loader with two committed transactions", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-loader"),
@@ -460,7 +460,7 @@ describe("Loader with many committed transactions", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    const dbOpts: LedgerOpts = {
+    const dbOpts: DatabaseOpts = {
       writeQueue: defaultWriteQueueOpts({}),
       keyBag: rt.defaultKeyBagOpts(sthis),
       storeUrls: toStoreURIRuntime(sthis, "test-loader-many"),

--- a/tests/fireproof/database.test.ts
+++ b/tests/fireproof/database.test.ts
@@ -2,20 +2,20 @@ import { URI } from "@adviser/cement";
 import { buildBlobFiles, FileWithCid, mockSuperThis } from "../helpers.js";
 import {
   bs,
-  Ledger,
+  Database,
   DocResponse,
   DocFileMeta,
   DocWithId,
   DocFiles,
   toStoreURIRuntime,
   keyConfigOpts,
-  LedgerFactory,
-  LedgerShell,
+  DatabaseFactory,
+  DatabaseShell,
   ensureSuperThis,
 } from "@fireproof/core";
 
-describe("basic Ledger", () => {
-  let db: Ledger;
+describe("basic Database", () => {
+  let db: Database;
   const sthis = mockSuperThis();
   afterEach(async () => {
     await db.close();
@@ -23,7 +23,7 @@ describe("basic Ledger", () => {
   });
   beforeEach(async () => {
     await sthis.start();
-    db = LedgerFactory(undefined, {
+    db = DatabaseFactory(undefined, {
       logger: sthis.logger,
     });
   });
@@ -49,11 +49,11 @@ describe("basic Ledger", () => {
   });
 });
 
-describe("basic Ledger with record", function () {
+describe("basic Database with record", function () {
   interface Doc {
     readonly value: string;
   }
-  let db: LedgerShell;
+  let db: DatabaseShell;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -61,7 +61,7 @@ describe("basic Ledger with record", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("factory-name") as LedgerShell;
+    db = DatabaseFactory("factory-name") as DatabaseShell;
     const ok = await db.put<Doc>({ _id: "hello", value: "world" });
     expect(ok.id).toBe("hello");
   });
@@ -93,7 +93,7 @@ describe("basic Ledger with record", function () {
     expect(rows[0].value._id).toBe("hello");
   });
   it("is not persisted", async function () {
-    const db2 = LedgerFactory("factory-name") as LedgerShell;
+    const db2 = DatabaseFactory("factory-name") as DatabaseShell;
     const { rows } = await db2.changes([]);
     expect(rows.length).toBe(1);
     expect(db2.ref).toBe(db.ref);
@@ -103,11 +103,11 @@ describe("basic Ledger with record", function () {
   });
 });
 
-describe("named Ledger with record", function () {
+describe("named Database with record", function () {
   interface Doc {
     readonly value: string;
   }
-  let db: Ledger;
+  let db: Database;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -115,7 +115,7 @@ describe("named Ledger with record", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-db-name");
+    db = DatabaseFactory("test-db-name");
     /** @type {Doc} */
     const doc = { _id: "hello", value: "world" };
     const ok = await db.put(doc);
@@ -217,13 +217,13 @@ describe("named Ledger with record", function () {
   });
 });
 
-// describe('basic Ledger parallel writes / public', function () {
-//   /** @type {Ledger} */
+// describe('basic Database parallel writes / public', function () {
+//   /** @type {Database} */
 //   let db
 //   const writes = []
 //   beforeEach(async function () {
 //     await resetDirectory(dataDir, 'test-parallel-writes')
-//     db = new Ledger('test-parallel-writes', { public: true })
+//     db = new Database('test-parallel-writes', { public: true })
 //     /** @type {Doc} */
 //     for (let i = 0; i < 10; i++) {
 //       const doc = { _id: `id-${i}`, hello: 'world' }
@@ -232,8 +232,8 @@ describe("named Ledger with record", function () {
 //     await Promise.all(writes)
 //   })
 
-describe("basic Ledger parallel writes / public ordered", () => {
-  let db: Ledger;
+describe("basic Database parallel writes / public ordered", () => {
+  let db: Database;
   const writes: Promise<DocResponse>[] = [];
   const sthis = mockSuperThis();
   afterEach(async () => {
@@ -242,7 +242,7 @@ describe("basic Ledger parallel writes / public ordered", () => {
   });
   beforeEach(async () => {
     await sthis.start();
-    db = LedgerFactory("test-parallel-writes-ordered", { writeQueue: { chunkSize: 1 } });
+    db = DatabaseFactory("test-parallel-writes-ordered", { writeQueue: { chunkSize: 1 } });
     for (let i = 0; i < 10; i++) {
       const doc = { _id: `id-${i}`, hello: "world" };
       writes.push(db.put(doc));
@@ -266,8 +266,8 @@ describe("basic Ledger parallel writes / public ordered", () => {
   });
 });
 
-describe("basic Ledger parallel writes / public", () => {
-  let db: Ledger;
+describe("basic Database parallel writes / public", () => {
+  let db: Database;
   const writes: Promise<DocResponse>[] = [];
   const sthis = ensureSuperThis();
   afterEach(async () => {
@@ -276,7 +276,7 @@ describe("basic Ledger parallel writes / public", () => {
   });
   beforeEach(async () => {
     await sthis.start();
-    db = LedgerFactory("test-parallel-writes", { writeQueue: { chunkSize: 32 } });
+    db = DatabaseFactory("test-parallel-writes", { writeQueue: { chunkSize: 32 } });
     for (let i = 0; i < 10; i++) {
       const doc = { _id: `id-${i}`, hello: "world" };
       writes.push(db.put(doc));
@@ -346,8 +346,8 @@ describe("basic Ledger parallel writes / public", () => {
   });
 });
 
-describe("basic Ledger with subscription", function () {
-  let db: Ledger;
+describe("basic Database with subscription", function () {
+  let db: Database;
   let didRun: number;
   let unsubscribe: () => void;
   let lastDoc: DocWithId<NonNullable<unknown>>;
@@ -359,7 +359,7 @@ describe("basic Ledger with subscription", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("factory-name");
+    db = DatabaseFactory("factory-name");
     didRun = 0;
     waitForSub = new Promise((resolve) => {
       unsubscribe = db.subscribe((docs) => {
@@ -392,8 +392,8 @@ describe("basic Ledger with subscription", function () {
   });
 });
 
-describe("basic Ledger with no update subscription", function () {
-  let db: Ledger;
+describe("basic Database with no update subscription", function () {
+  let db: Database;
   let didRun: number;
   let unsubscribe: () => void;
   const sthis = ensureSuperThis();
@@ -403,7 +403,7 @@ describe("basic Ledger with no update subscription", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("factory-name");
+    db = DatabaseFactory("factory-name");
     didRun = 0;
     unsubscribe = db.subscribe(() => {
       didRun++;
@@ -428,8 +428,8 @@ describe("basic Ledger with no update subscription", function () {
   });
 });
 
-describe("ledger with files input", () => {
-  let db: Ledger;
+describe("database with files input", () => {
+  let db: Database;
   let imagefiles: FileWithCid[] = [];
   let result: DocResponse;
   const sthis = ensureSuperThis();
@@ -441,7 +441,7 @@ describe("ledger with files input", () => {
   beforeEach(async function () {
     await sthis.start();
     imagefiles = await buildBlobFiles();
-    db = LedgerFactory("fireproof-with-images");
+    db = DatabaseFactory("fireproof-with-images");
     const doc = {
       _id: "images-main",
       type: "files",

--- a/tests/fireproof/hello.test.ts
+++ b/tests/fireproof/hello.test.ts
@@ -1,4 +1,4 @@
-import { fireproof, Ledger, DocResponse, DocWithId, index, isLedger } from "@fireproof/core";
+import { fireproof, Database, DocResponse, DocWithId, index, isDatabase } from "@fireproof/core";
 import { mockSuperThis } from "../helpers.js";
 
 describe("Hello World Test", function () {
@@ -12,7 +12,7 @@ describe("hello public API", () => {
   interface TestDoc {
     foo: string;
   }
-  let db: Ledger;
+  let db: Database;
   let ok: DocResponse;
   let doc: DocWithId<TestDoc>;
   // let idx: Index<string, TestDoc>;
@@ -28,9 +28,9 @@ describe("hello public API", () => {
     ok = await db.put({ _id: "test", foo: "bar" });
     doc = await db.get("test");
   });
-  it("should have a ledger", function () {
+  it("should have a database", function () {
     expect(db).toBeTruthy();
-    expect(isLedger(db)).toBeTruthy();
+    expect(isDatabase(db)).toBeTruthy();
   });
   it("should put", function () {
     expect(ok).toBeTruthy();
@@ -47,8 +47,8 @@ describe("hello public API", () => {
   });
 });
 
-describe("Simplified Reopening a ledger", function () {
-  let db: Ledger;
+describe("Simplified Reopening a database", function () {
+  let db: Database;
   afterEach(async function () {
     await db.close();
     await db.destroy();

--- a/tests/fireproof/indexer.test.ts
+++ b/tests/fireproof/indexer.test.ts
@@ -1,16 +1,16 @@
 import {
   Index,
   index,
-  Ledger,
+  Database,
   CRDT,
   IndexRows,
   toStoreURIRuntime,
   bs,
   rt,
-  LedgerFactory,
+  DatabaseFactory,
   defaultWriteQueueOpts,
   ensureSuperThis,
-  LedgerOpts,
+  DatabaseOpts,
 } from "@fireproof/core";
 
 interface TestType {
@@ -19,7 +19,7 @@ interface TestType {
 }
 
 describe("basic Index", () => {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<string, TestType>;
   let didMap: boolean;
   const sthis = ensureSuperThis();
@@ -31,7 +31,7 @@ describe("basic Index", () => {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
@@ -107,7 +107,7 @@ describe("basic Index", () => {
 });
 
 describe("Index query with compound key", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<[string, number], TestType>;
   const sthis = ensureSuperThis();
   afterEach(async function () {
@@ -118,7 +118,7 @@ describe("Index query with compound key", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing", score: 1 });
     await db.put({ title: "creative", score: 2 });
     await db.put({ title: "creative", score: 20 });
@@ -137,7 +137,7 @@ describe("Index query with compound key", function () {
 });
 
 describe("basic Index with map fun", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<string, TestType>;
   const sthis = ensureSuperThis();
   afterEach(async function () {
@@ -148,7 +148,7 @@ describe("basic Index with map fun", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
@@ -167,7 +167,7 @@ describe("basic Index with map fun", function () {
 });
 
 describe("basic Index with map fun with value", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<string, TestType, number>;
   const sthis = ensureSuperThis();
   afterEach(async function () {
@@ -176,7 +176,7 @@ describe("basic Index with map fun with value", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
@@ -205,7 +205,7 @@ describe("basic Index with map fun with value", function () {
 });
 
 describe("Index query with map and compound key", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<[string, number], TestType>;
   const sthis = ensureSuperThis();
   afterEach(async function () {
@@ -216,7 +216,7 @@ describe("Index query with map and compound key", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing", score: 1 });
     await db.put({ title: "creative", score: 2 });
     await db.put({ title: "creative", score: 20 });
@@ -235,7 +235,7 @@ describe("Index query with map and compound key", function () {
 });
 
 describe("basic Index with string fun", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<string, TestType>;
   const sthis = ensureSuperThis();
   afterEach(async function () {
@@ -246,7 +246,7 @@ describe("basic Index with string fun", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
@@ -277,7 +277,7 @@ describe("basic Index upon cold start", function () {
   let mapFn: (doc: TestType) => string;
   let result: IndexRows<string, TestType>;
   const sthis = ensureSuperThis();
-  let dbOpts: LedgerOpts;
+  let dbOpts: DatabaseOpts;
   // result, mapFn;
   afterEach(async function () {
     await crdt.close();
@@ -375,7 +375,7 @@ describe("basic Index upon cold start", function () {
 });
 
 describe("basic Index with no data", function () {
-  let db: Ledger<TestType>;
+  let db: Database<TestType>;
   let indexer: Index<string, TestType>;
   let didMap: boolean;
   const sthis = ensureSuperThis();
@@ -387,7 +387,7 @@ describe("basic Index with no data", function () {
   });
   beforeEach(async function () {
     await sthis.start();
-    db = LedgerFactory("test-indexer");
+    db = DatabaseFactory("test-indexer");
     indexer = new Index<string, TestType>(sthis, db.crdt, "hello", (doc) => {
       didMap = true;
       return doc.title;

--- a/tests/fireproof/multiple-database.test.ts
+++ b/tests/fireproof/multiple-database.test.ts
@@ -1,7 +1,7 @@
-import { Ledger, ensureSuperThis, fireproof } from "@fireproof/core";
+import { Database, ensureSuperThis, fireproof } from "@fireproof/core";
 
 interface DBItem {
-  readonly db: Ledger;
+  readonly db: Database;
   readonly name: string;
 }
 

--- a/tests/react/useFireproof.test.tsx
+++ b/tests/react/useFireproof.test.tsx
@@ -10,10 +10,10 @@ describe("HOOK: useFireproof", () => {
 
   it("renders the hook correctly and checks types", () => {
     renderHook(() => {
-      const { ledger, useLiveQuery, useDocument } = useFireproof("dbname");
+      const { database, useLiveQuery, useDocument } = useFireproof("dbname");
       expect(typeof useLiveQuery).toBe("function");
       expect(typeof useDocument).toBe("function");
-      expect(ledger?.constructor.name).toMatch(/^Ledger/);
+      expect(database?.constructor.name).toMatch(/^Database/);
     });
   });
 });

--- a/tests/www/gallery.html
+++ b/tests/www/gallery.html
@@ -122,7 +122,7 @@
     <h3>Files</h3>
     <p>
       Data is stored locally and encrypted before upload to S3. This is a demo so the encryption key is not managed securely. Read
-      more about <a href="https://use-fireproof.com/docs/ledger-api/replication">Fireproof replication options.</a> You can also see
+      more about <a href="https://use-fireproof.com/docs/database-api/replication">Fireproof replication options.</a> You can also see
       a demo without images but <a href="https://fireproof.storage/s3up-test.html">with compaction and refresh buttons.</a>
     </p>
     <label for="files-up"><strong>Drop files:</strong></label>

--- a/tests/www/todo-aws.html
+++ b/tests/www/todo-aws.html
@@ -211,7 +211,7 @@
 
   <body>
     <h1><a href="https://use-fireproof.com/">Fireproof</a> Test App</h1>
-    Ledger:
+    Database:
     <input title="Change list" type="text" name="list" id="list" />
     <button onclick="changeList(event)">Switch</button>
 

--- a/tests/www/todo-ipfs.html
+++ b/tests/www/todo-ipfs.html
@@ -156,7 +156,7 @@
           e.preventDefault();
           e.target.disabled = true;
           const input = document.querySelector("#join");
-          const { ledger: newDb, connection: newConn } = await cx.joinShared(input.value);
+          const { database: newDb, connection: newConn } = await cx.joinShared(input.value);
           setupDb(null, newDb, newConn);
         };
 

--- a/tests/www/todo-local.html
+++ b/tests/www/todo-local.html
@@ -196,7 +196,7 @@
 
   <body>
     <h1><a href="https://use-fireproof.com/">Fireproof</a> Test App</h1>
-    Ledger:
+    Database:
     <input title="Change list" type="text" name="list" id="list" />
     <button onclick="changeList(event)">Switch</button>
 

--- a/tests/www/todo.html
+++ b/tests/www/todo.html
@@ -235,7 +235,7 @@
 
   <body>
     <h1><a href="https://use-fireproof.com/">Fireproof</a> Test App</h1>
-    Ledger:
+    Database:
     <input title="Change list" type="text" name="list" id="list" />
     <button onclick="changeList(event)">Switch</button>
 


### PR DESCRIPTION
I am wary of making changes to our public API since we have a fair number of users a `ledger` release would break (and almost no one using the ledger naming) so this needs a little more review, but it basically undoes the ledger technical renaming. (This doesn't change how I feel about the concept of the ledger, and the docs will still talk about ledger but it's just not one of the APIs we make public in the code yet.