### PR TITLE
feat: add Version class with versionPrefix CLI option

### DIFF
--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -68,7 +68,7 @@ class Version {
   #version: string;
   #versionPrefix: string;
 
-  constructor(version: string, versionPrefix = "") {
+  constructor(version: string, versionPrefix: string) {
     this.#version = version;
     this.#versionPrefix = versionPrefix;
   }

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -22,7 +22,10 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1").replace(reVersionRangePrefix, "$1");
+  const calculatedVersion = wversion
+    .replace(reScopedVersion, "$1")
+    .replace(reVersionAlphaStart, "$1")
+    .replace(reVersionRangePrefix, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -10,7 +10,6 @@ import { SemVer } from "semver";
 const reVersionAlphaStart = /^[a-z](\d+\.\d+\.\d+.*)$/;
 // const reVersionOptionalAlphaStart = /^[a-z]?(\d+\.\d+\.\d+.*)$/;
 const reScopedVersion = /^[^@]+@(.*)$/;
-const reVersionRangePrefix = /^[~^](\d+\.\d+\.\d+.*)$/;
 const reEndVersion = /.*\/([^/]+)$/;
 
 function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
@@ -22,10 +21,7 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion
-    .replace(reScopedVersion, "$1")
-    .replace(reVersionAlphaStart, "$1")
-    .replace(reVersionRangePrefix, "$1");
+  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;
@@ -382,8 +378,10 @@ export function buildCmd(sthis: SuperThis) {
       if (args.prepareVersion) {
         await fs.mkdirp(args.dstDir);
         const fpVersionFile = path.join(args.dstDir, "fp-version.txt");
-        await fs.writeFile(fpVersionFile, version.version);
-        console.log(`Using version: ${version.prefixedVersion}`);
+        const rawVersion = await getVersion(args.fpVersion);
+        const vx = new Version(rawVersion, args.versionPrefix);
+        await fs.writeFile(fpVersionFile, vx.version);
+        console.log(`Using version: ${vx.version}`);
         return;
       }
       if (args.srcDir === args.dstDir) {

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -331,7 +331,7 @@ export function buildCmd(sthis: SuperThis) {
       }),
       versionPrefix: option({
         long: "versionPrefix",
-        short: "p",
+        short: "x",
         type: string,
         defaultValue: () => "",
         description: "Prefix to use for the version.",

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -71,7 +71,7 @@ function getPrefixedVersion(version: string, versionPrefix: string): string {
   return `${versionPrefix}${version}`;
 }
 
-function patchDeps(dep: Record<string, string>, version: string, versionPrefix: string = "") {
+function patchDeps(dep: Record<string, string>, version: string, versionPrefix = "") {
   if (typeof dep !== "object" || !dep) {
     return;
   }

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -10,6 +10,7 @@ import { SemVer } from "semver";
 const reVersionAlphaStart = /^[a-z](\d+\.\d+\.\d+.*)$/;
 // const reVersionOptionalAlphaStart = /^[a-z]?(\d+\.\d+\.\d+.*)$/;
 const reScopedVersion = /^[^@]+@(.*)$/;
+const reVersionRangePrefix = /^[~^](\d+\.\d+\.\d+.*)$/;
 const reEndVersion = /.*\/([^/]+)$/;
 
 function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
@@ -21,7 +22,7 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1");
+  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1").replace(reVersionRangePrefix, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;
@@ -362,7 +363,7 @@ export function buildCmd(sthis: SuperThis) {
         const fpVersionFile = path.join(args.dstDir, "fp-version.txt");
         args.version = await getVersion(args.fpVersion);
         const prefixedVersion = getPrefixedVersion(args.version, args.versionPrefix);
-        await fs.writeFile(fpVersionFile, prefixedVersion);
+        await fs.writeFile(fpVersionFile, args.version);
         console.log(`Using version: ${prefixedVersion}`);
         return;
       }

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -485,7 +485,7 @@ describe("Remote Sync Subscription Tests", () => {
 
       // Verify data was synced correctly across all databases
       // Wait for sync completion before checking all keys
-      await sleep(3000);
+      await sleep(5000);
 
       await Promise.all(
         dbs.map(async (db) => {

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -488,7 +488,7 @@ describe("Remote Sync Subscription Tests", () => {
       await Promise.all(
         dbs.map(async (db) => {
           let attempts = 0;
-          const maxAttempts = 10;
+          const maxAttempts = 20;
 
           while (attempts < maxAttempts) {
             try {

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -3,7 +3,7 @@ import { Attachable, Database, fireproof, GatewayUrlsParam, PARAM, DocBase } fro
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureSuperThis, sleep } from "@fireproof/core-runtime";
 
-const ROWS = 2;
+const ROWS = 1;
 
 class AJoinable implements Attachable {
   readonly name: string;

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -3,7 +3,7 @@ import { Attachable, Database, fireproof, GatewayUrlsParam, PARAM, DocBase } fro
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ensureSuperThis, sleep } from "@fireproof/core-runtime";
 
-const ROWS = 1;
+const ROWS = 2;
 
 class AJoinable implements Attachable {
   readonly name: string;
@@ -484,26 +484,14 @@ describe("Remote Sync Subscription Tests", () => {
       expect(totalSubscriptionFires).toBeGreaterThanOrEqual(dbs.length);
 
       // Verify data was synced correctly across all databases
-      // Wait for sync completion before checking all keys - retry up to 10 times with 1s intervals
+      // Wait for sync completion before checking all keys
+      await sleep(2000);
+
       await Promise.all(
         dbs.map(async (db) => {
-          let attempts = 0;
-          const maxAttempts = 10;
-
-          while (attempts < maxAttempts) {
-            try {
-              const allDocs = await db.db.allDocs();
-              // console.log(allDocs.rows);
-              expect(allDocs.rows.length).toBe(keys.length * 2);
-              break; // Success - exit retry loop
-            } catch (e) {
-              attempts++;
-              if (attempts >= maxAttempts) {
-                throw e; // Re-throw the error after max attempts
-              }
-              await sleep(5000); // Wait 1.5 seconds before retry
-            }
-          }
+          const allDocs = await db.db.allDocs();
+          // console.log(allDocs.rows);
+          expect(allDocs.rows.length).toBe(keys.length * 2);
           // for (const key of keys) {
           //   try {
           //     const doc = await db.db.get<{ value: string }>(key);

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -488,7 +488,7 @@ describe("Remote Sync Subscription Tests", () => {
       await Promise.all(
         dbs.map(async (db) => {
           let attempts = 0;
-          const maxAttempts = 20;
+          const maxAttempts = 10;
 
           while (attempts < maxAttempts) {
             try {
@@ -501,7 +501,7 @@ describe("Remote Sync Subscription Tests", () => {
               if (attempts >= maxAttempts) {
                 throw e; // Re-throw the error after max attempts
               }
-              await sleep(3000); // Wait 1.5 seconds before retry
+              await sleep(5000); // Wait 1.5 seconds before retry
             }
           }
           // for (const key of keys) {

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -501,7 +501,7 @@ describe("Remote Sync Subscription Tests", () => {
               if (attempts >= maxAttempts) {
                 throw e; // Re-throw the error after max attempts
               }
-              await sleep(1500); // Wait 1.5 seconds before retry
+              await sleep(3000); // Wait 1.5 seconds before retry
             }
           }
           // for (const key of keys) {

--- a/core/tests/fireproof/attachable-subscription.test.ts
+++ b/core/tests/fireproof/attachable-subscription.test.ts
@@ -485,7 +485,7 @@ describe("Remote Sync Subscription Tests", () => {
 
       // Verify data was synced correctly across all databases
       // Wait for sync completion before checking all keys
-      await sleep(2000);
+      await sleep(3000);
 
       await Promise.all(
         dbs.map(async (db) => {


### PR DESCRIPTION
## Summary
- Add Version class to encapsulate version handling with optional prefix
- Add `--versionPrefix` CLI option to build command for flexible version references
- Replace manual version prefix logic with clean getter-based API

## Changes
- **Version class**: Encapsulates version and versionPrefix with clean getters
  - `version` getter returns raw version string
  - `prefixedVersion` getter returns version with optional prefix (e.g., `^1.2.3`)
- **CLI option**: `--versionPrefix` allows setting prefix for workspace dependencies
- **Clean refactor**: Replace ad-hoc version handling with class-based approach

## Use case
Enables building packages with caret version references (`^1.2.3`) instead of exact versions (`1.2.3`) for more flexible dependency management.

## Test plan
- Existing build functionality should work unchanged (no prefix = exact versions)
- New `--versionPrefix "^"` option should produce caret-prefixed dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build command option --versionPrefix (-x) to apply a user-specified prefix to workspace dependency versions during patching.
  - Normalizes versions by ignoring leading ~ or ^ when determining the stored version.
  - fp-version.txt continues to store the raw version while workspace dependencies receive the chosen prefix.

- **Chores**
  - Updated patching flow to propagate version prefixes through package dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->