### PR TITLE
feat: add quiet flags to reduce build output verbosity

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:indexeddb": "vitest --config vitest.indexeddb.config.ts --run",
     "test:deno": "deno run --quiet --allow-net --allow-write --allow-run  --allow-sys --allow-ffi  --allow-read --allow-env  ./node_modules/vitest/vitest.mjs --run --project core:file",
     "format": "prettier .",
-    "check": "pnpm format --write && pnpm lint && pnpm test && pnpm build",
+    "check": "pnpm format --write --log-level silent && pnpm lint --quiet && pnpm test && pnpm build",
     "lint": "eslint",
     "drizzle:libsql": "drizzle-kit push --config ./cloud/backend/node/drizzle.cloud.libsql.config.ts",
     "drizzle:d1-local": "drizzle-kit push --config ./cloud/backend/cf-d1/drizzle.cloud.d1-local.config.ts",


### PR DESCRIPTION
## Summary
- Add `--log-level silent` flag to prettier in the root check script
- Add `--quiet` flag to eslint in the root check script
- Reduces verbose output during builds and checks for cleaner CI/developer experience

## Test plan
- [x] Verify check script runs without excessive output
- [x] Confirm all existing functionality is preserved
- [x] Test that errors are still properly reported

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script commands to reduce output noise during formatting and linting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->