### PR TITLE
ignore dizzle kit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+ignore:
+  - dependency-name: "drizzle-kit:*"
+    versions: [ ">=0.30.7" ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings to ignore updates for "drizzle-kit" versions 0.30.7 and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->