### PR TITLE
standard query return values

### DIFF
--- a/notes/query-docs.md
+++ b/notes/query-docs.md
@@ -1,0 +1,182 @@
+# Implementation Plan: Standardizing Query Return Values
+
+## Issue Summary
+- **Issue #802**: useLiveQuery and query return different structures
+- **Problem**: Two inconsistencies exist:
+  1. Database's `query` method returns only `rows` while React's `useLiveQuery` hook returns both `rows` and `docs`
+  2. Type parameter order differs: `query<K, T, R>` vs `useLiveQuery<T, K, R>`
+- **Impact**: These inconsistencies confuse AI models and cause runtime errors when code tries to access a non-existent property
+
+## Implementation Plan: Option 1
+Modify the Database `query` method to match `useLiveQuery` by:
+1. Returning both `rows` and `docs` properties
+2. Standardizing the type parameter order to match `useLiveQuery` (`<T, K, R>` instead of `<K, T, R>`)
+
+## Steps
+
+### 1. Update Type Definitions
+
+#### File: `src/types.ts`
+- Modify the `IndexRows` interface to include the `docs` property and standardize type parameter order:
+
+```typescript
+// Change from <K, T, R> to <T, K, R> to match useLiveQuery
+export interface IndexRows<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T> {
+  rows: IndexRow<K, T, R>[];
+  docs: DocWithId<T>[];  // Add this line
+}
+```
+
+- Note that we're also adding the default type parameter `K extends IndexKeyType = string` to match `useLiveQuery`
+
+### 2. Modify the Query Implementation
+
+#### File: `src/database.ts`
+- Update the `query` method in `DatabaseImpl` class to add the `docs` property and reorder type parameters:
+
+```typescript
+// Change type parameter order from <K, T, R> to <T, K, R>
+async query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(
+  field: string | MapFn<T>,
+  opts: QueryOpts<K> = {},
+): Promise<IndexRows<T, K, R>> {  // Note the reordered type parameters here
+  await this.ready();
+  this.logger.Debug().Any("field", field).Any("opts", opts).Msg("query");
+  const idx = typeof field === "string" 
+    ? index<T, K, R>(this, field)  // Reordered type parameters
+    : index<T, K, R>(this, makeName(field.toString()), field);  // Reordered type parameters
+  
+  const result = await idx.query(opts);
+  
+  // Add docs property to match useLiveQuery behavior
+  return {
+    rows: result.rows,
+    docs: result.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r)
+  };
+}
+```
+
+#### File: `src/indexer.ts`
+- Update the `Index.query` method to return both `rows` and `docs` and adjust for reordered type parameters:
+
+```typescript
+// The Index class will need its type parameters reordered: <T, K, R> instead of <K, T, R>
+async query(opts: QueryOpts<K> = {}): Promise<IndexRows<T, K, R>> { // Note reordered type params
+  // Existing implementation...
+  
+  // When returning results, add the docs property
+  const queryResult = await applyQuery<T, K, R>( // Reordered type parameters
+    this.crdt,
+    // ... existing logic for getting results
+    opts
+  );
+  
+  return {
+    rows: queryResult.rows,
+    docs: queryResult.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r)
+  };
+}
+```
+
+### 3. Simplify useLiveQuery Implementation
+
+#### File: `src/react/use-live-query.ts`
+- Simplify the hook now that the `query` method returns the expected structure with matching type parameter order:
+
+```typescript
+export function createUseLiveQuery(database: Database) {
+  return function useLiveQuery<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(
+    mapFn: MapFn<T> | string,
+    query = {},
+    initialRows: IndexRow<K, T, R>[] = [],
+  ): LiveQueryResult<T, K, R> {
+    const initialResult = {
+      docs: initialRows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r),
+      rows: initialRows,
+    };
+    
+    const [result, setResult] = useState<LiveQueryResult<T, K, R>>(initialResult);
+
+    const queryString = useMemo(() => JSON.stringify(query), [query]);
+    const mapFnString = useMemo(() => mapFn.toString(), [mapFn]);
+
+    const refreshRows = useCallback(async () => {
+      // Now database.query returns both rows and docs directly with matching type order
+      const res = await database.query<T, K, R>(mapFn, query); // Note: now using <T, K, R> to match type order
+      setResult(res);
+    }, [database, mapFnString, queryString]);
+
+    useEffect(() => {
+      refreshRows();
+      const unsubscribe = database.subscribe(refreshRows);
+      return () => {
+        unsubscribe();
+      };
+    }, [database, refreshRows]);
+
+    return result;
+  };
+}
+```
+
+### 4. Update Tests
+
+#### Update existing tests to reflect the new return type:
+- Modify test assertions to expect both `rows` and `docs` properties
+- Add tests specifically for the `docs` property to ensure it contains the correct data
+
+#### Example test:
+```typescript
+test('query returns both rows and docs', async () => {
+  const db = await fireproof('test-db');
+  await db.put({ _id: 'doc1', type: 'test', value: 123 });
+  
+  const result = await db.query('type');
+  
+  expect(result).toHaveProperty('rows');
+  expect(result).toHaveProperty('docs');
+  expect(result.docs[0]._id).toBe('doc1');
+  expect(result.rows[0].doc._id).toBe('doc1');
+});
+```
+
+### 5. Update Documentation
+
+- Update API documentation to reflect the new return structure
+- Add examples showing how to use both `rows` and `docs` properties
+- Add a note in the changelog about this enhancement
+
+## Compatibility Considerations
+
+This change should not break existing code for several reasons:
+
+1. **Return Values**:
+   - Adding the `docs` property is additive and doesn't remove any existing functionality
+   - Code that expects only `rows` will still work since that property remains unchanged
+
+2. **Type Parameter Reordering**:
+   - TypeScript's type inference will handle most cases automatically
+   - Explicit type usage like `db.query<string, MyDocType>()` would need updates, but this is rare
+   - We'll search the codebase for explicit type usages and update them
+
+3. **Default Type Parameter**:
+   - Adding `K extends IndexKeyType = string` provides better alignment with `useLiveQuery`
+   - Makes it easier to use when the key type is string (most common case)
+
+## Validation Plan
+
+1. Run all existing tests to ensure backward compatibility
+2. Add new tests for the `docs` property as described above
+3. Test with actual applications that use the API to ensure no regressions
+
+## Timeline
+
+1. Code changes: 2-3 hours
+   - Type definition updates: 30 minutes
+   - Implementation changes: 1-1.5 hours
+   - Finding and fixing explicit type parameter usages: 30-60 minutes
+2. Testing: 1-2 hours
+3. Documentation updates: 30 minutes
+4. Code review and adjustments: 1 hour
+
+Total estimated time: 4.5-6.5 hours

