### PR TITLE
Upgrade to type-checked ESLint rules (demonstrates scope of PR 465)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,31 +5,45 @@ import importPlugin from "eslint-plugin-import";
 const opts = tseslint.config(
   eslint.configs.recommended,
   //   ...tseslint.configs.recommended,
-  ...tseslint.configs.strict,
-  ...tseslint.configs.stylistic,
+  // ...tseslint.configs.strict,
+  // ...tseslint.configs.stylistic,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
-      globals: {
-        queueMicrotask: "readonly",
+      parserOptions: {
+        sourceType: "module",
+        project: "./tsconfig.json",
+        //        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },
   {
     ignores: [
       "babel.config.cjs",
+      "prettier.config.js",
       "jest.config.js",
+      "setup.*.js",
+      "to-esm.js",
+      "vitest.*.ts",
+      "**/.esm-cache/**",
       "**/dist/",
+      "dist/**",
       "**/pubdir/",
       "**/node_modules/",
       "**/scripts/",
       "**/examples/",
       "scripts/",
+      "coverage/",
       "smoke/react/",
       "src/missingTypes/lib.deno.d.ts",
-      "**/.cache/**",
-      "**/.esm-cache/**",
-      "**/.wrangler/**",
     ],
+  },
+  {
+    files: ["**/*.js", "*.mjs"],
+    extends: [tseslint.configs.disableTypeChecked],
   },
   {
     plugins: {
@@ -51,6 +65,12 @@ const opts = tseslint.config(
   {
     rules: {
       "no-restricted-globals": ["error", "URL", "TextDecoder", "TextEncoder"],
+    },
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/prefer-readonly": "error",
     },
   },
 );


### PR DESCRIPTION
## Summary
- Upgrades ESLint configuration from basic strict/stylistic rules to type-checked rules
- Demonstrates the massive scope of cleanup needed for stricter type checking
- Exposes **2,304 lint violations** that need to be addressed

## Changes
- `eslint.config.mjs`: Switch to `strictTypeChecked`, `stylisticTypeChecked`, `recommendedTypeChecked`
- Added TypeScript project configuration for type-aware linting
- Added `@typescript-eslint/prefer-readonly` rule

## Test Results
Running `pnpm lint` after this change reveals 2,304 errors including:
- `@typescript-eslint/no-unsafe-assignment` - lots of `any` type issues
- `@typescript-eslint/no-unsafe-member-access` - unsafe property access 
- `@typescript-eslint/prefer-nullish-coalescing` - using `||` instead of `??`
- `@typescript-eslint/prefer-readonly` - class members that should be readonly
- `@typescript-eslint/require-await` - async functions without await
- Plus many more strict typing violations

## Context
This PR demonstrates that PR #465 is essentially just the ESLint config upgrade plus the massive cleanup of all resulting violations. The "real" change is this config file - everything else in #465 is cleanup.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded linting configuration to use type-aware rules for TypeScript, improving static analysis and code consistency.
  * Refined ignore patterns and introduced targeted per-file overrides to streamline developer workflow and reduce false positives.
  * No user-facing changes; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->