### PR TITLE
fix: update blockLength calls with proper CID type casting in commitor.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:indexeddb": "vitest --config vitest.indexeddb.config.ts --run",
     "test:deno": "deno run --quiet --allow-net --allow-write --allow-run  --allow-sys --allow-ffi  --allow-read --allow-env  ./node_modules/vitest/vitest.mjs --run --project file",
     "format": "prettier .",
-    "check": "pnpm format --write && pnpm lint && pnpm test",
+    "check": "pnpm format --write && pnpm lint && pnpm test && pnpm build",
     "lint": "eslint",
     "drizzle:libsql": "drizzle-kit push --config ./cloud/backend/node/drizzle.cloud.libsql.config.ts",
     "drizzle:d1-local": "drizzle-kit push --config ./cloud/backend/cf-d1/drizzle.cloud.d1-local.config.ts",

--- a/src/blockstore/commitor.ts
+++ b/src/blockstore/commitor.ts
@@ -181,11 +181,11 @@ async function prepareCarFiles(
   let clonedt = new CarTransactionImpl(t.parent, { add: false, noLoader: false });
   // console.log("prepareCarFiles-root", rootBlock.cid.toString());
   clonedt.putSync(rootBlock);
-  let newsize = CBW.blockLength(rootBlock);
+  let newsize = CBW.blockLength({ cid: rootBlock.cid as CID<unknown, number, number, 1>, bytes: rootBlock.bytes } as CBW.Block);
   let cidRootBlock = rootBlock;
   for await (const fpblock of t.entries()) {
     // console.log("prepareCarFiles", cid.toString(), bytes.length);
-    newsize += CBW.blockLength(fpblock);
+    newsize += CBW.blockLength({ cid: fpblock.cid as CID<unknown, number, number, 1>, bytes: fpblock.bytes } as CBW.Block);
     // ktoCIDBlock({ cid: cid, bytes }));
     // console.log("prepareCarFiles", cid.toString(), bytes.length)
     if (newsize >= threshold) {
@@ -193,7 +193,7 @@ async function prepareCarFiles(
       clonedt = new CarTransactionImpl(t.parent, { add: false, noLoader: false });
       clonedt.putSync(fpblock);
       cidRootBlock = fpblock;
-      newsize = CBW.blockLength(fpblock);
+      newsize = CBW.blockLength({ cid: fpblock.cid as CID<unknown, number, number, 1>, bytes: fpblock.bytes } as CBW.Block);
     } else {
       clonedt.putSync(fpblock);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "check" script to include the build process after formatting, linting, and testing. No user-facing functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->