### PR TITLE
feat: add parameterized D1 scripts for tenant maxLedgers management

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,6 +18,9 @@
     "drizzle:libsql": "drizzle-kit push --config ./drizzle.libsql.config.ts",
     "drizzle:d1-local": "drizzle-kit push --config ./drizzle.d1-local-backend.config.ts",
     "drizzle:d1-remote": "drizzle-kit push --config ./drizzle.d1-remote.config.ts",
+    "d1:update-tenant-ledgers:dev": "wrangler d1 execute fp-connect-dev --remote --command \"UPDATE Tenants SET maxLedgers=$MAX_LEDGERS WHERE tenantId='$TENANT_ID'\"",
+    "d1:update-tenant-ledgers:staging": "wrangler d1 execute fp-connect-staging --remote --command \"UPDATE Tenants SET maxLedgers=$MAX_LEDGERS WHERE tenantId='$TENANT_ID'\"",
+    "d1:update-tenant-ledgers:prod": "wrangler d1 execute fp-connect-production --remote --command \"UPDATE Tenants SET maxLedgers=$MAX_LEDGERS WHERE tenantId='$TENANT_ID'\"",
     "pack": "echo dashboard need not to pack",
     "publish": "echo skip"
   },


### PR DESCRIPTION
## Summary
- Add parameterized npm scripts to update tenant maxLedgers limits across D1 databases
- Support for dev, staging, and production environments  
- Uses environment variables for safe tenant ID and limit specification

## Scripts Added
- `d1:update-tenant-ledgers:dev` - Update limits in development database
- `d1:update-tenant-ledgers:staging` - Update limits in staging database  
- `d1:update-tenant-ledgers:prod` - Update limits in production database

## Usage
```bash
MAX_LEDGERS=100000 TENANT_ID=xyz pnpm run d1:update-tenant-ledgers:dev
```

## Test plan
- [x] Tested dev script with tenant `z4PVsAz8fHkwBeYB2M` 
- [x] Verified parameter substitution works correctly
- [x] Confirmed database updates are applied successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added internal maintenance scripts to remotely update tenant ledger limits across environments (development, staging, production).
  - Standardizes and streamlines operational updates for support/ops, reducing manual steps and risk.
  - No impact to application behavior, performance, or UI; end users remain unaffected.
  - No dependency changes and no downtime required.
  - Intended solely for internal operations and environment maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->