--- a/src/crdt.ts
+++ b/src/crdt.ts
@@ -51,7 +51,7 @@ export class CRDTImpl implements CRDT {
   readonly blockstore: BaseBlockstore;
   // we can run without an index instance
   readonly indexBlockstore?: BaseBlockstore;
-  readonly indexers = new Map<string, Index<IndexKeyType, NonNullable<unknown>>>();
+  readonly indexers = new Map<string, Index<DocTypes, IndexKeyType>>();
   readonly clock: CRDTClock;
 
   readonly logger: Logger;

--- a/src/database.ts
+++ b/src/database.ts
@@ -171,7 +171,13 @@ export class DatabaseImpl implements Database {
     this.logger.Debug().Any("field", field).Any("opts", opts).Msg("query");
     // const _crdt = this.ledger.crdt as unknown as CRDT<T>;
     const idx = typeof field === "string" ? index<K, T, R>(this, field) : index<K, T, R>(this, makeName(field.toString()), field);
-    return await idx.query(opts);
+    const result = await idx.query(opts);
+    
+    // Add docs property to match useLiveQuery behavior
+    return {
+      rows: result.rows,
+      docs: result.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r)
+    };
   }
 
   async compact() {

--- a/src/database.ts
+++ b/src/database.ts
@@ -163,14 +163,14 @@ export class DatabaseImpl implements Database {
   }
 
   // todo if we add this onto dbs in fireproof.ts then we can make index.ts a separate package
-  async query<K extends IndexKeyType, T extends DocTypes, R extends DocFragment = T>(
+  async query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(
     field: string | MapFn<T>,
     opts: QueryOpts<K> = {},
-  ): Promise<IndexRows<K, T, R>> {
+  ): Promise<IndexRows<T, K, R>> {
     await this.ready();
     this.logger.Debug().Any("field", field).Any("opts", opts).Msg("query");
     // const _crdt = this.ledger.crdt as unknown as CRDT<T>;
-    const idx = typeof field === "string" ? index<K, T, R>(this, field) : index<K, T, R>(this, makeName(field.toString()), field);
+    const idx = typeof field === "string" ? index<T, K, R>(this, field) : index<T, K, R>(this, makeName(field.toString()), field);
     const result = await idx.query(opts);
 
     // Add docs property to match useLiveQuery behavior

--- a/src/database.ts
+++ b/src/database.ts
@@ -172,11 +172,11 @@ export class DatabaseImpl implements Database {
     // const _crdt = this.ledger.crdt as unknown as CRDT<T>;
     const idx = typeof field === "string" ? index<K, T, R>(this, field) : index<K, T, R>(this, makeName(field.toString()), field);
     const result = await idx.query(opts);
-    
+
     // Add docs property to match useLiveQuery behavior
     return {
       rows: result.rows,
-      docs: result.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r)
+      docs: result.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r),
     };
   }
 

--- a/src/indexer-helpers.ts
+++ b/src/indexer-helpers.ts
@@ -187,14 +187,18 @@ export async function applyQuery<T extends DocObject, K extends IndexKeyType, R 
     return {
       key: charwise.decode(key),
       ...row,
-    } as IndexRow<T, K, R>;
+    } as IndexRow<K, T, R>;
   });
 
   // We need to be explicit about the document types here
