### PR TITLE
feat: add npm tag logic to core-publish action

### DIFF
--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -24,4 +24,18 @@ runs:
         echo "//registry.npmjs.org/:_authToken=${{ inputs.NPM_TOKEN }}" > ~/.npmrc
         mkdir -p dist
         echo "//registry.npmjs.org/:_authToken=${{ inputs.NPM_TOKEN }}" > dist/npmrc-smoke
-        pnpm run publish --registry https://registry.npmjs.org/
+        
+        # Extract version from tag and determine npm tag
+        TAG_NAME=$(git describe --tags --abbrev=0)
+        VERSION=${TAG_NAME#*@v}  # Remove prefix up to @v
+        if [[ "$VERSION" == *"-"* ]]; then
+          # Version contains dash (pre-release) - publish to 'dev' tag
+          NPM_TAG="dev"
+          echo "Publishing pre-release version $VERSION to 'dev' tag"
+        else
+          # Version has no dash (stable release) - publish to 'latest' tag
+          NPM_TAG="latest"
+          echo "Publishing stable version $VERSION to 'latest' tag"
+        fi
+        
+        pnpm run publish --registry https://registry.npmjs.org/ --tag $NPM_TAG


### PR DESCRIPTION
## Summary
- Modifies the core-publish action to automatically determine npm tag based on version format
- Pre-release versions (with dash) publish to `dev` tag 
- Stable versions (no dash) publish to `latest` tag

## Changes
- Added version extraction logic to detect dash in tag names
- Added conditional npm tag assignment (`dev` vs `latest`)
- Updated publish command to use the determined tag

## Examples  
- `core@v0.22.0-lazy` → publishes to `dev` tag
- `core@v0.22.0-dev-preview-1` → publishes to `dev` tag  
- `core@v0.22.0` → publishes to `latest` tag

## Test plan
- [x] Logic tested with sample tags - all work correctly
- [x] Tested with `core@v0.22.0-lazy` tag (published to dev)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing process to automatically assign the appropriate npm tag ("dev" for pre-releases, "latest" for stable versions) based on the latest Git tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->