### PR TITLE
Jchris/build option

### DIFF
--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -68,7 +68,7 @@ class Version {
   #version: string;
   #versionPrefix: string;
 
-  constructor(version: string, versionPrefix = "") {
+  constructor(version: string, versionPrefix: string) {
     this.#version = version;
     this.#versionPrefix = versionPrefix;
   }

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -22,7 +22,10 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1").replace(reVersionRangePrefix, "$1");
+  const calculatedVersion = wversion
+    .replace(reScopedVersion, "$1")
+    .replace(reVersionAlphaStart, "$1")
+    .replace(reVersionRangePrefix, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -10,7 +10,6 @@ import { SemVer } from "semver";
 const reVersionAlphaStart = /^[a-z](\d+\.\d+\.\d+.*)$/;
 // const reVersionOptionalAlphaStart = /^[a-z]?(\d+\.\d+\.\d+.*)$/;
 const reScopedVersion = /^[^@]+@(.*)$/;
-const reVersionRangePrefix = /^[~^](\d+\.\d+\.\d+.*)$/;
 const reEndVersion = /.*\/([^/]+)$/;
 
 function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
@@ -22,10 +21,7 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion
-    .replace(reScopedVersion, "$1")
-    .replace(reVersionAlphaStart, "$1")
-    .replace(reVersionRangePrefix, "$1");
+  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;
@@ -382,8 +378,10 @@ export function buildCmd(sthis: SuperThis) {
       if (args.prepareVersion) {
         await fs.mkdirp(args.dstDir);
         const fpVersionFile = path.join(args.dstDir, "fp-version.txt");
-        await fs.writeFile(fpVersionFile, version.version);
-        console.log(`Using version: ${version.prefixedVersion}`);
+        const rawVersion = await getVersion(args.fpVersion);
+        const vx = new Version(rawVersion, args.versionPrefix);
+        await fs.writeFile(fpVersionFile, vx.version);
+        console.log(`Using version: ${vx.version}`);
         return;
       }
       if (args.srcDir === args.dstDir) {

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -10,6 +10,7 @@ import { SemVer } from "semver";
 const reVersionAlphaStart = /^[a-z](\d+\.\d+\.\d+.*)$/;
 // const reVersionOptionalAlphaStart = /^[a-z]?(\d+\.\d+\.\d+.*)$/;
 const reScopedVersion = /^[^@]+@(.*)$/;
+const reVersionRangePrefix = /^[~^](\d+\.\d+\.\d+.*)$/;
 const reEndVersion = /.*\/([^/]+)$/;
 
 function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
@@ -21,7 +22,7 @@ function getEnvVersion(version = "refs/tags/v0.0.0-smoke", xenv = process.env) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     wversion = wversion.match(reEndVersion)![1];
   }
-  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1");
+  const calculatedVersion = wversion.replace(reScopedVersion, "$1").replace(reVersionAlphaStart, "$1").replace(reVersionRangePrefix, "$1");
   try {
     new SemVer(calculatedVersion);
     return calculatedVersion;
@@ -358,8 +359,9 @@ export function buildCmd(sthis: SuperThis) {
         await fs.mkdirp(args.dstDir);
         const fpVersionFile = path.join(args.dstDir, "fp-version.txt");
         args.version = await getVersion(args.fpVersion);
+        const prefixedVersion = getPrefixedVersion(args.version, args.versionPrefix);
         await fs.writeFile(fpVersionFile, args.version);
-        console.log(`Using version: ${args.version}`);
+        console.log(`Using version: ${prefixedVersion}`);
         return;
       }
       if (args.srcDir === args.dstDir) {

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -64,7 +64,14 @@ export async function getVersion(
   return getEnvVersion(`refs/tags/v0.0.0-smoke-${gitHead}-${dateTick}`, xenv);
 }
 
-function patchDeps(dep: Record<string, string>, version: string) {
+function getPrefixedVersion(version: string, versionPrefix: string): string {
+  if (!versionPrefix) {
+    return version;
+  }
+  return `${versionPrefix}${version}`;
+}
+
+function patchDeps(dep: Record<string, string>, version: string, versionPrefix = "") {
   if (typeof dep !== "object" || !dep) {
     return;
   }

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -320,6 +320,13 @@ export function buildCmd(sthis: SuperThis) {
         defaultValue: () => "",
         description: "Change the scope of the package.",
       }),
+      versionPrefix: option({
+        long: "versionPrefix",
+        short: "x",
+        type: string,
+        defaultValue: () => "",
+        description: "Prefix to use for the version.",
+      }),
       pubTags: multioption({
         long: "pubTags",
         short: "t",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a --versionPrefix (-x) CLI option to the build command to prepend a prefix to the version used in build artifacts and publishing (e.g., v1.2.3).
- Refactor
  - Centralized version handling for consistent version formatting across build and publish steps.
  - fp-version.txt now records the base version (without prefix), while the prefixed version is applied to outputs where relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->