### PR TITLE
add test for CORS header deduplication

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/cloud/3rd-party/package.json
+++ b/cloud/3rd-party/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "use-fireproof": "workspace:0.0.0"

--- a/cloud/backend/base/package.json
+++ b/cloud/backend/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@cloudflare/workers-types": "^4.20251011.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/backend/cf-d1/package.json
+++ b/cloud/backend/cf-d1/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@cloudflare/workers-types": "^4.20251011.0",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",

--- a/cloud/backend/node/package.json
+++ b/cloud/backend/node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/base/package.json
+++ b/cloud/base/package.json
@@ -38,7 +38,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/cloud/todo-app/package.json
+++ b/cloud/todo-app/package.json
@@ -41,7 +41,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/react": "^19.2.2",
     "react-dom": "^19.2.0",

--- a/core/base/package.json
+++ b/core/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/blockstore/package.json
+++ b/core/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-gateways-file": "workspace:0.0.0",

--- a/core/core/package.json
+++ b/core/core/package.json
@@ -39,7 +39,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/device-id/package.json
+++ b/core/device-id/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/base/package.json
+++ b/core/gateways/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/gateways/cloud/package.json
+++ b/core/gateways/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/gateways/file-deno/package.json
+++ b/core/gateways/file-deno/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/deno": "^2.5.0",

--- a/core/gateways/file-node/package.json
+++ b/core/gateways/file-node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0"
   }

--- a/core/gateways/file/package.json
+++ b/core/gateways/file/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.7.2"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-file-deno": "workspace:0.0.0",
     "@fireproof/core-gateways-file-node": "workspace:0.0.0",

--- a/core/gateways/indexeddb/package.json
+++ b/core/gateways/indexeddb/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/memory/package.json
+++ b/core/gateways/memory/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.7.2"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/keybag/package.json
+++ b/core/keybag/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-gateways-file": "workspace:0.0.0",
     "@fireproof/core-gateways-indexeddb": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/protocols/cloud/package.json
+++ b/core/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/protocols/dashboard/package.json
+++ b/core/protocols/dashboard/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/runtime/package.json
+++ b/core/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@adviser/ts-xxhash": "^1.0.2",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/tests/package.json
+++ b/core/tests/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",

--- a/core/types/base/package.json
+++ b/core/types/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@web3-storage/pail": "^0.6.2",

--- a/core/types/blockstore/package.json
+++ b/core/types/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-runtime": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/protocols/cloud/package.json
+++ b/core/types/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/runtime/package.json
+++ b/core/types/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/vendor": "workspace:0.0.0",
     "multiformats": "^13.4.0"
   }

--- a/dashboard/backend/cf-serve.ts
+++ b/dashboard/backend/cf-serve.ts
@@ -1,6 +1,6 @@
 import { drizzle } from "drizzle-orm/d1";
 import { D1Database, Fetcher, Request as CFRequest, Response as CFResponse } from "@cloudflare/workers-types";
-import { CORS, createHandler } from "./create-handler.js";
+import { DefaultHttpHeaders, createHandler } from "./create-handler.js";
 import { URI } from "@adviser/cement";
 import { resWellKnownJwks } from "./well-known-jwks.js";
 
@@ -33,10 +33,7 @@ export default {
     return new Response(res.body as ReadableStream<Uint8Array>, {
       status: res.status,
       statusText: res.statusText,
-      headers: {
-        ...Object.fromEntries(res.headers.entries()),
-        ...CORS,
-      },
+      headers: DefaultHttpHeaders(res.headers),
     });
   },
 };

--- a/dashboard/backend/double-cors.test.ts
+++ b/dashboard/backend/double-cors.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "vitest";
+import { DefaultHttpHeaders } from "./create-handler.js";
+
+it("adds CORS headers only once", async () => {
+  const CORS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+  const x = new Response("Var", {
+    status: 400,
+    statusText: "Bad Request",
+    headers: DefaultHttpHeaders(CORS),
+  });
+
+  expect(x.headers.get("Access-Control-Allow-Origin")).toBe("*");
+});

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,7 +25,7 @@
     "publish": "echo skip"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@clerk/backend": "^2.17.2",
     "@clerk/clerk-js": "^5.99.0",
     "@clerk/clerk-react": "^5.51.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
   cli:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../core/runtime
@@ -129,8 +129,8 @@ importers:
   cloud/3rd-party:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -157,8 +157,8 @@ importers:
   cloud/backend/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251011.0
         version: 4.20251011.0
@@ -221,8 +221,8 @@ importers:
   cloud/backend/cf-d1:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251011.0
         version: 4.20251011.0
@@ -282,8 +282,8 @@ importers:
   cloud/backend/node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/cloud-backend-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -343,8 +343,8 @@ importers:
   cloud/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../../core/blockstore
@@ -383,8 +383,8 @@ importers:
   cloud/todo-app:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../vendor
