### PR TITLE
fix: make ImgFile references stable using content-based comparison

### DIFF
--- a/use-fireproof/react/img-file.ts
+++ b/use-fireproof/react/img-file.ts
@@ -32,7 +32,6 @@ function getCacheKey(fileObj: File): string {
   return `${fileObj.name}-${fileObj.size}-${fileObj.lastModified}`;
 }
 
-
 // Keyed variant so we can use DocFileMeta.cid for stable identity
 function getObjectUrlByKey(cacheKey: string, fileObj: File): string {
   if (!objectUrlCache.has(cacheKey)) {
@@ -72,14 +71,14 @@ async function loadFile({
     }
   }
 
-  // Prefer DocFileMeta.cid; fallback to file-derived key
+  // Use CID-based key for DocFileMeta, file-based key for direct File objects
   const currentKey = keyRef.current ?? null;
   const newKey =
-    (fileData && isFileMeta(fileData) && fileData.cid
+    fileData && isFileMeta(fileData) && fileData.cid
       ? `cid:${String(fileData.cid)}`
-      : fileObj
-        ? getCacheKey(fileObj)
-        : null);
+      : fileData && isFile(fileData)
+        ? getCacheKey(fileData)
+        : null;
   const isDifferentFile = currentKey !== newKey;
 
   // Defer cleanup of previous URL until after new URL is set

--- a/use-fireproof/react/img-file.ts
+++ b/use-fireproof/react/img-file.ts
@@ -72,15 +72,21 @@ async function loadFile({
     }
   }
 
+  // Use content-based comparison instead of object reference comparison
+  // This prevents premature cleanup when DocFileMeta.file() returns new objects for same content
+  const currentKey = fileObjRef.current ? getCacheKey(fileObjRef.current) : null;
+  const newKey = fileObj ? getCacheKey(fileObj) : null;
+  const isDifferentFile = currentKey !== newKey;
+
   // Clean up previous object URL if it exists and we're loading a new file
-  if (fileObjRef.current !== fileObj && cleanupRef.current) {
+  if (isDifferentFile && cleanupRef.current) {
     cleanupRef.current();
     cleanupRef.current = null;
   }
 
   if (fileObj && /image/.test(fileType)) {
-    // Skip if it's the same exact file object
-    if (fileObjRef.current !== fileObj) {
+    // Skip if it's the same file content (even if different object reference)
+    if (isDifferentFile) {
       const src = getObjectUrl(fileObj);
       setImgDataUrl(src);
       fileObjRef.current = fileObj;

--- a/use-fireproof/tests/img-file.test.tsx
+++ b/use-fireproof/tests/img-file.test.tsx
@@ -231,11 +231,12 @@ describe("COMPONENT: ImgFile", () => {
       expect(window.URL.revokeObjectURL).not.toHaveBeenCalled();
 
       // Force a re-render with a NEW DocFileMeta object that yields the same content
-      const fileSpy = vi.fn(async () =>
-        new File([fileContent], "same-content.svg", {
-          type: "image/svg+xml",
-          lastModified: 1234567890000,
-        }),
+      const fileSpy = vi.fn(
+        async () =>
+          new File([fileContent], "same-content.svg", {
+            type: "image/svg+xml",
+            lastModified: 1234567890000,
+          }),
       );
       const docFileMeta2: DocFileMeta = {
         ...docFileMeta,
@@ -303,7 +304,7 @@ describe("COMPONENT: ImgFile", () => {
 
       // Second DocFileMeta with SAME CID but different file metadata
       const docFileMeta2: DocFileMeta = {
-        type: "image/svg+xml", 
+        type: "image/svg+xml",
         size: fileContent.size,
         cid: mockCid, // Same CID - should be treated as same content
         file: async () =>
@@ -341,7 +342,7 @@ describe("COMPONENT: ImgFile", () => {
     async () => {
       const fileContent1 = new Blob([SVG_CONTENT], { type: "image/svg+xml" });
       const fileContent2 = new Blob(["<svg>different content</svg>"], { type: "image/svg+xml" });
-      
+
       const mockCid1 = { toString: () => "content-cid-1" } as AnyLink;
       const mockCid2 = { toString: () => "content-cid-2" } as AnyLink;
 
@@ -380,7 +381,7 @@ describe("COMPONENT: ImgFile", () => {
         cid: mockCid2, // Different CID - should be treated as different content
         file: async () =>
           new File([fileContent2], "same-name.svg", {
-            type: "image/svg+xml", 
+            type: "image/svg+xml",
             lastModified: 1234567890000, // Same metadata as first
           }),
       };
@@ -412,7 +413,7 @@ describe("COMPONENT: ImgFile", () => {
     "handles cross-type comparison between File and DocFileMeta objects",
     async () => {
       const fileContent = new Blob([SVG_CONTENT], { type: "image/svg+xml" });
-      
+
       // Start with a direct File object
       const directFile = new File([fileContent], "test.svg", {
         type: "image/svg+xml",


### PR DESCRIPTION
## Summary
- Fixed ImgFile component to use content-based comparison instead of object reference comparison
- Prevents premature cleanup of blob URLs when DocFileMeta.file() returns new File objects for same content
- Eliminates image flickering and unnecessary re-renders in React components

## Test plan
- [x] Added comprehensive test case covering the scenario where DocFileMeta returns new File objects with same content
- [x] Verified that blob URLs are not cleaned up unnecessarily
- [x] Confirmed that object URLs are not recreated for identical content
- [x] Run existing ImgFile tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Use content-based identity (preferring stable CIDs) to compare image inputs, preventing unnecessary blob URL reloads/revokes and reducing flicker when content is unchanged.
  - Ensure cleanup/revocation is keyed to content identity so only truly different content triggers new URLs and cleanup.
  - Public component signatures remain unchanged.

- Tests
  - Added tests verifying blob URL lifecycle for same-content new File objects, CID-based stable keys, CID changes creating new URLs, and cross-type (File vs DocFileMeta) comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->