### PR TITLE
feat(quotas): add configurable tenant and user limits via environment…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ smoke/react/pnpm-lock.yaml
 **/.env.*
 .wrangler
 .npmrc
+node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 **/pnpm-lock.yaml
+.pnpm-store/**
 scripts/
 **/.cache/**
 **/.esm-cache/**

--- a/core/protocols/dashboard/msg-types.ts
+++ b/core/protocols/dashboard/msg-types.ts
@@ -1,3 +1,4 @@
+import { JWKPublic } from "@fireproof/core-types-base";
 import { ReadWrite, Role, TenantLedger } from "@fireproof/core-types-protocols-cloud";
 
 export type AuthProvider = "github" | "google" | "fp" | "invite-per-email";
@@ -124,12 +125,20 @@ export interface ResCreateTenant {
   readonly tenant: OutTenantParams;
 }
 
+export interface FPApiParameters {
+  readonly cloudPublicKeys: JWKPublic[];
+  readonly clerkPublishableKey: string;
+  readonly maxTenants: number;
+  readonly maxAdminUsers: number;
+  readonly maxMemberUsers: number;
+  readonly maxInvites: number;
+  readonly maxLedgers: number;
+}
+
 export interface InCreateTenantParams {
   readonly name?: string;
   readonly ownerUserId: string;
-  readonly maxAdminUsers?: number;
-  readonly maxMemberUsers?: number;
-  readonly maxInvites?: number;
+  readonly defaultTenant?: boolean;
 }
 
 export interface ReqCreateTenant {
@@ -206,23 +215,6 @@ export interface ResListLedgersByUser {
   readonly ledgers: LedgerUser[];
 }
 
-// export interface ReqAttachUserToLedger {
-//   readonly type: "reqAttachUserToLedger";
-//   readonly auth: AuthType;
-//   readonly tenantId: string;
-//   readonly ledgerId: string;
-//   readonly userId: string;
-//   readonly role: ReadWrite;
-// }
-
-// export interface ResAttachUserToLedger {
-//   readonly type: "resAttachUserToLedger";
-//   readonly tenantId: string;
-//   readonly ledgerId: string;
-//   readonly userId: string;
-//   readonly role: ReadWrite;
-// }
-
 export interface ReqListTenantsByUser {
   readonly type: "reqListTenantsByUser";
   readonly auth: AuthType;
@@ -236,12 +228,19 @@ export interface UserTenantCommon {
   readonly updatedAt: Date;
 }
 
+export interface TenantLimits {
+  readonly maxAdminUsers: number;
+  readonly maxMemberUsers: number;
+  readonly maxInvites: number;
+  readonly maxLedgers: number;
+}
+
 export interface UserTenant {
   readonly tenantId: string;
   readonly role: Role;
   readonly default: boolean;
-  readonly user: UserTenantCommon;
-  readonly tenant: UserTenantCommon;
+  readonly user: UserTenantCommon & { readonly limits: { readonly maxTenants: number } };
+  readonly tenant: UserTenantCommon & { readonly limits: TenantLimits };
 }
 
 export function isAdmin(ut: UserTenant) {
@@ -260,7 +259,7 @@ export interface ResListTenantsByUser {
   readonly type: "resListTenantsByUser";
   readonly userId: string;
   readonly authUserId: string;
-  readonly tenants: UserTenant[];
+  readonly tenants: (AdminTenant | UserTenant)[];
 }
 
 // export type AuthProvider = "github" | "google" | "fp";

--- a/core/runtime/utils.ts
+++ b/core/runtime/utils.ts
@@ -665,3 +665,12 @@ export function deepFreeze<T extends object>(o?: T): T | undefined {
   }
   return o;
 }
+
+export function coerceInt(value: undefined | string | number, def: number): number {
+  if (value === undefined || value === null || value === "") {
+    return def;
+  }
+  const n = typeof value === "number" ? value : parseInt(value, 10);
+  if (!Number.isFinite(n) || Number.isNaN(n)) return def;
+  return n;
+}

--- a/dashboard/actions/deploy/action.yaml
+++ b/dashboard/actions/deploy/action.yaml
@@ -31,6 +31,16 @@ inputs:
   CLOUDFLARE_ENV:
     description: "Cloudflare environment (e.g., production, staging)"
     required: true
+  MAX_TENANTS:
+    description: "default for max tenants per new user"
+  MAX_ADMIN_USERS:
+    description: "default for max admin user for a tenant"
+  MAX_MEMBER_USERS:
+    description: "default for max member users for a tenant"
+  MAX_INVITES:
+    description: "default how many invitest could be created per tenant"
+  MAX_LEDGERS:
+    description: "default how many ledgers per tenant are allowed"
 
 runs:
   using: "composite"
@@ -51,6 +61,11 @@ runs:
         CLERK_PUBLISHABLE_KEY: ${{ inputs.CLERK_PUBLISHABLE_KEY }}
         CLERK_PUB_JWT_KEY: ${{ inputs.CLERK_PUB_JWT_KEY }}
         CLERK_PUB_JWT_URL: ${{ inputs.CLERK_PUB_JWT_URL }}
+        MAX_TENANTS: ${{ inputs.MAX_TENANTS }}
+        MAX_ADMIN_USERS: ${{ inputs.MAX_ADMIN_USERS }}
+        MAX_MEMBER_USERS: ${{ inputs.MAX_MEMBER_USERS }}
+        MAX_INVITES: ${{ inputs.MAX_INVITES }}
+        MAX_LEDGERS: ${{ inputs.MAX_LEDGERS }}
         # need during build
         VITE_CLERK_PUBLISHABLE_KEY: ${{ inputs.CLERK_PUBLISHABLE_KEY }}
       run: |
@@ -59,6 +74,11 @@ runs:
           --fromEnv CLERK_PUBLISHABLE_KEY \
           --fromEnv CLERK_PUB_JWT_URL \
           --fromEnv CLERK_PUB_JWT_KEY \
+          --fromEnv MAX_TENANTS \
+          --fromEnv MAX_ADMIN_USERS \
+          --fromEnv MAX_MEMBER_USERS \
+          --fromEnv MAX_INVITES \
+          --fromEnv MAX_LEDGERS \
           --fromEnv CLOUD_SESSION_TOKEN_SECRET \
           --fromEnv CLOUD_SESSION_TOKEN_PUBLIC | \
           pnpm exec wrangler -c ./wrangler.toml secret --env ${{inputs.CLOUDFLARE_ENV}} bulk

--- a/dashboard/backend/cf-serve.ts
+++ b/dashboard/backend/cf-serve.ts
@@ -8,7 +8,17 @@ export interface Env {
   DB: D1Database;
   // CLERK_SECRET_KEY: string;
   ASSETS: Fetcher;
+
+  MAX_TENANTS?: number;
+  MAX_ADMIN_USERS?: number;
+  MAX_MEMBER_USERS?: number;
+  MAX_INVITES?: number;
+  MAX_LEDGERS?: number;
+
+  CLERK_PUBLISHABLE_KEY: string;
+  CLOUD_SESSION_TOKEN_PUBLIC: string;
 }
+
 export default {
   async fetch(request: Request, env: Env) {
     const uri = URI.from(request.url);
@@ -16,7 +26,7 @@ export default {
     switch (true) {
       case uri.pathname.startsWith("/api"):
         // console.log("cf-serve", request.url, env);
-        ares = createHandler(drizzle(env.DB), env)(request) as unknown as Promise<CFResponse>;
+        ares = createHandler(drizzle(env.DB), env).then((fn) => fn(request) as unknown as Promise<CFResponse>);
         break;
 
       case uri.pathname.startsWith("/.well-known/jwks.json"):

--- a/dashboard/backend/deno-serve.ts
+++ b/dashboard/backend/deno-serve.ts
@@ -12,7 +12,7 @@ function getClient() {
 async function main() {
   Deno.serve({
     port: 7370,
-    handler: createHandler(getClient(), Deno.env.toObject()),
+    handler: await createHandler(getClient(), Deno.env.toObject()),
   });
 }
 

--- a/dashboard/backend/get-cloud-pubkey-from-env.ts
+++ b/dashboard/backend/get-cloud-pubkey-from-env.ts
@@ -1,0 +1,29 @@
+import { Result, toCryptoRuntime } from "@adviser/cement";
+import { ensureSuperThis, sts } from "@fireproof/core-runtime";
+import { JWKPublic, JWKPublicSchema, SuperThis, toJwksAlg } from "@fireproof/core-types-base";
+import { isArrayBuffer, isUint8Array } from "util/types";
+
+export async function getCloudPubkeyFromEnv(cloudToken?: string, sthis: SuperThis = ensureSuperThis()): Promise<Result<JWKPublic>> {
+  const cstPub = cloudToken ?? sthis.env.get("CLOUD_SESSION_TOKEN_PUBLIC");
+  if (!cstPub) {
+    return Result.Err("no public key: env:CLOUD_SESSION_TOKEN_PUBLIC");
+  }
+  const key = await sts.env2jwk(cstPub, "ES256", sthis);
+  const jwKey = await toCryptoRuntime().exportKey("jwk", key);
+  if (isUint8Array(jwKey) || isArrayBuffer(jwKey)) {
+    return Result.Err("invalid key: jwk is ArrayBuffer or Uint8Array");
+  }
+  const rJwtPublicKey = JWKPublicSchema.safeParse({
+    use: "sig",
+    // kty: ktyFromAlg(key.algorithm.name),
+    ...jwKey,
+    alg: toJwksAlg(key.algorithm.name, jwKey),
+    ext: undefined,
+    key_ops: undefined,
+    kid: undefined,
+  });
+  if (!rJwtPublicKey.success) {
+    return Result.Err(rJwtPublicKey.error);
+  }
+  return Result.Ok(rJwtPublicKey.data);
+}


### PR DESCRIPTION
… variables

  Implement a comprehensive quota management system that allows configuring
  limits for tenants, users, invites, and ledgers through environment variables:
  MAX_TENANTS, MAX_ADMIN_USERS, MAX_MEMBER_USERS, MAX_INVITES, MAX_LEDGERS.

  Key changes:
  - Add FPApiParameters interface with configurable limits passed to FPApiSQL
  - Refactor user/tenant data structures to expose limits in API responses via new TenantLimits interface
  - Add automatic migration logic to update existing users/tenants from old hardcoded defaults (5/10) to new configurable parameters
  - Extend GitHub Actions (actions/deploy/action.yaml) and Cloudflare Workers (backend/cf-serve.ts) to support MAX_* environment variables
  - Add coerceInt() utility in core/runtime/utils.ts for safe integer parsing with defaults
  - Create backend/get-cloud-pubkey-from-env.ts for centralized CLOUD_SESSION_ TOKEN_PUBLIC key handling
  - Update test suite to validate new limit structures and API responses

  The migration logic runs during ensureUser() and upgrades accounts where
  current limits match old defaults and new parameters specify higher limits.
  Also adds CLERK_PUBLISHABLE_KEY as required environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable tenant and user limits surfaced per-user and per-tenant (tenants, admins, members, invites, ledgers)
  * Clerk publishable key and cloud public-key support for session validation; automatic cloud key retrieval

* **Deployment**
  * New deployment inputs to set system limits at build/deploy time

* **Tests**
  * Improved, parameterized tests for limit propagation and tenant-listing behavior

* **Chores**
  * Updated ignore patterns for tooling (Prettier, .gitignore) and async handler initialization to load env keys during startup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->