### PR TITLE
make the includeDocs default = true

### DIFF
--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -77,7 +77,7 @@ export class Index<K extends IndexKeyType, T extends DocTypes, R extends DocFrag
   byKey: IndexTree<K, R> = new IndexTree<K, R>();
   byId: IndexTree<K, R> = new IndexTree<K, R>();
   indexHead?: ClockHead;
-  includeDocsDefault = false;
+  includeDocsDefault = true;
   initError?: Error;
 
   ready(): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Query operations now include associated documents by default when no explicit preference is provided, ensuring more comprehensive results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->