-  const typedRows = rows as unknown as IndexRow<T, K, R>[];
+  const typedRows = rows as IndexRow<K, T, R>[];
+
+  // Simply filter out null/undefined docs and cast the result
+  const docs = typedRows.map((r) => r.doc).filter(Boolean) as unknown as DocWithId<T>[];
+
   return {
     rows: typedRows,
-    docs: typedRows.map((r) => r.doc).filter((d): d is DocWithId<T> => !!d),
+    docs,
   };
 }
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -232,7 +232,7 @@ export class Index<T extends DocTypes, K extends IndexKeyType = string, R extend
       const start = [...opts.prefix, NaN];
       const end = [...opts.prefix, Infinity];
       const encodedR = encodeRange([start, end]);
-      return await applyQuery<K, T, R>(this.crdt, await this.byKey.root.range(...encodedR), opts);
+      return await applyQuery<T, K, R>(this.crdt, await this.byKey.root.range(...encodedR), opts);
     }
     const all = await this.byKey.root.getAllEntries(); // funky return type
     return await applyQuery<T, K, R>(

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -44,7 +44,7 @@ function refLedger(u: HasCRDT | RefLedger): u is RefLedger {
   return !!(u as RefLedger).ledger;
 }
 
-export function index<T extends DocTypes = NonNullable<unknown>, K extends IndexKeyType = string, R extends DocFragment = T>(
+export function index<T extends DocTypes = DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(
   refDb: HasLogger & HasSuperThis & (HasCRDT | RefLedger),
   name: string,
   mapFn?: MapFn<T>,
@@ -59,7 +59,7 @@ export function index<T extends DocTypes = NonNullable<unknown>, K extends Index
     idx.applyMapFn(name, mapFn, meta);
   } else {
     const idx = new Index<T, K>(refDb.sthis, crdt, name, mapFn, meta);
-    crdt.indexers.set(name, idx as unknown as Index<NonNullable<unknown>, string, NonNullable<unknown>>);
+    crdt.indexers.set(name, idx as unknown as Index<DocTypes, K, DocTypes>);
   }
   return crdt.indexers.get(name) as unknown as Index<T, K, R>;
 }
@@ -240,7 +240,7 @@ export class Index<T extends DocTypes, K extends IndexKeyType = string, R extend
       {
         // getAllEntries returns a different type than range
         result: all.result.map(({ key: [k, id], value }) => ({
-          key: k,
+          key: k as [K, string],
           id,
           value,
         })),

--- a/src/react/use-live-query.ts
+++ b/src/react/use-live-query.ts
@@ -20,11 +20,8 @@ export function createUseLiveQuery(database: Database) {
     const mapFnString = useMemo(() => mapFn.toString(), [mapFn]);
 
     const refreshRows = useCallback(async () => {
-      const res = await database.query<K, T, R>(mapFn, query);
-      setResult({
-        docs: res.rows.map((r) => r.doc).filter((r): r is DocWithId<T> => !!r),
-        rows: res.rows,
-      });
+      const res = await database.query<T, K, R>(mapFn, query);
+      setResult(res);
     }, [database, mapFnString, queryString]);
 
     useEffect(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,7 +460,7 @@ export interface CRDT extends ReadyCloseDestroy, HasLogger, HasSuperThis, HasCRD
 
   readonly blockstore: BaseBlockstore;
   readonly indexBlockstore?: BaseBlockstore;
-  readonly indexers: Map<string, Index<IndexKeyType, DocTypes>>;
+  readonly indexers: Map<string, Index<DocTypes, IndexKeyType>>;
 
   bulk<T extends DocTypes>(updates: DocUpdate<T>[]): Promise<CRDTMeta>;
   ready(): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,7 @@ export interface IndexRow<K extends IndexKeyType, T extends DocObject, R extends
 
 export interface IndexRows<K extends IndexKeyType, T extends DocObject, R extends DocFragment = T> {
   readonly rows: IndexRow<K, T, R>[];
+  readonly docs: DocWithId<T>[];
 }
 export interface CRDTMeta {
   readonly head: ClockHead;

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,7 +289,7 @@ export interface IndexRow<K extends IndexKeyType, T extends DocObject, R extends
   readonly doc?: DocWithId<T>;
 }
 
-export interface IndexRows<K extends IndexKeyType, T extends DocObject, R extends DocFragment = T> {
+export interface IndexRows<T extends DocObject, K extends IndexKeyType = string, R extends DocFragment = T> {
   readonly rows: IndexRow<K, T, R>[];
   readonly docs: DocWithId<T>[];
 }
@@ -605,10 +605,10 @@ export interface Database extends ReadyCloseDestroy, HasLogger, HasSuperThis {
   }>;
   subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void;
 
-  query<K extends IndexKeyType, T extends DocTypes, R extends DocFragment = T>(
+  query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(
     field: string | MapFn<T>,
     opts?: QueryOpts<K>,
-  ): Promise<IndexRows<K, T, R>>;
+  ): Promise<IndexRows<T, K, R>>;
   compact(): Promise<void>;
 }
 

--- a/tests/fireproof/crdt.test.ts
+++ b/tests/fireproof/crdt.test.ts
@@ -356,7 +356,7 @@ describe("Compact a named CRDT with writes", function () {
 
 describe("CRDT with an index", function () {
   let crdt: CRDT;
-  let idx: Index<number, CRDTTestType>;
+  let idx: Index<CRDTTestType, number>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await crdt.close();
@@ -378,7 +378,7 @@ describe("CRDT with an index", function () {
       { id: "ace", value: { points: 11 } },
       { id: "king", value: { points: 10 } },
     ]);
-    idx = await index<number, CRDTTestType>(crdt, "points");
+    idx = await index<CRDTTestType, number>(crdt, "points");
   });
   it("should query the data", async () => {
     const got = await idx.query({ range: [9, 12] });
@@ -387,7 +387,7 @@ describe("CRDT with an index", function () {
     expect(got.rows[0].key).toBe(10);
   });
   it("should register the index", async () => {
-    const rIdx = await index<number, CRDTTestType>(crdt, "points");
+    const rIdx = await index<CRDTTestType, number>(crdt, "points");
     expect(rIdx).toBeTruthy();
     expect(rIdx.name).toBe("points");
     const got = await rIdx.query({ range: [9, 12] });

--- a/tests/fireproof/fireproof.test.ts
+++ b/tests/fireproof/fireproof.test.ts
@@ -39,7 +39,7 @@ describe("dreamcode", function () {
   }
   let ok: DocResponse;
   let doc: DocWithId<Doc>;
-  let result: IndexRows<string, Doc>;
+  let result: IndexRows<Doc, string>;
   let db: Database;
   const sthis = ensureSuperThis();
   afterEach(async () => {
@@ -67,7 +67,7 @@ describe("dreamcode", function () {
     expect(result.rows[0].key).toBe("fireproof");
   });
   it("should query with function", async () => {
-    const result = await db.query<boolean, Doc>((doc) => doc.dream);
+    const result = await db.query<Doc, boolean>((doc) => doc.dream);
     expect(result).toBeTruthy();
     expect(result.rows).toBeTruthy();
     expect(result.rows.length).toBe(1);
@@ -82,7 +82,7 @@ describe("public API", function () {
   let db: Database;
   let ok: DocResponse;
   let doc: DocWithId<Doc>;
-  let query: IndexRows<string, Doc>;
+  let query: IndexRows<Doc, string>;
   const sthis = ensureSuperThis();
 
   afterEach(async () => {
@@ -96,7 +96,7 @@ describe("public API", function () {
     // index = index(db, 'test-index', (doc) => doc.foo)
     ok = await db.put({ _id: "test", foo: "bar" });
     doc = await db.get("test");
-    query = await db.query<string, Doc>((doc) => doc.foo);
+    query = await db.query<Doc, string>((doc) => doc.foo);
   });
   it("should be a ledger instance", function () {
     expect(db).toBeTruthy();
@@ -199,7 +199,7 @@ describe("basic ledger", function () {
   it("can define an index", async () => {
     const ok = await db.put({ _id: "test", foo: "bar" });
     expect(ok).toBeTruthy();
-    const idx = index<string, { foo: string }>(db, "test-index", (doc) => doc.foo);
+    const idx = index<{ foo: string }, string>(db, "test-index", (doc) => doc.foo);
     const result = await idx.query();
     expect(result).toBeTruthy();
     expect(result.rows).toBeTruthy();
@@ -223,10 +223,10 @@ describe("basic ledger", function () {
       baz: string;
     }
     await db.put<TestDoc>({ _id: "test", foo: "bar", baz: "qux" });
-    const query1 = await db.query<string, TestDoc>((doc) => {
+    const query1 = await db.query<TestDoc, string>((doc) => {
       return doc.foo;
     });
-    const query2 = await db.query<string, TestDoc>((doc) => {
+    const query2 = await db.query<TestDoc, string>((doc) => {
       return doc.baz;
     });
     expect(query1).toBeTruthy();
@@ -550,7 +550,7 @@ describe("Reopening a ledger with indexes", function () {
     foo: string;
   }
   let db: Database;
-  let idx: Index<string, Doc>;
+  let idx: Index<Doc, string>;
   let didMap: boolean;
   let mapFn: MapFn<Doc>;
   const sthis = ensureSuperThis();
@@ -570,13 +570,13 @@ describe("Reopening a ledger with indexes", function () {
       didMap = true;
       return doc.foo;
     };
-    idx = index<string, Doc>(db, "foo", mapFn);
+    idx = index<Doc, string>(db, "foo", mapFn);
   });
 
   it("should persist data", async () => {
     const doc = await db.get<Doc>("test");
     expect(doc.foo).toBe("bar");
-    const idx2 = index<string, Doc>(db, "foo");
+    const idx2 = index<Doc, string>(db, "foo");
     expect(idx2).toBe(idx);
     const result = await idx2.query();
     expect(result).toBeTruthy();

--- a/tests/fireproof/hello.test.ts
+++ b/tests/fireproof/hello.test.ts
@@ -24,7 +24,7 @@ describe("hello public API", () => {
   beforeEach(async () => {
     await sthis.start();
     db = fireproof("test-public-api");
-    index<string, TestDoc>(db, "test-index", (doc) => doc.foo);
+    index<TestDoc, string>(db, "test-index", (doc) => doc.foo);
     ok = await db.put({ _id: "test", foo: "bar" });
     doc = await db.get("test");
   });

--- a/tests/fireproof/indexer.test.ts
+++ b/tests/fireproof/indexer.test.ts
@@ -23,7 +23,7 @@ interface TestType {
 
 describe("basic Index", () => {
   let db: Database;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType, string>;
   let didMap: boolean;
   const sthis = ensureSuperThis();
   afterEach(async () => {
@@ -38,7 +38,7 @@ describe("basic Index", () => {
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
-    indexer = new Index<string, TestType>(sthis, db.ledger.crdt, "hello", (doc) => {
+    indexer = new Index<TestType, string>(sthis, db.ledger.crdt, "hello", (doc) => {
       didMap = true;
       return doc.title;
     });
@@ -111,7 +111,7 @@ describe("basic Index", () => {
 
 describe("Index query with compound key", function () {
   let db: Database;
-  let indexer: Index<[string, number], TestType>;
+  let indexer: Index<TestType, [string, number]>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -126,7 +126,7 @@ describe("Index query with compound key", function () {
     await db.put({ title: "creative", score: 2 });
     await db.put({ title: "creative", score: 20 });
     await db.put({ title: "bazillas", score: 3 });
-    indexer = new Index<[string, number], TestType>(sthis, db.ledger.crdt, "hello", (doc) => {
+    indexer = new Index<TestType, [string, number]>(sthis, db.ledger.crdt, "hello", (doc) => {
       return [doc.title, doc.score];
     });
     await indexer.ready();
@@ -141,7 +141,7 @@ describe("Index query with compound key", function () {
 
 describe("basic Index with map fun", function () {
   let db: Database;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType, string>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -155,7 +155,7 @@ describe("basic Index with map fun", function () {
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
-    indexer = new Index<string, TestType>(sthis, db.ledger.crdt, "hello", (doc, map) => {
+    indexer = new Index<TestType, string>(sthis, db.ledger.crdt, "hello", (doc, map) => {
       map(doc.title);
     });
     await indexer.ready();
@@ -171,7 +171,7 @@ describe("basic Index with map fun", function () {
 
 describe("basic Index with map fun with value", function () {
   let db: Database;
-  let indexer: Index<string, TestType, number>;
+  let indexer: Index<TestType, string, number>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -183,7 +183,7 @@ describe("basic Index with map fun with value", function () {
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
-    indexer = new Index<string, TestType, number>(sthis, db.ledger.crdt, "hello", (doc, map) => {
+    indexer = new Index<TestType, string, number>(sthis, db.ledger.crdt, "hello", (doc, map) => {
       map(doc.title, doc.title.length);
     });
   });
@@ -209,7 +209,7 @@ describe("basic Index with map fun with value", function () {
 
 describe("Index query with map and compound key", function () {
   let db: Database;
-  let indexer: Index<[string, number], TestType>;
+  let indexer: Index<TestType, [string, number]>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -224,7 +224,7 @@ describe("Index query with map and compound key", function () {
     await db.put({ title: "creative", score: 2 });
     await db.put({ title: "creative", score: 20 });
     await db.put({ title: "bazillas", score: 3 });
-    indexer = new Index<[string, number], TestType>(sthis, db.ledger.crdt, "hello", (doc, emit) => {
+    indexer = new Index<TestType, [string, number]>(sthis, db.ledger.crdt, "hello", (doc, emit) => {
       emit([doc.title, doc.score]);
     });
     await indexer.ready();
@@ -239,7 +239,7 @@ describe("Index query with map and compound key", function () {
 
 describe("basic Index with string fun", function () {
   let db: Database;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType, string>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -253,7 +253,7 @@ describe("basic Index with string fun", function () {
     await db.put({ title: "amazing" });
     await db.put({ title: "creative" });
     await db.put({ title: "bazillas" });
-    indexer = new Index<string, TestType>(sthis, db.ledger.crdt, "title");
+    indexer = new Index<TestType, string>(sthis, db.ledger.crdt, "title");
     await indexer.ready();
   });
   it("should get results", async () => {
@@ -271,7 +271,7 @@ describe("basic Index with string fun", function () {
 
 describe("basic Index with string fun and numeric keys", function () {
   let db: Database;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType, string>;
   const sthis = ensureSuperThis();
   afterEach(async () => {
     await db.close();
@@ -286,7 +286,7 @@ describe("basic Index with string fun and numeric keys", function () {
     await db.put({ points: 1 });
     await db.put({ points: 2 });
     await db.put({ points: 3 });
-    indexer = new Index<string, TestType>(sthis, db.ledger.crdt, "points");
+    indexer = new Index<TestType, string>(sthis, db.ledger.crdt, "points");
     await indexer.ready();
   });
   it("should get results", async () => {
@@ -308,10 +308,10 @@ describe("basic Index upon cold start", function () {
     score?: number;
   }
   let crdt: CRDT;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType>;
   let didMap: number;
   let mapFn: (doc: TestType) => string;
-  let result: IndexRows<string, TestType>;
+  let result: IndexRows<TestType>;
   const sthis = ensureSuperThis();
   let dbOpts: LedgerOpts;
   // result, mapFn;
@@ -346,7 +346,7 @@ describe("basic Index upon cold start", function () {
       didMap++;
       return doc.title;
     };
-    indexer = await index<string, TestType>(crdt, "hello", mapFn);
+    indexer = await index<TestType>(crdt, "hello", mapFn);
     logger.Debug().Msg("post index beforeEach");
     await indexer.ready();
     logger.Debug().Msg("post indexer.ready beforeEach");
@@ -371,7 +371,7 @@ describe("basic Index upon cold start", function () {
     const { result, head } = await crdt2.changes();
     expect(result).toBeTruthy();
     await crdt2.ready();
-    const indexer2 = await index<string, TestType>(crdt2, "hello", mapFn);
+    const indexer2 = await index<TestType>(crdt2, "hello", mapFn);
     await indexer2.ready();
     const result2 = await indexer2.query();
     expect(indexer2.indexHead).toEqual(head);
@@ -407,7 +407,7 @@ describe("basic Index upon cold start", function () {
   });
   it("should ignore meta when map function definiton changes", async () => {
     const crdt2 = new CRDTImpl(sthis, dbOpts);
-    const result = await index<string, TestType>(crdt2, "hello", (doc) => doc.title.split("").reverse().join("")).query();
+    const result = await index<TestType>(crdt2, "hello", (doc) => doc.title.split("").reverse().join("")).query();
     expect(result.rows.length).toEqual(3);
     expect(result.rows[0].key).toEqual("evitaerc"); // creative
   });
@@ -415,7 +415,7 @@ describe("basic Index upon cold start", function () {
 
 describe("basic Index with no data", function () {
   let db: Database;
-  let indexer: Index<string, TestType>;
+  let indexer: Index<TestType>;
   let didMap: boolean;
   const sthis = ensureSuperThis();
   afterEach(async () => {
@@ -427,7 +427,7 @@ describe("basic Index with no data", function () {
   beforeEach(async () => {
     await sthis.start();
     db = fireproof("test-indexer");
-    indexer = new Index<string, TestType>(sthis, db.ledger.crdt, "hello", (doc) => {
+    indexer = new Index<TestType>(sthis, db.ledger.crdt, "hello", (doc) => {
       didMap = true;
       return doc.title;
     });

--- a/tests/fireproof/query-docs.test.ts
+++ b/tests/fireproof/query-docs.test.ts
@@ -28,7 +28,7 @@ describe("query return value consistency", function () {
 
   it("database query should return docs property like useLiveQuery", async function () {
     // This test should initially fail because the query method doesn't return docs yet
-    const result = await db.query<string, TestDoc>("category");
+    const result = await db.query<TestDoc>("category");
 
     // Check that rows property exists (this should pass)
     expect(result).toHaveProperty("rows");
@@ -45,7 +45,7 @@ describe("query return value consistency", function () {
   });
 
   it("should return docs with the same order as rows", async function () {
-    const result = await db.query<string, TestDoc>("category");
+    const result = await db.query<TestDoc>("category");
 
     // Ensure docs array exists
     expect(result).toHaveProperty("docs");
@@ -60,7 +60,7 @@ describe("query return value consistency", function () {
 
   it("should work with complex map functions and query options", async function () {
     // Test with a map function and query options
-    const result = await db.query<boolean, TestDoc>((doc) => doc.active, {
+    const result = await db.query<TestDoc, boolean>((doc) => doc.active, {
       key: true,
       includeDocs: true,
     });

--- a/tests/fireproof/query-docs.test.ts
+++ b/tests/fireproof/query-docs.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import {
-  Database,
-  DocWithId,
-  ensureSuperThis,
-  fireproof,
-  IndexRows
-} from "@fireproof/core";
+import { Database, DocWithId, ensureSuperThis, fireproof } from "@fireproof/core";
 
 interface TestDoc {
   text: string;
@@ -20,7 +14,7 @@ describe("query return value consistency", function () {
   beforeEach(async () => {
     await sthis.start();
     db = fireproof("test-query-docs");
-    
+
     // Add test documents
     await db.put({ _id: "doc1", text: "hello world", category: "greeting", active: true });
     await db.put({ _id: "doc2", text: "goodbye world", category: "farewell", active: true });
@@ -35,27 +29,27 @@ describe("query return value consistency", function () {
   it("database query should return docs property like useLiveQuery", async function () {
     // This test should initially fail because the query method doesn't return docs yet
     const result = await db.query<string, TestDoc>("category");
-    
+
     // Check that rows property exists (this should pass)
     expect(result).toHaveProperty("rows");
     expect(result.rows.length).toBe(3);
-    
+
     // Check that docs property exists (this should fail until we implement the feature)
     expect(result).toHaveProperty("docs");
     expect(Array.isArray(result.docs)).toBe(true);
     expect(result.docs.length).toBe(3);
-    
+
     // Verify docs contain the correct document data
-    const docIds = result.docs.map(doc => doc._id).sort();
+    const docIds = result.docs.map((doc) => doc._id).sort();
     expect(docIds).toEqual(["doc1", "doc2", "doc3"]);
   });
 
   it("should return docs with the same order as rows", async function () {
     const result = await db.query<string, TestDoc>("category");
-    
+
     // Ensure docs array exists
     expect(result).toHaveProperty("docs");
-    
+
     // Verify the order matches between rows and docs
     for (let i = 0; i < result.rows.length; i++) {
       const row = result.rows[i];
@@ -66,20 +60,20 @@ describe("query return value consistency", function () {
 
   it("should work with complex map functions and query options", async function () {
     // Test with a map function and query options
-    const result = await db.query<boolean, TestDoc>(doc => doc.active, { 
-      key: true, 
-      includeDocs: true 
+    const result = await db.query<boolean, TestDoc>((doc) => doc.active, {
+      key: true,
+      includeDocs: true,
     });
-    
+
     // Check rows (this should pass)
     expect(result.rows.length).toBeGreaterThan(0);
-    
+
     // Check docs property (this should fail until we implement the feature)
     expect(result).toHaveProperty("docs");
     expect(result.docs.length).toBe(result.rows.length);
-    
+
     // Verify all returned docs are active
-    result.docs.forEach(doc => {
+    result.docs.forEach((doc) => {
       // Since we know these are TestDoc documents
       expect((doc as DocWithId<TestDoc>).active).toBe(true);
     });

--- a/tests/fireproof/query-docs.test.ts
+++ b/tests/fireproof/query-docs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import {
+  Database,
+  DocWithId,
+  ensureSuperThis,
+  fireproof,
+  IndexRows
+} from "@fireproof/core";
+
+interface TestDoc {
+  text: string;
+  category: string;
+  active: boolean;
+}
+
+describe("query return value consistency", function () {
+  let db: Database;
+  const sthis = ensureSuperThis();
+
+  beforeEach(async () => {
+    await sthis.start();
+    db = fireproof("test-query-docs");
+    
+    // Add test documents
+    await db.put({ _id: "doc1", text: "hello world", category: "greeting", active: true });
+    await db.put({ _id: "doc2", text: "goodbye world", category: "farewell", active: true });
+    await db.put({ _id: "doc3", text: "hello again", category: "greeting", active: false });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    await db.destroy();
+  });
+
+  it("database query should return docs property like useLiveQuery", async function () {
+    // This test should initially fail because the query method doesn't return docs yet
+    const result = await db.query<string, TestDoc>("category");
+    
+    // Check that rows property exists (this should pass)
+    expect(result).toHaveProperty("rows");
+    expect(result.rows.length).toBe(3);
+    
+    // Check that docs property exists (this should fail until we implement the feature)
+    expect(result).toHaveProperty("docs");
+    expect(Array.isArray(result.docs)).toBe(true);
+    expect(result.docs.length).toBe(3);
+    
+    // Verify docs contain the correct document data
+    const docIds = result.docs.map(doc => doc._id).sort();
+    expect(docIds).toEqual(["doc1", "doc2", "doc3"]);
+  });
+
+  it("should return docs with the same order as rows", async function () {
+    const result = await db.query<string, TestDoc>("category");
+    
+    // Ensure docs array exists
+    expect(result).toHaveProperty("docs");
+    
+    // Verify the order matches between rows and docs
+    for (let i = 0; i < result.rows.length; i++) {
+      const row = result.rows[i];
+      const doc = result.docs[i];
+      expect(doc._id).toBe(row.id);
+    }
+  });
+
+  it("should work with complex map functions and query options", async function () {
+    // Test with a map function and query options
+    const result = await db.query<boolean, TestDoc>(doc => doc.active, { 
+      key: true, 
+      includeDocs: true 
+    });
+    
+    // Check rows (this should pass)
+    expect(result.rows.length).toBeGreaterThan(0);
+    
+    // Check docs property (this should fail until we implement the feature)
+    expect(result).toHaveProperty("docs");
+    expect(result.docs.length).toBe(result.rows.length);
+    
+    // Verify all returned docs are active
+    result.docs.forEach(doc => {
+      // Since we know these are TestDoc documents
+      expect((doc as DocWithId<TestDoc>).active).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
for #802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new document outlining changes to standardize the structure and type parameter order of database query results for improved consistency with related React hooks.  
- **New Features**
  - Query results now consistently include both `rows` and `docs` for easier access to documents.  
  - Standardized the type parameter order across database queries and related APIs for consistency.  
- **Tests**
  - Added tests verifying the presence, order, and correctness of `docs` alongside `rows` in query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->