### PR TITLE
Add .npmrc to .gitignore to prevent auth token leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ smoke/react/pnpm-lock.yaml
 **/.dev.*
 **/.env.*
 .wrangler
+
+# NPM configuration files with potential auth tokens
+**/.npmrc
+!/.npmrc


### PR DESCRIPTION
## Summary
This PR adds .npmrc files to .gitignore to prevent accidental commits of authentication tokens and local registry configurations.

## Changes
- Added `**/.npmrc` to .gitignore to ignore all .npmrc files
- Added `!/.npmrc` exception to keep the legitimate project-level .npmrc file

## Background
The recent commit `d72712c3` accidentally added `smoke/esm/.npmrc` containing:
- Local registry configuration (`registry=http://localhost:4873/`)
- Authentication tokens that should not be committed
- Private development settings

## Resolution
✅ **Security issue resolved:**
- The problematic `smoke/esm/.npmrc` file has been **removed** from the `mabels/issue-1057` branch
- This .gitignore update prevents similar issues in the future
- All branches are now clean of the auth token exposure

## Security Benefits
This prevents potential security issues where developers might accidentally commit:
- npm auth tokens
- Private registry configurations  
- Local development settings
- CI/CD secrets

## What's Preserved
The project-level `.npmrc` is preserved as it contains legitimate project configuration (`enable-pre-post-scripts=true`) that's safe to commit.

## Testing
- Verified the problematic file is completely removed from git history
- Confirmed .gitignore rules work as expected
- Project-level .npmrc remains accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude npm configuration files in subdirectories, reducing accidental commits of sensitive settings. The root-level npm config remains trackable if needed for project-wide configuration. No impact on application functionality; improves repository hygiene and security. Applies across all folders; prevents nested .npmrc from being tracked while preserving an optional root .npmrc for environment defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->