### PR TITLE
fix: extend timeout for concurrent test

### DIFF
--- a/core/tests/fireproof/concurrent.test.ts
+++ b/core/tests/fireproof/concurrent.test.ts
@@ -33,5 +33,5 @@ describe("concurrent opens", () => {
     }
 
     await future.asPromise();
-  });
+  }, 30000); // 30 second timeout for concurrent operations
 });


### PR DESCRIPTION
## Summary
Fixes test timeout failures in `fireproof/concurrent.test.ts` by extending the timeout from 5 seconds to 30 seconds.

## Problem
The concurrent test creates 100 database operations with random delays, which frequently exceeded the default 5000ms timeout:
```
Error: Test timed out in 5000ms.
```

## Solution
- Extended test timeout to 30 seconds (30000ms)
- This provides sufficient time for all 100 concurrent database operations to complete
- The test creates databases, performs 3 puts each, queries allDocs, and closes - operations that need time to complete concurrently

## Test Results
- ✅ Test now has adequate time to complete all concurrent operations
- ✅ No changes to test logic, only timeout extension

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a specific test case in the concurrent operations suite to 30 seconds to ensure reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->