### PR TITLE
update cement from 0.4.x -> 0.5.0

### DIFF
--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
     volumes:
       - ${HOME}/.cache/vd:/verdaccio/storage/data
   esm-sh:
-    # image: "ghcr.io/esm-dev/esm.sh:v136"
-    image: "ghcr.io/esm-dev/esm.sh:latest"
+    image: "ghcr.io/esm-dev/esm.sh:v136"
+    # image: "ghcr.io/esm-dev/esm.sh:latest"
     # image: "ghcr.io/esm-dev/esm.sh:v135_7"
     environment:
       NPM_REGISTRY: http://registry:4873/

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/cloud/3rd-party/package.json
+++ b/cloud/3rd-party/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "react-dom": "^19.1.1",
     "use-fireproof": "workspace:0.0.0"
   },

--- a/cloud/backend/base/package.json
+++ b/cloud/backend/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@cloudflare/workers-types": "^4.20251001.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/backend/cf-d1/package.json
+++ b/cloud/backend/cf-d1/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@cloudflare/workers-types": "^4.20251001.0",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",

--- a/cloud/backend/node/package.json
+++ b/cloud/backend/node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/base/package.json
+++ b/cloud/base/package.json
@@ -38,7 +38,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/cloud/todo-app/package.json
+++ b/cloud/todo-app/package.json
@@ -41,7 +41,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/react": "^19.1.15",
     "react-dom": "^19.1.0",

--- a/core/base/package.json
+++ b/core/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/blockstore/package.json
+++ b/core/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-gateways-file": "workspace:0.0.0",

--- a/core/core/package.json
+++ b/core/core/package.json
@@ -39,7 +39,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/device-id/package.json
+++ b/core/device-id/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/base/package.json
+++ b/core/gateways/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/gateways/cloud/package.json
+++ b/core/gateways/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/gateways/file-deno/package.json
+++ b/core/gateways/file-deno/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/deno": "^2.3.0",

--- a/core/gateways/file-node/package.json
+++ b/core/gateways/file-node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0"
   }

--- a/core/gateways/file/package.json
+++ b/core/gateways/file/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.6.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-file-deno": "workspace:0.0.0",
     "@fireproof/core-gateways-file-node": "workspace:0.0.0",

--- a/core/gateways/indexeddb/package.json
+++ b/core/gateways/indexeddb/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/memory/package.json
+++ b/core/gateways/memory/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.6.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/keybag/package.json
+++ b/core/keybag/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-gateways-file": "workspace:0.0.0",
     "@fireproof/core-gateways-indexeddb": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/protocols/cloud/package.json
