### PR TITLE
don't crash on dates

### DIFF
--- a/src/crdt-helpers.ts
+++ b/src/crdt-helpers.ts
@@ -68,7 +68,7 @@ export function sanitizeDocumentFields<T>(obj: T): T {
     if (obj instanceof Date) {
       return obj.toISOString() as unknown as T;
     }
-    
+
     const typedObj = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const key in typedObj) {

--- a/src/crdt-helpers.ts
+++ b/src/crdt-helpers.ts
@@ -64,6 +64,11 @@ export function sanitizeDocumentFields<T>(obj: T): T {
       return item;
     }) as T;
   } else if (typeof obj === "object" && obj !== null) {
+    // Special case for Date objects - convert to ISO string
+    if (obj instanceof Date) {
+      return obj.toISOString() as unknown as T;
+    }
+    
     const typedObj = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const key in typedObj) {
@@ -71,8 +76,13 @@ export function sanitizeDocumentFields<T>(obj: T): T {
         const value = typedObj[key];
         if (value === null || (!Number.isNaN(value) && value !== undefined)) {
           if (typeof value === "object" && !key.startsWith("_")) {
-            const sanitized = sanitizeDocumentFields(value);
-            result[key] = sanitized;
+            // Handle Date objects in properties
+            if (value instanceof Date) {
+              result[key] = (value as Date).toISOString();
+            } else {
+              const sanitized = sanitizeDocumentFields(value);
+              result[key] = sanitized;
+            }
           } else {
             result[key] = value;
           }

--- a/tests/fireproof/database.test.ts
+++ b/tests/fireproof/database.test.ts
@@ -136,6 +136,19 @@ describe("named Ledger with record", function () {
     expect(doc._id).toBe("hello");
     expect(doc.value).toBe("universe");
   });
+  it("should update with Date value", async function () {
+    const date = new Date();
+    const dateStr = date.toISOString();
+    const ok = await db.put({ _id: "hello", value: date });
+    expect(ok.id).toBe("hello");
+    const doc = await db.get<Doc>("hello");
+    expect(doc).toBeTruthy();
+    expect(doc._id).toBe("hello");
+    expect(doc.value).toBe(dateStr);
+    expect(typeof doc.value).toBe("string");
+    const parsed = new Date(doc.value);
+    expect(parsed).toStrictEqual(date);
+  });
   it("should update with null value", async function () {
     const ok = await db.put({ _id: "hello", value: null });
     expect(ok.id).toBe("hello");


### PR DESCRIPTION
this comes up on a lot of first run apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Date values are now automatically converted to a standardized ISO format during record updates, ensuring that any date-based data is handled uniformly across the system.
  - This improvement means that when interacting with date fields, users will enjoy a more reliable and predictable experience. The update minimizes inconsistencies and helps maintain data integrity.
  
- **Tests**
  - Added a new test case to verify the correct handling of Date objects in database updates, ensuring that they are stored and retrieved accurately as ISO strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->