@@ -414,8 +414,8 @@ importers:
   core/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -460,8 +460,8 @@ importers:
   core/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../gateways/base
@@ -520,8 +520,8 @@ importers:
   core/core:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -541,8 +541,8 @@ importers:
   core/device-id:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-keybag':
         specifier: workspace:0.0.0
         version: link:../keybag
@@ -572,8 +572,8 @@ importers:
   core/gateways/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -596,8 +596,8 @@ importers:
   core/gateways/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -626,8 +626,8 @@ importers:
   core/gateways/file:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -663,8 +663,8 @@ importers:
   core/gateways/file-deno:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -681,8 +681,8 @@ importers:
   core/gateways/file-node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -693,8 +693,8 @@ importers:
   core/gateways/indexeddb:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -717,8 +717,8 @@ importers:
   core/gateways/memory:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -748,8 +748,8 @@ importers:
   core/keybag:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-gateways-file':
         specifier: workspace:0.0.0
         version: link:../gateways/file
@@ -778,8 +778,8 @@ importers:
   core/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -802,8 +802,8 @@ importers:
   core/protocols/dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -820,8 +820,8 @@ importers:
   core/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@adviser/ts-xxhash':
         specifier: ^1.0.2
         version: 1.0.2
@@ -857,8 +857,8 @@ importers:
   core/tests:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core':
         specifier: workspace:0.0.0
         version: link:../core
@@ -963,8 +963,8 @@ importers:
   core/types/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-types-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -990,8 +990,8 @@ importers:
   core/types/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -1015,8 +1015,8 @@ importers:
   core/types/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -1043,8 +1043,8 @@ importers:
   core/types/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../../vendor
@@ -1055,8 +1055,8 @@ importers:
   dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@clerk/backend':
         specifier: ^2.17.2
         version: 2.17.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1224,8 +1224,8 @@ importers:
   use-fireproof:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../core/base
@@ -1294,8 +1294,8 @@ importers:
   vendor:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.49
-        version: 0.4.49(typescript@5.9.3)
+        specifier: ^0.4.51
+        version: 0.4.51(typescript@5.9.3)
       yocto-queue:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1327,8 +1327,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@adviser/cement@0.4.49':
-    resolution: {integrity: sha512-X5zOuI4C78K1lz3IKApx7r6Cbe/pHh5T+xXivKeSOXTZ6clGE14GVnNqOUAuPm3RBpZC2lQhKprJag2+qOxiuA==}
+  '@adviser/cement@0.4.51':
+    resolution: {integrity: sha512-VJ6x3Z0tP4t1Ig7HO/yI1FkZ0SuosVkwHt6wncJTa2e3Ze9S7D7Q5FiGweDpE6xvw+5kCyJqTIzby9XMICVYKg==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6012,7 +6012,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@adviser/cement@0.4.49(typescript@5.9.3)':
+  '@adviser/cement@0.4.51(typescript@5.9.3)':
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       yaml: 2.8.1

--- a/use-fireproof/package.json
+++ b/use-fireproof/package.json
@@ -22,7 +22,7 @@
   "license": "AFL-2.0",
   "gptdoc": "Fireproof/React/Usage: import { useFireproof } from 'use-fireproof'; function WordCounterApp() { const { useLiveQuery, useDocument } = useFireproof('my-word-app'); const { doc: wordInput, merge: updateWordInput, save: saveWordInput, reset: clearWordInput } = useDocument({ word: '', timestamp: Date.now() }); const recentWords = useLiveQuery('timestamp', { descending: true, limit: 10 }); const { doc: { totalSubmitted }, merge: updateTotalSubmitted, save: saveTotalSubmitted } = useDocument({ _id: 'word-counter', totalSubmitted: 0 }); const handleWordSubmission = (e) => { e.preventDefault(); updateTotalSubmitted({ totalSubmitted: totalSubmitted + 1 }); saveTotalSubmitted(); saveWordInput(); clearWordInput();}; return (<><p>{totalSubmitted} words submitted</p><form onSubmit={handleWordSubmission}><input type='text' value={wordInput.word} onChange={e => updateWordInput({ word: e.target.value })} placeholder='Enter a word' /></form><ul>{recentWords.docs.map(entry => (<li key={entry._id}>{entry.word}</li>))} </ul></>) } export default WordCounterApp;",
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -29,7 +29,7 @@
     "zx": "^8.8.4"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.49",
+    "@adviser/cement": "^0.4.51",
     "yocto-queue": "^1.2.1"
   }
 }


### PR DESCRIPTION
Adds test to verify that CORS headers are only added once when using DefaultHttpHeaders function, preventing duplicate headers in responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Streamlined dashboard HTTP response headers to apply CORS once and ensure consistent Content-Type and Server-Timing headers.

- Tests
  - Added coverage to verify CORS headers are not duplicated.

- Chores
  - Updated @adviser/cement to ^0.4.51 across multiple packages for alignment and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->