+++ b/core/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/protocols/dashboard/package.json
+++ b/core/protocols/dashboard/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/runtime/package.json
+++ b/core/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@adviser/ts-xxhash": "^1.0.2",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/runtime/utils.ts
+++ b/core/runtime/utils.ts
@@ -287,7 +287,12 @@ export function ensureLogger(
                   logger.SetFormatter(new JSONFormatter(logger.TxtEnDe(), 2));
                   break;
                 case "yaml":
-                  logger.SetFormatter(new YAMLFormatter(logger.TxtEnDe(), 2));
+                  // abit of a hack, but we need to wait for the import to resolve
+                  // this could cause that some logs on startup are not formatted correctly
+                  // but it removes the need to carry around yaml as a dependency
+                  YAMLFormatter.create(logger.TxtEnDe(), 2).then((yamlFormatter) => {
+                    logger.SetFormatter(yamlFormatter);
+                  });
                   break;
                 case "json":
                 default:

--- a/core/tests/package.json
+++ b/core/tests/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",

--- a/core/tests/runtime/hash.test.ts
+++ b/core/tests/runtime/hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hashStringSync, hashObjectSync } from "../../runtime/utils.js";
+import { hashStringSync, hashObjectSync } from "@fireproof/core-runtime";
 
 describe("Hash functions", () => {
   describe("hashStringSync", () => {

--- a/core/types/base/package.json
+++ b/core/types/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@web3-storage/pail": "^0.6.2",

--- a/core/types/blockstore/package.json
+++ b/core/types/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-runtime": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/protocols/cloud/package.json
+++ b/core/types/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/runtime/package.json
+++ b/core/types/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "multiformats": "^13.4.0"
   }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,7 +25,7 @@
     "publish": "echo skip"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@clerk/backend": "^2.16.0",
     "@clerk/clerk-js": "^5.97.0",
     "@clerk/clerk-react": "^5.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
   cli:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../core/runtime
@@ -126,8 +126,8 @@ importers:
   cloud/3rd-party:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
@@ -151,8 +151,8 @@ importers:
   cloud/backend/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251001.0
         version: 4.20251001.0
@@ -215,8 +215,8 @@ importers:
   cloud/backend/cf-d1:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251001.0
         version: 4.20251001.0
@@ -276,8 +276,8 @@ importers:
   cloud/backend/node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/cloud-backend-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -337,8 +337,8 @@ importers:
   cloud/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../../core/blockstore
@@ -377,8 +377,8 @@ importers:
   cloud/todo-app:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../vendor
@@ -408,8 +408,8 @@ importers:
   core/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -454,8 +454,8 @@ importers:
   core/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../gateways/base
@@ -514,8 +514,8 @@ importers:
   core/core:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -535,8 +535,8 @@ importers:
   core/device-id:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-keybag':
         specifier: workspace:0.0.0
         version: link:../keybag
@@ -566,8 +566,8 @@ importers:
   core/gateways/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -590,8 +590,8 @@ importers:
   core/gateways/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -620,8 +620,8 @@ importers:
   core/gateways/file:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -657,8 +657,8 @@ importers:
   core/gateways/file-deno:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -675,8 +675,8 @@ importers:
   core/gateways/file-node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -687,8 +687,8 @@ importers:
   core/gateways/indexeddb:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -711,8 +711,8 @@ importers:
   core/gateways/memory:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -742,8 +742,8 @@ importers:
   core/keybag:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-gateways-file':
         specifier: workspace:0.0.0
         version: link:../gateways/file
@@ -772,8 +772,8 @@ importers:
   core/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -796,8 +796,8 @@ importers:
   core/protocols/dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -814,8 +814,8 @@ importers:
   core/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@adviser/ts-xxhash':
         specifier: ^1.0.2
         version: 1.0.2
@@ -851,8 +851,8 @@ importers:
   core/tests:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core':
         specifier: workspace:0.0.0
         version: link:../core
@@ -957,8 +957,8 @@ importers:
   core/types/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-types-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -984,8 +984,8 @@ importers:
   core/types/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -1009,8 +1009,8 @@ importers:
   core/types/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -1037,8 +1037,8 @@ importers:
   core/types/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../../vendor
@@ -1049,8 +1049,8 @@ importers:
   dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@clerk/backend':
         specifier: ^2.16.0
         version: 2.17.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1218,8 +1218,8 @@ importers:
   use-fireproof:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../core/base
@@ -1288,8 +1288,8 @@ importers:
   vendor:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.39
-        version: 0.4.41(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
       yocto-queue:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1321,8 +1321,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@adviser/cement@0.4.41':
-    resolution: {integrity: sha512-S0gYwm0fClODuaNMwWix+A8bvp8r4xpR+UIwi792Pv+WRE3hsnSWKKsy/e2hAL9dV+FTqUasabRHs1ncqQaMwg==}
+  '@adviser/cement@0.5.0':
+    resolution: {integrity: sha512-WtmWKFErbDkrcqJBOXnTS9ILHwxmo8F1s4Zo3gtqrutfm1C/nIRgBF/emGhItP1da7woBGxe7YOWg4QHsxI87A==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -5874,7 +5874,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@adviser/cement@0.4.41(typescript@5.9.3)':
+  '@adviser/cement@0.5.0(typescript@5.9.3)':
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       yaml: 2.8.1

--- a/smoke/esm/package-template.json
+++ b/smoke/esm/package-template.json
@@ -7,14 +7,14 @@
     "test": "vitest --run --testTimeout=90000"
   },
   "devDependencies": {
-    "deno": "^2.3.6",
-    "typescript": "^5.8.3",
-    "playwright": "^1.53.0",
-    "playwright-chromium": "^1.53.0",
+    "deno": "^2.5.0",
+    "typescript": "^5.9.0",
+    "playwright": "^1.55.1",
+    "playwright-chromium": "^1.55.1",
     "@vitest/browser": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "vitest": "^3.2.4",
-    "vite": "^7.0.0"
+    "vite": "^7.1.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild", "msw", "playwright-chromium", "deno"]

--- a/smoke/npm/package-template.json
+++ b/smoke/npm/package-template.json
@@ -14,6 +14,6 @@
   "type": "module",
   "devDependencies": {
     "tsx": "^4.20.3",
-    "deno": "^2.4.1"
+    "deno": "^2.5.0"
   }
 }

--- a/smoke/react/package-template.json
+++ b/smoke/react/package-template.json
@@ -22,13 +22,13 @@
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "playwright": "^1.53.0",
-    "playwright-chromium": "^1.53.0",
-    "@vitejs/plugin-react": "^4.2.1",
+    "playwright": "^1.55.0",
+    "playwright-chromium": "^1.55.0",
+    "@vitejs/plugin-react": "^5.0.4",
     "@vitest/browser": "^3.2.4",
     "@vitest/ui": "^3.2.4",
-    "typescript": "^5.8.3",
-    "vite": "^7.0.0",
+    "typescript": "^5.9.0",
+    "vite": "^7.1.0",
     "vitest": "^3.2.4"
   }
 }

--- a/use-fireproof/package.json
+++ b/use-fireproof/package.json
@@ -22,7 +22,7 @@
   "license": "AFL-2.0",
   "gptdoc": "Fireproof/React/Usage: import { useFireproof } from 'use-fireproof'; function WordCounterApp() { const { useLiveQuery, useDocument } = useFireproof('my-word-app'); const { doc: wordInput, merge: updateWordInput, save: saveWordInput, reset: clearWordInput } = useDocument({ word: '', timestamp: Date.now() }); const recentWords = useLiveQuery('timestamp', { descending: true, limit: 10 }); const { doc: { totalSubmitted }, merge: updateTotalSubmitted, save: saveTotalSubmitted } = useDocument({ _id: 'word-counter', totalSubmitted: 0 }); const handleWordSubmission = (e) => { e.preventDefault(); updateTotalSubmitted({ totalSubmitted: totalSubmitted + 1 }); saveTotalSubmitted(); saveWordInput(); clearWordInput();}; return (<><p>{totalSubmitted} words submitted</p><form onSubmit={handleWordSubmission}><input type='text' value={wordInput.word} onChange={e => updateWordInput({ word: e.target.value })} placeholder='Enter a word' /></form><ul>{recentWords.docs.map(entry => (<li key={entry._id}>{entry.word}</li>))} </ul></>) } export default WordCounterApp;",
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",

--- a/use-fireproof/package.json
+++ b/use-fireproof/package.json
@@ -37,7 +37,7 @@
     "ts-essentials": "^10.1.1"
   },
   "peerDependencies": {
-    "@adviser/cement": "^0.4.20",
+    "@adviser/cement": ">=0.4.20",
     "react": ">=18.0.0"
   },
   "keywords": [

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -29,7 +29,7 @@
     "zx": "^8.8.4"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.39",
+    "@adviser/cement": "^0.5.0",
     "yocto-queue": "^1.2.1"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Improvements
  - YAML log formatting initializes asynchronously; brief unformatted logs may appear during startup.

- Chores
  - Updated @adviser/cement to 0.5.0 across the project.
  - Pinned the esm-sh container image to v136 for reproducible environments.
  - Upgraded dev toolchain versions (Deno, TypeScript, Vite, Playwright, React plugin).

- Tests
  - Refreshed smoke app templates to use the latest toolchain versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->