### PR TITLE
feat(svc): add database service proxy layer with protocol definitions

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/cloud/3rd-party/package.json
+++ b/cloud/3rd-party/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "use-fireproof": "workspace:0.0.0"

--- a/cloud/backend/base/package.json
+++ b/cloud/backend/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@cloudflare/workers-types": "^4.20251111.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/backend/cf-d1/package.json
+++ b/cloud/backend/cf-d1/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@cloudflare/workers-types": "^4.20251111.0",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",

--- a/cloud/backend/node/package.json
+++ b/cloud/backend/node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/base/package.json
+++ b/cloud/base/package.json
@@ -38,7 +38,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/cloud/todo-app/package.json
+++ b/cloud/todo-app/package.json
@@ -41,7 +41,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/react": "^19.2.3",
     "react-dom": "^19.2.0",

--- a/core/base/ledger.ts
+++ b/core/base/ledger.ts
@@ -48,7 +48,7 @@ export function LedgerFactory(name: string, opts?: ConfigOpts): Ledger {
   const key = keyConfigOpts(sthis, name, opts);
   const item = ledgers.get(key);
   return new LedgerShell(
-    item.once(({ key }) => {
+    item.once(() => {
       const db = new LedgerImpl(sthis, {
         name,
         meta: opts?.meta,

--- a/core/base/package.json
+++ b/core/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/blockstore/package.json
+++ b/core/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-gateways-file": "workspace:0.0.0",

--- a/core/core/package.json
+++ b/core/core/package.json
@@ -39,7 +39,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/device-id/package.json
+++ b/core/device-id/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/base/package.json
+++ b/core/gateways/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/gateways/cloud/gateway.ts
+++ b/core/gateways/cloud/gateway.ts
@@ -269,7 +269,7 @@ function getGwCtx(conn: Partial<QSId>, uri: URI): Result<ReqGwCtx> {
 
 class CurrentMeta {
   // readonly boundGetMeta = new KeyedResolvOnce<ReadableStream<MsgWithError<EventGetMeta>>>();
-  readonly boundGetMeta = new KeyedResolvOnce<void>();
+  readonly boundGetMeta = new KeyedResolvOnce();
 
   readonly currentMeta = new KeyedResolvOnce<Result<FPEnvelopeMeta>>();
 

--- a/core/gateways/cloud/package.json
+++ b/core/gateways/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/gateways/file-deno/package.json
+++ b/core/gateways/file-deno/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/deno": "^2.5.0",

--- a/core/gateways/file-node/package.json
+++ b/core/gateways/file-node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0"
   }

--- a/core/gateways/file/package.json
+++ b/core/gateways/file/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.10.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-file-deno": "workspace:0.0.0",
     "@fireproof/core-gateways-file-node": "workspace:0.0.0",

--- a/core/gateways/indexeddb/package.json
+++ b/core/gateways/indexeddb/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/memory/package.json
+++ b/core/gateways/memory/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.10.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/keybag/package.json
+++ b/core/keybag/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-gateways-file": "workspace:0.0.0",
     "@fireproof/core-gateways-indexeddb": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/protocols/cloud/package.json
+++ b/core/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/protocols/dashboard/package.json
+++ b/core/protocols/dashboard/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/runtime/package.json
+++ b/core/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@adviser/ts-xxhash": "^1.0.2",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/svc/api/database-api.ts
+++ b/core/svc/api/database-api.ts
@@ -1,0 +1,398 @@
+// export interface Database extends ReadyCloseDestroy, HasLogger, HasSuperThis {
+//   // readonly name: string;
+//   readonly ledger: Ledger;
+//   readonly logger: Logger;
+//   readonly sthis: SuperThis;
+//   // readonly id: string;
+//   readonly name: string;
+
+import { AppContext, Future, KeyedResolvOnce, Lazy, Logger, OnFunc, OnFuncReturn, Result, timeouted } from "@adviser/cement";
+import {
+  AllDocsQueryOpts,
+  AllDocsResponse,
+  Attachable,
+  Attached,
+  BulkResponse,
+  ChangesOptions,
+  ChangesResponse,
+  ClockHead,
+  Database,
+  DatabaseConfig,
+  DatabaseConfigWithName,
+  DatabaseConfigWithNameSchema,
+  DocFragment,
+  DocResponse,
+  DocSet,
+  DocTypes,
+  DocWithId,
+  IndexKeyType,
+  Ledger,
+  ListenerFn,
+  MapFn,
+  QueryOpts,
+  QueryResult,
+  SuperThis,
+} from "@fireproof/core-types-base";
+import { ensureLogger, ensureSuperThis, hashObjectSync, makePartial } from "@fireproof/core-runtime";
+import {
+  FPApiPostMessageTransport,
+  FPApiTransportCtx,
+  FPTransport,
+  FPTransportOriginCTX,
+  FPTransportTargetCTX,
+  isResApplyDatabaseConfig,
+  MsgBase,
+  MsgTypeSchema,
+  ReqApplyDatabaseConfig,
+  ResApplyDatabaseConfig,
+  ResDBGet,
+  ReqDBGet,
+  isResDBGet,
+  ResDBGetSchema,
+  MsgType,
+  DBSend,
+} from "@fireproof/core-svc-protocol";
+
+//   onClosed(fn: () => void): void;
+
+//   attach(a: Attachable): Promise<Attached>;
+
+//   get<T extends DocTypes>(id: string): Promise<DocWithId<T>>;
+//   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse>;
+//   bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse>;
+//   del(id: string): Promise<DocResponse>;
+//   remove(id: string): Promise<DocResponse>;
+//   changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>>;
+
+//   allDocs<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   allDocuments<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithoutDocs<K>>): Promise<IndexRowsWithoutDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOptsWithUndefDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+
+//   query<
+//     T extends DocTypes,
+//     K extends IndexKeyType = string,
+//     R extends DocFragment = T,
+//     O extends Partial<QueryOpts<K>> = Partial<QueryOpts<K>>,
+//   >(
+//     field: string | MapFn<T>,
+//     opts?: O,
+//   ): Promise<QueryResult<T, K, R, O>>;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: undefined): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOpts<K>>): Promise<IndexRows<T, K, R>>;
+//   compact(): Promise<void>;
+// }
+
+class DatabaseProxy implements Database {
+  readonly ledger: Ledger;
+  readonly logger: Logger;
+  readonly sthis: SuperThis;
+  readonly name: string;
+  readonly proxyCfg: DatabaseInternalProxyConfig;
+  readonly id: string;
+  readonly transport: FPTransport;
+  readonly roundTripTimeoutMs: number;
+  constructor(
+    cfg: DatabaseInternalProxyConfig & FPApiTransportCtx & FPApiTransportParams & { readonly refId: string; readonly name: string },
+  ) {
+    this.ledger = {
+      ctx: new AppContext(),
+    } as Ledger;
+    this.sthis = ensureSuperThis();
+    this.logger = ensureLogger(this.sthis, "DatabaseProxy", {
+      dbName: cfg.name,
+    });
+    this.proxyCfg = cfg;
+    this.name = cfg.name;
+    this.id = cfg.refId;
+    this.transport = cfg.transport;
+    this.ledger.ctx.set("transport", this.transport);
+    this.roundTripTimeoutMs = cfg.roundTripTimeoutMs;
+    console.log("DatabaseProxy created for", this.name, "with id", this.id);
+  }
+
+  onClosed(_fn: () => void): void {
+    throw new Error("Method not implemented.");
+  }
+  attach(_a: Attachable): Promise<Attached> {
+    throw new Error("Method not implemented.");
+  }
+
+  transaction<Q extends MsgType, S extends MsgType>(
+    req: DBSend<Q>,
+    onRes: (fn: (res: S) => void) => void,
+    skipReady = false,
+  ): Promise<Result<S>> {
+    // console.log("DatabaseProxy.transaction called with", req);
+    return (skipReady ? Promise.resolve() : this.myReady())
+      .then(() => {
+        // console.log("DatabaseProxy.transaction sending request", req);
+        const wait = new Future<S>();
+        onRes((res) => {
+          // console.log("DatabaseProxy.transaction received response", res, "waiting for", wait.id());
+          if (res.tid === wait.id()) {
+            wait.resolve(res);
+            return OnFuncReturn.UNREGISTER;
+          }
+        });
+        // console.log("DatabaseProxy.transaction waiting for response to", req, this.transport.send.toString());
+        this.transport.send(
+          {
+            ...req,
+            tid: req.tid || wait.id(),
+            src: req.src || this.proxyCfg.origin,
+          } as Q,
+          { ...this.proxyCfg },
+        ); //.then((sendResult) => {
+        // console.log("DatabaseProxy.transaction request sent", sendResult, this.proxyCfg);
+        // });
+        return timeouted(wait.asPromise(), {
+          timeout: this.roundTripTimeoutMs,
+        });
+      })
+      .then((r) => {
+        console.log("DatabaseProxy.transaction completed with", r);
+        if (r.state !== "success") {
+          return this.logger
+            .Error()
+            .Any({ ...r })
+            .Msg("Transaction failed")
+            .ResultError();
+        }
+        return Result.Ok(r.value);
+      });
+  }
+
+  readonly onResDBGet = OnFunc<(res: ResDBGet, ctx: FPTransportOriginCTX) => void>();
+  get<T extends DocTypes>(_id: string): Promise<DocWithId<T>> {
+    return this.transaction<ReqDBGet, ResDBGet>(
+      {
+        tid: "",
+        src: this.proxyCfg.origin,
+        dst: this.proxyCfg.target,
+        type: "reqDBGet",
+        dbName: this.name,
+        dbId: this.id,
+        docIds: [_id],
+      },
+      this.onResDBGet,
+    ).then((res) => {
+      if (res.isErr()) {
+        return Promise.reject(res.Err());
+      }
+      const resParse = ResDBGetSchema.safeParse(res.Ok());
+      if (!resParse.success) {
+        return Promise.reject(
+          this.logger.Error().Any({ res: res.Ok() }).Msg("Failed to parse ResDBGet in DatabaseProxy.get").AsError(),
+        );
+      }
+      return Promise.resolve(res.Ok().results[0] as unknown as DocWithId<T>);
+    });
+  }
+  put<T extends DocTypes>(_doc: DocSet<T>): Promise<DocResponse> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  bulk<T extends DocTypes>(_docs: DocSet<T>[]): Promise<BulkResponse> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  del(_id: string): Promise<DocResponse> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  remove(_id: string): Promise<DocResponse> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  changes<T extends DocTypes>(_since?: ClockHead, _opts?: ChangesOptions): Promise<ChangesResponse<T>> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  allDocs<T extends DocTypes>(_opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  allDocuments<T extends DocTypes>(_opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  subscribe<T extends DocTypes>(_listener: ListenerFn<T>, _updates?: boolean): () => void {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    }) as unknown as () => void;
+  }
+  query<
+    T extends DocTypes,
+    K extends IndexKeyType = string,
+    R extends DocFragment = T,
+    O extends Partial<QueryOpts<K>> = Partial<QueryOpts<K>>,
+  >(_field: string | MapFn<T>, _opts?: O): Promise<QueryResult<T, K, R, O>> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  compact(): Promise<void> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  close(): Promise<void> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+  destroy(): Promise<void> {
+    return this.ready().then(() => {
+      throw new Error("Method not implemented.");
+    });
+  }
+
+  readonly onResApplyDatabaseConfig = OnFunc<(res: ResApplyDatabaseConfig, ctx: FPTransportOriginCTX) => void>();
+  readonly appliedDatabaseConfig = Lazy(() => {
+    return this.transaction<ReqApplyDatabaseConfig, ResApplyDatabaseConfig>(
+      {
+        dst: this.proxyCfg.target,
+        type: "reqApplyDatabaseConfig",
+        config: makePartial(DatabaseConfigWithNameSchema).parse(this.proxyCfg),
+      },
+      this.onResApplyDatabaseConfig,
+      true,
+    );
+  });
+  //   const waitResApplyDatabaseConfig = new Future<ResApplyDatabaseConfig>();
+  //   this.onResApplyDatabaseConfig((res, _ctx) => {
+  //     if (res.tid === waitResApplyDatabaseConfig.id()) {
+  //       waitResApplyDatabaseConfig.resolve(res);
+  //       return OnFuncReturn.UNREGISTER;
+  //     }
+  //   });
+  //   this.transport.send(
+  //     {
+  //       tid: waitResApplyDatabaseConfig.id(),
+  //       src: this.proxyCfg.origin,
+  //       dst: this.proxyCfg.target,
+  //       type: "reqApplyDatabaseConfig",
+  //       config: makePartial(DatabaseConfigWithNameSchema).parse(this.proxyCfg),
+  //     },
+  //     { ...this.proxyCfg },
+  //   );
+  //   return timeouted(waitResApplyDatabaseConfig.asPromise(), {
+  //     timeout: this.roundTripTimeoutMs,
+  //   });
+  // });
+
+  readonly myReady = Lazy(
+    (): Promise<ResApplyDatabaseConfig> =>
+      this.transport.start().then((r) => {
+        if (r.isErr()) {
+          return Promise.reject(
+            this.logger
+              .Error()
+              .Err(r)
+              .Any({ ...this.proxyCfg })
+              .Msg("Failed to start transport for DatabaseProxy")
+              .AsError(),
+          );
+        }
+        console.log("DatabaseProxy.transport started", this.name);
+        this.transport.recv(async (msg: MsgBase, ctx: FPTransportOriginCTX) => {
+          const parsed = MsgTypeSchema.safeParse(msg);
+          console.log("DatabaseProxy received message", this.id, this.name, msg, parsed.success);
+          if (!parsed.success) {
+            return this.logger
+              .Error()
+              .Any({ msg, origin: ctx.origin })
+              .Msg("Received invalid message in DatabaseProxy")
+              .ResultError();
+          }
+          switch (true) {
+            case isResApplyDatabaseConfig(parsed.data):
+              this.onResApplyDatabaseConfig.invoke(parsed.data, ctx);
+              break;
+            case isResDBGet(parsed.data):
+              this.onResDBGet.invoke(parsed.data, ctx);
+              break;
+            default:
+              return this.logger
+                .Warn()
+                .Any({ msg, origin: ctx.origin })
+                .Msg("Received unhandled message type in DatabaseProxy")
+                .ResultError();
+          }
+          return Promise.resolve(Result.Ok());
+        });
+        return this.appliedDatabaseConfig().then((res) => {
+          if (res.isErr()) {
+            return Promise.reject(res.Err());
+          }
+          this.logger.Info().Any(res.Ok()).Msg("DatabaseProxy ready");
+          return Promise.resolve(res.Ok());
+        });
+      }),
+  );
+  ready(): Promise<void> {
+    return this.myReady().then(() => Promise.resolve());
+  }
+}
+
+type KeyedDatabaseConfig = DatabaseProxyConfig & { readonly name: string };
+const fireproofProxies = new KeyedResolvOnce<Database, KeyedDatabaseConfig>({
+  key2string: (cfg: KeyedDatabaseConfig) => {
+    //export function makePartial<T extends z.ZodObject<Record<string, z.ZodTypeAny>>>(schema: T): T {
+    const parsed = makePartial(DatabaseConfigWithNameSchema).safeParse(cfg);
+    if (!parsed.success) {
+      throw new Error(`Invalid DatabaseConfigWithName for fireproofProxy key: ${JSON.stringify(cfg)}`);
+    }
+    return hashObjectSync(parsed.data);
+  },
+});
+
+export interface FPApiTransportParams {
+  readonly roundTripTimeoutMs: number;
+}
+
+export type DatabaseInternalProxyConfig = Partial<DatabaseConfigWithName> &
+  Partial<FPApiTransportCtx> &
+  FPTransportTargetCTX &
+  Partial<FPApiTransportParams>;
+
+export type DatabaseProxyConfig = Partial<DatabaseConfig> &
+  Partial<FPApiTransportCtx> &
+  FPTransportTargetCTX &
+  Partial<FPApiTransportParams>;
+
+export function fireproofProxy(name: string, cfg: DatabaseProxyConfig): Database {
+  return fireproofProxies
+    .get({
+      ...cfg,
+      name,
+    })
+    .once((x) => {
+      const sthis = ensureSuperThis();
+      console.log("Creating DatabaseProxy for", name, "with config", cfg, x.refKey);
+      return new DatabaseProxy({
+        ...x.givenKey,
+        name,
+        refId: x.refKey,
+        transport: cfg.transport ?? new FPApiPostMessageTransport(sthis, cfg.webWindow ?? window),
+        webWindow: cfg.webWindow ?? window,
+        target: cfg.target,
+        origin: cfg.origin,
+        roundTripTimeoutMs: cfg.roundTripTimeoutMs ?? 10000,
+      });
+    });
+}

--- a/core/svc/api/index.ts
+++ b/core/svc/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./database-api.js";

--- a/core/svc/api/package.json
+++ b/core/svc/api/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-svc-protocol": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/svc/api/package.json
+++ b/core/svc/api/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@fireproof/core-runtime",
+  "name": "@fireproof/core-svc-api",
   "version": "0.0.0",
-  "description": "Live ledger for the web.",
+  "description": "Fireproof service layer API implementation.",
   "type": "module",
   "main": "./index.js",
   "scripts": {
@@ -27,7 +27,6 @@
   "author": "J Chris Anderson",
   "license": "AFL-2.0",
   "homepage": "https://use-fireproof.com",
-  "gptdoc": "import { fireproof } from 'use-fireproof'; const db = fireproof('app-db-name'); const ok = await db.put({ anyField: ['any','json'] }); const doc = await db.get(ok.id); await db.del(doc._id); db.subscribe(myRedrawFn); const result = await db.query('anyField', {range : ['a', 'z']}); result.rows.map(({ key }) => key);",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fireproof-storage/fireproof.git"
@@ -37,18 +36,10 @@
   },
   "dependencies": {
     "@adviser/cement": "^0.4.65",
-    "@adviser/ts-xxhash": "^1.0.2",
+    "@fireproof/core-runtime": "workspace:0.0.0",
+    "@fireproof/core-svc-protocol": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
-    "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",
-    "@fireproof/core-types-runtime": "workspace:0.0.0",
-    "@fireproof/vendor": "workspace:0.0.0",
-    "cborg": "^4.3.0",
-    "jose": "^6.1.1",
-    "multiformats": "^13.4.0",
     "zod": "^4.1.12"
-  },
-  "devDependencies": {
-    "@fireproof/core-cli": "workspace:^"
   }
 }

--- a/core/svc/host/database-host.ts
+++ b/core/svc/host/database-host.ts
@@ -1,0 +1,182 @@
+import { Database, DatabaseConfig, SuperThis } from "@fireproof/core-types-base";
+import { MsgType, MsgTypeSchema, ReqApplyDatabaseConfig, ResApplyDatabaseConfig } from "../protocol/database-protocol.js";
+import { Result, Logger, KeyedResolvOnce } from "@adviser/cement";
+import { hashObjectSync } from "@fireproof/core-runtime";
+import { fireproof } from "@fireproof/core-base";
+import { FPApiPostMessageTransport, FPTransport, FPTransportOriginCTX, FPWebWindow } from "@fireproof/core-svc-protocol";
+
+export interface FPDBContext {
+  send<T extends MsgType>(msg: T): Promise<Result<T>>;
+}
+
+export interface FPDBActions {
+  applyDatabaseConfig(
+    msg: ReqApplyDatabaseConfig,
+    trans: FPTransport,
+    ctx: FPTransportOriginCTX,
+  ): Promise<Result<ResApplyDatabaseConfig>>;
+}
+
+export class FPActionService implements FPDBActions {
+  readonly sthis: SuperThis;
+  readonly id: string;
+  readonly fpInstances = new KeyedResolvOnce<Database, DatabaseConfig>({
+    key2string: (config: DatabaseConfig) => {
+      return hashObjectSync(config);
+    },
+  });
+
+  constructor(sthis: SuperThis) {
+    this.sthis = sthis;
+    this.id = `FPActionService[${sthis.nextId().str}]`;
+  }
+  applyDatabaseConfig(
+    msg: ReqApplyDatabaseConfig,
+    transport: FPTransport,
+    ctx: FPTransportOriginCTX,
+  ): Promise<Result<ResApplyDatabaseConfig>> {
+    // console.log("FPActionService.applyDatabaseConfig called with", msg);
+    const db = this.fpInstances.get(msg.config).once(() =>
+      fireproof(msg.config.name, {
+        storeUrls: msg.config.storeUrls,
+        env: msg.config.env,
+        writeQueue: msg.config.writeQueue,
+        autoCompact: msg.config.autoCompact,
+        compactStrategy: msg.config.compactStrategy,
+        threshold: msg.config.threshold,
+      }),
+    );
+    // console.log("FPActionService.applyDatabaseConfig created database instance", db);
+    return transport.send(
+      {
+        type: "resApplyDatabaseConfig",
+        tid: msg.tid,
+        src: this.id,
+        dst: msg.src,
+        dbId: db.ledger.refId(),
+        dbName: msg.config.name,
+      } satisfies ResApplyDatabaseConfig,
+      {
+        origin: this.id,
+        target: ctx.origin,
+      },
+    );
+  }
+}
+
+// function isMsgWithData(msg: unknown): msg is {data: unknown} {
+//   return (msg as {data?: unknown}).data !== undefined;
+// }
+
+export async function databaseMsgHandler(
+  sthis: SuperThis,
+  logger: Logger,
+  actions: FPDBActions,
+  msg: unknown,
+  transport: FPTransport,
+  ctx: FPTransportOriginCTX,
+): Promise<Result<void>> {
+  // console.log("databaseMsgHandler called with msg:", msg);
+  // if (!isMsgWithData(msg)) {
+  //   return logger.Error().Msg("Invalid message format no data").ResultError();
+  // }
+  // console.log("databaseMsgHandler received message", msg, ctx);
+  const base = MsgTypeSchema.safeParse(msg);
+  if (!base.success) {
+    return logger.Error().Err(base.error).Any({ data: msg }).Msg("Invalid message format").ResultError();
+  }
+  // console.log("databaseMsgHandler", base.data);
+  switch (base.data.type) {
+    case "reqApplyDatabaseConfig":
+      return actions.applyDatabaseConfig(base.data, transport, ctx);
+    default:
+      return logger.Error().Any(base.data).Msg("Unhandled message").ResultError();
+  }
+}
+
+export interface FPDatabaseSvcParams {
+  readonly sthis: SuperThis;
+  readonly logger: Logger;
+  readonly action?: FPActionService;
+  readonly transport?: FPTransport;
+  readonly webWindow?: FPWebWindow;
+}
+
+export class FPDatabaseSvc {
+  private readonly sthis: SuperThis;
+  private readonly logger: Logger;
+  private readonly transport: FPTransport;
+  private readonly action: FPActionService;
+  private stopRecv?: () => void;
+  private readonly webWindow: FPWebWindow;
+
+  constructor(params: FPDatabaseSvcParams) {
+    this.webWindow = params.webWindow ?? window;
+    this.transport = params.transport ?? new FPApiPostMessageTransport(params.sthis, this.webWindow);
+    this.sthis = params.sthis;
+    this.logger = params.logger;
+    this.action = params.action ?? new FPActionService(this.sthis);
+  }
+
+  start(): Promise<Result<void>> {
+    const action = new FPActionService(this.sthis);
+    console.log("FPDatabaseSvc started");
+    this.stopRecv = this.transport.recv((msg: unknown, ctx: FPTransportOriginCTX) => {
+      return databaseMsgHandler(this.sthis, this.logger, action, msg, this.transport, ctx);
+    });
+    return Promise.resolve(Result.Ok());
+  }
+
+  stop() {
+    if (this.stopRecv) {
+      this.stopRecv();
+      this.stopRecv = undefined;
+    }
+  }
+}
+
+// import {
+
+// export interface Database extends ReadyCloseDestroy, HasLogger, HasSuperThis {
+//   // readonly name: string;
+//   readonly ledger: Ledger;
+//   readonly logger: Logger;
+//   readonly sthis: SuperThis;
+//   // readonly id: string;
+//   readonly name: string;
+
+//   onClosed(fn: () => void): void;
+
+//   attach(a: Attachable): Promise<Attached>;
+
+//   get<T extends DocTypes>(id: string): Promise<DocWithId<T>>;
+//   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse>;
+//   bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse>;
+//   del(id: string): Promise<DocResponse>;
+//   remove(id: string): Promise<DocResponse>;
+//   changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>>;
+
+//   allDocs<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   allDocuments<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithoutDocs<K>>): Promise<IndexRowsWithoutDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOptsWithUndefDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+
+//   query<
+//     T extends DocTypes,
+//     K extends IndexKeyType = string,
+//     R extends DocFragment = T,
+//     O extends Partial<QueryOpts<K>> = Partial<QueryOpts<K>>,
+//   >(
+//     field: string | MapFn<T>,
+//     opts?: O,
+//   ): Promise<QueryResult<T, K, R, O>>;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: undefined): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOpts<K>>): Promise<IndexRows<T, K, R>>;
+//   compact(): Promise<void>;
+// }

--- a/core/svc/host/index.ts
+++ b/core/svc/host/index.ts
@@ -1,0 +1,1 @@
+export * from "./database-host.js";

--- a/core/svc/host/package.json
+++ b/core/svc/host/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@fireproof/core-runtime",
+  "name": "@fireproof/core-svc-host",
   "version": "0.0.0",
-  "description": "Live ledger for the web.",
+  "description": "Fireproof service layer host implementation.",
   "type": "module",
   "main": "./index.js",
   "scripts": {
@@ -27,7 +27,6 @@
   "author": "J Chris Anderson",
   "license": "AFL-2.0",
   "homepage": "https://use-fireproof.com",
-  "gptdoc": "import { fireproof } from 'use-fireproof'; const db = fireproof('app-db-name'); const ok = await db.put({ anyField: ['any','json'] }); const doc = await db.get(ok.id); await db.del(doc._id); db.subscribe(myRedrawFn); const result = await db.query('anyField', {range : ['a', 'z']}); result.rows.map(({ key }) => key);",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fireproof-storage/fireproof.git"
@@ -37,18 +36,11 @@
   },
   "dependencies": {
     "@adviser/cement": "^0.4.65",
-    "@adviser/ts-xxhash": "^1.0.2",
+    "@fireproof/core-base": "workspace:0.0.0",
+    "@fireproof/core-runtime": "workspace:0.0.0",
+    "@fireproof/core-svc-protocol": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
-    "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",
-    "@fireproof/core-types-runtime": "workspace:0.0.0",
-    "@fireproof/vendor": "workspace:0.0.0",
-    "cborg": "^4.3.0",
-    "jose": "^6.1.1",
-    "multiformats": "^13.4.0",
     "zod": "^4.1.12"
-  },
-  "devDependencies": {
-    "@fireproof/core-cli": "workspace:^"
   }
 }

--- a/core/svc/host/package.json
+++ b/core/svc/host/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-svc-protocol": "workspace:0.0.0",

--- a/core/svc/protocol/base.zod.ts
+++ b/core/svc/protocol/base.zod.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+
+export const MsgBaseSchemaBase = z.object({
+  tid: z.string(),
+  type: z.string(),
+  src: z.string(),
+  dst: z.string(),
+});
+
+export const MsgBaseSchema = MsgBaseSchemaBase.readonly();
+
+export type MsgBase = z.infer<typeof MsgBaseSchema>;
+
+export const ErrorMsgSchema = MsgBaseSchemaBase.extend({
+  type: z.literal("error"),
+  error: z.string(),
+  code: z.number().optional(),
+  stack: z.array(z.string()).optional(),
+}).readonly();
+
+export type ErrorMsg = z.infer<typeof ErrorMsgSchema>;
+
+/**
+ * Base schema for database instance messages
+ */
+export const DbInstanceSchemaBase = MsgBaseSchemaBase.extend({
+  dbName: z.string(),
+  dbId: z.string(),
+});
+
+export const DbInstanceSchema = DbInstanceSchemaBase.readonly();
+
+export type DbInstance = z.infer<typeof DbInstanceSchema>;

--- a/core/svc/protocol/database-protocol-bulk.zod.ts
+++ b/core/svc/protocol/database-protocol-bulk.zod.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { DbInstanceSchemaBase } from "./base.zod.js";
+
+/**
+ * Schema for ProxyBulkResponse
+ */
+export const ProxyBulkResponseSchema = z
+  .object({
+    ids: z.array(z.string()),
+    clock: z.string(),
+    name: z.string().optional(),
+  })
+  .readonly();
+
+export type ProxyBulkResponse = z.infer<typeof ProxyBulkResponseSchema>;
+
+/**
+ * Request to bulk insert/update documents
+ */
+export const ReqDBBulkSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("reqDBBulk"),
+  docs: z.array(z.any()), // Array of ProxyDocWithId<unknown> - generic type
+}).readonly();
+
+export type ReqDBBulk = z.infer<typeof ReqDBBulkSchema>;
+
+/**
+ * Response after bulk operation
+ */
+export const ResDBBulkSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("resDBBulk"),
+  results: ProxyBulkResponseSchema,
+}).readonly();
+
+export type ResDBBulk = z.infer<typeof ResDBBulkSchema>;

--- a/core/svc/protocol/database-protocol-get.zod.ts
+++ b/core/svc/protocol/database-protocol-get.zod.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { ProxyDocFileMetaSchema, ProxyDocWithId, ProxyDocWithIdSchema } from "./doc-base.zod.js";
+import { DbInstanceSchemaBase } from "./base.zod.js";
+
+/**
+ * Request to get a document by ID
+ */
+export const ReqDBGetSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("reqDBGet"),
+  docIds: z.array(z.string()),
+}).readonly();
+
+export type ReqDBGet = z.infer<typeof ReqDBGetSchema>;
+
+/**
+ * Response with document data
+ * Note: Uses z.any() for result since we don't know T at schema definition time
+ */
+export const ResDBGetSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("resDBGet"),
+  docId: z.string(),
+  results: ProxyDocWithIdSchema.array(),
+}).readonly();
+
+export type ResDBGet<T = unknown> = z.infer<typeof ResDBGetSchema> & {
+  results: ProxyDocWithId<T>[];
+};
+
+/**
+ * Request to get file content from a document
+ */
+export const ReqDBGetFileContentSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("reqDBGetFile"),
+  docId: z.string(),
+  fileData: ProxyDocFileMetaSchema,
+}).readonly();
+
+export type ReqDBGetFileContent = z.infer<typeof ReqDBGetFileContentSchema>;
+
+/**
+ * Response with file content
+ */
+export const ResDBGetFileContentSchema = DbInstanceSchemaBase.extend({
+  type: z.literal("resDBGetFile"),
+  docId: z.string(),
+  fileData: ProxyDocFileMetaSchema,
+  content: z.instanceof(Uint8Array),
+}).readonly();
+
+export type ResDBGetFileContent = z.infer<typeof ResDBGetFileContentSchema>;

--- a/core/svc/protocol/database-protocol.ts
+++ b/core/svc/protocol/database-protocol.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { DatabaseConfigWithNameSchema } from "@fireproof/core-types-base";
+import { makePartial } from "@fireproof/core-runtime";
+import {
+  ReqDBGetSchema,
+  ResDBGetSchema,
+  ReqDBGetFileContentSchema,
+  ResDBGetFileContentSchema,
+} from "./database-protocol-get.zod.js";
+import { ReqDBBulkSchema, ResDBBulkSchema } from "./database-protocol-bulk.zod.js";
+
+import { ErrorMsgSchema, MsgBaseSchemaBase } from "./base.zod.js";
+
+export const ReqApplyDatabaseConfigSchema = MsgBaseSchemaBase.extend({
+  type: z.literal("reqApplyDatabaseConfig"),
+  config: makePartial(DatabaseConfigWithNameSchema),
+}).readonly();
+
+export type ReqApplyDatabaseConfig = z.infer<typeof ReqApplyDatabaseConfigSchema>;
+
+export const ResApplyDatabaseConfigSchema = MsgBaseSchemaBase.extend({
+  type: z.literal("resApplyDatabaseConfig"),
+  dbName: z.string(),
+  dbId: z.string(), // typically ledger refId hash of the given config
+}).readonly();
+
+export type ResApplyDatabaseConfig = z.infer<typeof ResApplyDatabaseConfigSchema>;
+
+export function isResApplyDatabaseConfig(msg: MsgType): msg is ResApplyDatabaseConfig {
+  return msg.type === "resApplyDatabaseConfig";
+}
+
+export function isResDBGet(msg: MsgType): msg is z.infer<typeof ResDBGetSchema> {
+  return msg.type === "resDBGet";
+}
+
+export const MsgTypeSchema = z.union([
+  ReqApplyDatabaseConfigSchema,
+  ResApplyDatabaseConfigSchema,
+  ErrorMsgSchema,
+  ReqDBGetSchema,
+  ResDBGetSchema,
+  ReqDBGetFileContentSchema,
+  ResDBGetFileContentSchema,
+  ReqDBBulkSchema,
+  ResDBBulkSchema,
+]);
+
+export type MsgType = z.infer<typeof MsgTypeSchema>;
+
+export type DBSend<Req extends MsgType> = Omit<Req, "tid" | "src"> &
+  Partial<{
+    readonly tid: string;
+    readonly src: string;
+  }>;
+
+// export interface Database extends ReadyCloseDestroy, HasLogger, HasSuperThis {
+//   // readonly name: string;
+//   readonly ledger: Ledger;
+//   readonly logger: Logger;
+//   readonly sthis: SuperThis;
+//   // readonly id: string;
+//   readonly name: string;
+
+//   onClosed(fn: () => void): void;
+
+//   attach(a: Attachable): Promise<Attached>;
+
+//   get<T extends DocTypes>(id: string): Promise<DocWithId<T>>;
+//   put<T extends DocTypes>(doc: DocSet<T>): Promise<DocResponse>;
+//   bulk<T extends DocTypes>(docs: DocSet<T>[]): Promise<BulkResponse>;
+//   del(id: string): Promise<DocResponse>;
+//   remove(id: string): Promise<DocResponse>;
+//   changes<T extends DocTypes>(since?: ClockHead, opts?: ChangesOptions): Promise<ChangesResponse<T>>;
+
+//   allDocs<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   allDocuments<T extends DocTypes>(opts?: Partial<AllDocsQueryOpts>): Promise<AllDocsResponse<T>>;
+
+//   subscribe<T extends DocTypes>(listener: ListenerFn<T>, updates?: boolean): () => void;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithoutDocs<K>>): Promise<IndexRowsWithoutDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts: Partial<QueryOptsWithDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOptsWithUndefDocs<K>>): Promise<IndexRowsWithDocs<T, K, R>>;
+
+//   query<
+//     T extends DocTypes,
+//     K extends IndexKeyType = string,
+//     R extends DocFragment = T,
+//     O extends Partial<QueryOpts<K>> = Partial<QueryOpts<K>>,
+//   >(
+//     field: string | MapFn<T>,
+//     opts?: O,
+//   ): Promise<QueryResult<T, K, R, O>>;
+
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: undefined): Promise<IndexRowsWithDocs<T, K, R>>;
+//   // query<T extends DocTypes, K extends IndexKeyType = string, R extends DocFragment = T>(field: string | MapFn<T>, opts?: Partial<QueryOpts<K>>): Promise<IndexRows<T, K, R>>;
+//   compact(): Promise<void>;
+// }

--- a/core/svc/protocol/doc-base.zod.ts
+++ b/core/svc/protocol/doc-base.zod.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for DocFileMeta interface
+ */
+export const ProxyDocFileMetaSchema = z
+  .object({
+    type: z.string(),
+    size: z.number(),
+    cid: z.any(), // AnyLink type - would need proper schema if AnyLink has a specific structure
+    car: z.any().optional(), // AnyLink type
+    lastModified: z.number().optional(),
+    url: z.string().optional(),
+    // file is a function that returns Promise<File>, but Zod function validation is complex
+    // so we'll use z.any() for the function type
+  })
+  .readonly();
+
+export type ProxyDocFileMeta = z.infer<typeof ProxyDocFileMetaSchema>;
+
+/**
+ * Schema for DocFiles - a record of DocFileMeta or File objects
+ */
+export const ProxyDocFilesSchema = z.record(z.string(), z.union([ProxyDocFileMetaSchema, z.instanceof(File)]));
+
+export type ProxyDocFiles = z.infer<typeof ProxyDocFilesSchema>;
+
+/**
+ * Zod schema for DocBase interface
+ */
+export const ProxyDocBaseSchema = z.object({
+  _id: z.string(),
+  _files: ProxyDocFilesSchema.optional(),
+  _publicFiles: ProxyDocFilesSchema.optional(),
+  _deleted: z.boolean().optional(),
+});
+
+export const readonlyDocBaseSchema = z.readonly(ProxyDocBaseSchema);
+
+export type DocBase = z.infer<typeof readonlyDocBaseSchema>;
+
+/**
+ * Partial version of DocBaseSchema for use in DocSet
+ */
+const PartialDocBaseSchema = z
+  .object({
+    _id: z.string(),
+    _files: ProxyDocFilesSchema.optional(),
+    _publicFiles: ProxyDocFilesSchema.optional(),
+    _deleted: z.boolean().optional(),
+  })
+  .partial()
+  .readonly();
+
+/**
+ * Schema factory for DocWithId<T> - creates a schema that intersects DocBase with T
+ * @param docSchema - The Zod schema for type T (the document type)
+ * @returns A Zod schema for DocWithId<T>
+ *
+ * @example
+ * const MyDocSchema = z.object({ name: z.string(), age: z.number() });
+ * const MyDocWithIdSchema = DocWithIdSchema(MyDocSchema);
+ * type MyDocWithId = z.infer<typeof MyDocWithIdSchema>;
+ */
+// export function ProxyDocWithIdSchema<T extends z.ZodTypeAny>(docSchema: T) {
+//   return DocBaseSchema.and(docSchema);
+// }
+
+export const ProxyDocWithIdSchema = z.union([readonlyDocBaseSchema, z.any()]);
+
+export type ProxyDocWithId<T> = z.infer<typeof ProxyDocWithIdSchema> & T;
+
+/**
+ * Schema factory for DocSet<T> - creates a schema that intersects Partial<DocBase> with T
+ * @param docSchema - The Zod schema for type T (the document type)
+ * @returns A Zod schema for DocSet<T>
+ *
+ * @example
+ * const MyDocSchema = z.object({ name: z.string(), age: z.number() });
+ * const MyDocSetSchema = DocSetSchema(MyDocSchema);
+ * type MyDocSet = z.infer<typeof MyDocSetSchema>;
+ */
+export function DocSetSchema<T extends z.ZodTypeAny>(docSchema: T) {
+  return PartialDocBaseSchema.and(docSchema);
+}
+
+export type DocSet<T> = z.infer<ReturnType<typeof DocSetSchema<z.ZodType<T>>>>;

--- a/core/svc/protocol/index.ts
+++ b/core/svc/protocol/index.ts
@@ -1,0 +1,5 @@
+export * from "./database-protocol.js";
+export * from "./transport.js";
+export * from "./base.zod.js";
+export * from "./database-protocol-get.zod.js";
+export * from "./database-protocol-bulk.zod.js";

--- a/core/svc/protocol/package.json
+++ b/core/svc/protocol/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/svc/protocol/package.json
+++ b/core/svc/protocol/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@fireproof/core-runtime",
+  "name": "@fireproof/core-svc-protocol",
   "version": "0.0.0",
-  "description": "Live ledger for the web.",
+  "description": "Fireproof service layer protocols and interfaces.",
   "type": "module",
   "main": "./index.js",
   "scripts": {
@@ -27,7 +27,6 @@
   "author": "J Chris Anderson",
   "license": "AFL-2.0",
   "homepage": "https://use-fireproof.com",
-  "gptdoc": "import { fireproof } from 'use-fireproof'; const db = fireproof('app-db-name'); const ok = await db.put({ anyField: ['any','json'] }); const doc = await db.get(ok.id); await db.del(doc._id); db.subscribe(myRedrawFn); const result = await db.query('anyField', {range : ['a', 'z']}); result.rows.map(({ key }) => key);",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fireproof-storage/fireproof.git"
@@ -37,18 +36,10 @@
   },
   "dependencies": {
     "@adviser/cement": "^0.4.65",
-    "@adviser/ts-xxhash": "^1.0.2",
+    "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
-    "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",
-    "@fireproof/core-types-runtime": "workspace:0.0.0",
-    "@fireproof/vendor": "workspace:0.0.0",
     "cborg": "^4.3.0",
-    "jose": "^6.1.1",
-    "multiformats": "^13.4.0",
     "zod": "^4.1.12"
-  },
-  "devDependencies": {
-    "@fireproof/core-cli": "workspace:^"
   }
 }

--- a/core/svc/protocol/transport.ts
+++ b/core/svc/protocol/transport.ts
@@ -1,0 +1,88 @@
+import { isUint8Array, Logger, OnFunc, Result } from "@adviser/cement";
+import { MsgType } from "./database-protocol.js";
+import { SuperThis } from "@fireproof/core-types-base";
+import { ensureLogger } from "@fireproof/core-runtime";
+import { decode, encode } from "cborg";
+
+export interface FPTransportOriginCTX {
+  readonly origin: string;
+}
+
+export interface FPTransportTargetCTX extends FPTransportOriginCTX {
+  readonly target: string;
+}
+
+export interface FPTransport {
+  start(): Promise<Result<void>>;
+  send<R extends MsgType>(msg: R, ctx: FPTransportTargetCTX): Promise<Result<R>>;
+  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<Result<void>>): () => void;
+
+  onSend(fn: (msg: MsgType, ctx: FPTransportTargetCTX) => Promise<void>): () => void;
+  onRecv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<void>): () => void;
+}
+
+export interface FPWebWindow {
+  // readonly postMessage: Window["postMessage"];
+  postMessage(message: unknown, options?: string): void;
+  // readonly addEventListener: Window["addEventListener"];
+  addEventListener<T>(type: string, listener: (evt: T) => void, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener<T>(type: string, listener: (evt: T) => void, options?: boolean | EventListenerOptions): void;
+}
+export interface FPApiTransportCtx {
+  readonly transport: FPTransport;
+  readonly webWindow: FPWebWindow;
+}
+
+export class FPApiPostMessageTransport implements FPTransport {
+  readonly logger: Logger;
+  readonly webWindow: FPWebWindow;
+
+  readonly onSend = OnFunc<(msg: MsgType, ctx: FPTransportTargetCTX) => Promise<void>>();
+  readonly onRecv = OnFunc<(msg: MsgType, ctx: FPTransportOriginCTX) => Promise<void>>();
+
+  constructor(sthis: SuperThis, fpWindow: FPWebWindow) {
+    this.logger = ensureLogger(sthis, "FPApiTransport");
+    this.webWindow = fpWindow;
+  }
+
+  start() {
+    return Promise.resolve(Result.Ok());
+  }
+
+  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<Result<void>>): () => void {
+    const handleMessage = (event: MessageEvent) => {
+      const msgCbor = event.data;
+      if (!isUint8Array(msgCbor)) {
+        return this.logger.Warn().Msg("Received non-Uint8Array message in FPApiPostMessageTransport").ResultError();
+      }
+      const msg = decode(msgCbor);
+      const ctx: FPTransportOriginCTX = {
+        origin: event.origin,
+      };
+      this.onRecv.invoke(msg, ctx);
+      // console.log("FPApiPostMessageTransport received message", event, msg, ctx, fn.toString());
+      fn(msg, ctx);
+    };
+    // console.log("FPApiPostMessageTransport adding message listener");
+
+    this.webWindow.addEventListener("message", handleMessage);
+    return () => {
+      this.webWindow.removeEventListener("message", handleMessage);
+    };
+  }
+
+  async send<T extends MsgType>(msg: T, ctx: FPTransportTargetCTX): Promise<Result<T>> {
+    // console.log("FPApiPostMessageTransport:1 sending message", msg, ctx.target);
+    const cborMsg = encode(msg);
+    // console.log("FPApiPostMessageTransport:2 sending message", msg, ctx.target);
+    this.webWindow.postMessage(
+      {
+        origin: ctx.origin,
+        data: cborMsg,
+      },
+      ctx.target,
+    );
+    this.onSend.invoke(msg, ctx);
+    return Result.Ok(msg);
+  }
+}

--- a/core/tests/fireproof/utils.test.ts
+++ b/core/tests/fireproof/utils.test.ts
@@ -1,8 +1,9 @@
 import { runtimeFn, URI } from "@adviser/cement";
 import { getFileName } from "@fireproof/core-gateways-base";
-import { ensureSuperThis, ensureSuperLog, getStore, inplaceFilter } from "@fireproof/core-runtime";
+import { ensureSuperThis, ensureSuperLog, getStore, inplaceFilter, makePartial } from "@fireproof/core-runtime";
 import { UUID } from "uuidv7";
 import { describe, beforeAll, it, expect, assert } from "vitest";
+import { z } from "zod";
 
 describe("utils", () => {
   const sthis = ensureSuperThis();
@@ -133,5 +134,19 @@ describe("runtime", () => {
       isNodeIsh: isNode,
       isReactNative: false,
     });
+  });
+  it("zod makePartial", () => {
+    const BaseSchema = z.object({
+      a: z.string(),
+      b: z.number(),
+      c: z.boolean(),
+    });
+
+    const partialSchema = makePartial(BaseSchema);
+    const parsed = partialSchema.parse({ a: "hello", z: 1 });
+    expect(parsed).toEqual({ a: "hello" });
+
+    const parsed2 = partialSchema.safeParse({ a: "hello", b: "xx", z: 1 });
+    expect(parsed2.success).toBeFalsy();
   });
 });

--- a/core/tests/package.json
+++ b/core/tests/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",

--- a/core/tests/package.json
+++ b/core/tests/package.json
@@ -53,6 +53,9 @@
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
+    "@fireproof/core-svc-api": "workspace:0.0.0",
+    "@fireproof/core-svc-host": "workspace:0.0.0",
+    "@fireproof/core-svc-protocol": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",
@@ -66,7 +69,8 @@
     "charwise": "^3.0.1",
     "jose": "^6.1.1",
     "use-fireproof": "workspace:0.0.0",
-    "uuidv7": "^1.0.2"
+    "uuidv7": "^1.0.2",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@fireproof/core-cli": "workspace:0.0.0",

--- a/core/tests/svc/full-round-trip.test.ts
+++ b/core/tests/svc/full-round-trip.test.ts
@@ -1,0 +1,132 @@
+import { it, describe, beforeAll, expect, vi } from "vitest";
+import { fireproofProxy } from "@fireproof/core-svc-api";
+import { FPDatabaseSvc } from "@fireproof/core-svc-host";
+import { FPTransport, FPWebWindow, MsgType } from "@fireproof/core-svc-protocol";
+import { ensureLogger, ensureSuperThis } from "@fireproof/core-runtime";
+
+class DirectSide implements FPWebWindow {
+  // #otherSide?: DirectSide;
+  readonly mySide: string;
+  readonly recvHandlers: ((msg: unknown) => void)[] = [];
+  readonly targetSides: DirectSide[] = [];
+  constructor(mySide: string) {
+    this.mySide = mySide;
+  }
+  clone() {
+    return new DirectSide(this.mySide);
+  }
+  attachOtherSide(otherSide: DirectSide) {
+    // this.#otherSide = otherSide;
+    otherSide.targetSides.push(this);
+    this.targetSides.push(otherSide);
+    return this;
+  }
+  postMessage(msg: Event, target: string): void {
+    this.targetSides.find((side) => target === side.mySide)?.recvHandlers.forEach((h) => h({ ...msg, origin: this.mySide }));
+  }
+  addEventListener<T>(type: string, listener: (msg: T) => void, _options?: boolean | AddEventListenerOptions): void {
+    this.recvHandlers.push((msg: unknown) => {
+      return listener(msg as T);
+    });
+  }
+
+  removeEventListener<T>(_type: string, _listener: (msg: T) => void, _options?: boolean | EventListenerOptions): void {
+    // this.recvHandlers.splice(
+    //   this.recvHandlers.indexOf((msg: unknown) => listener(msg as T)),
+    //   1,
+    // );
+  }
+}
+
+const svcSide = new DirectSide("svcSide");
+// const proxySide = new DirectSide("proxySide");
+
+describe("Full Round Trip Tests", () => {
+  const sthis = ensureSuperThis();
+
+  const fpHost = new FPDatabaseSvc({
+    sthis,
+    logger: ensureLogger(sthis, "FPDatabaseSvcTestHost"),
+    webWindow: svcSide,
+  });
+
+  const fps = Array(5)
+    .fill(0)
+    .map((_, i) => {
+      const webWindow = new DirectSide(`proxySide-${i}`).attachOtherSide(svcSide);
+      const proxy = fireproofProxy(`frt-db-${i}`, {
+        target: "svcSide",
+        origin: "proxySide",
+        webWindow,
+      });
+      const transport = proxy.ledger.ctx.get("transport") as FPTransport;
+      const sendMock = vi.fn((...args: unknown[]) => Promise.resolve(console.log("sendMock called with", ...args)));
+      transport.onSend(sendMock);
+      const recvMock = vi.fn((...args: unknown[]) => Promise.resolve(console.log("recvMock called with", ...args)));
+      transport.onRecv(recvMock);
+      return {
+        webWindow,
+        transport,
+        sendMock,
+        recvMock,
+        proxy: fireproofProxy(`frt-db-${i}`, {
+          target: "svcSide",
+          origin: "proxySide",
+          webWindow,
+        }),
+      };
+    });
+
+  beforeAll(async () => {
+    await fpHost.start();
+  });
+
+  it("justReady", async () => {
+    for (const fp of fps) {
+      await fp.proxy.ready();
+      expect(fp.sendMock).toHaveBeenCalledTimes(1);
+      const send = fp.sendMock.mock.calls[0][0] as MsgType;
+      expect(fp.recvMock).toHaveBeenCalledWith(
+        {
+          dbId: expect.any(String),
+          dbName: fp.proxy.name,
+          src: expect.any(String),
+          tid: send.tid,
+          dst: send.src,
+          type: "resApplyDatabaseConfig",
+        },
+        { origin: "svcSide" },
+      );
+    }
+  });
+
+  it.skip("get non-existing doc", async () => {
+    for (const fp of fps) {
+      await expect(fp.proxy.get("non-existing-doc")).rejects.toThrowError("Document with ID non-existing-doc not found");
+    }
+  });
+
+  it.skip("bulk insert and get", async () => {
+    const now = Date.now();
+    for (const fp of fps) {
+      const docsToInsert = Array(5)
+        .fill(0)
+        .map((_, i) => ({
+          _id: `doc-${i}`,
+          data: {
+            value: `value-${i}`,
+            timestamp: now,
+            // eslint-disable-next-line no-restricted-globals
+            binValue: new TextEncoder().encode(`binary-${i}`),
+          },
+        }));
+      const bulkRes = await fp.proxy.bulk(docsToInsert);
+
+      expect(bulkRes.ids).toHaveLength(docsToInsert.length);
+      for (const doc of docsToInsert) {
+        const gotDoc = await fp.proxy.get(doc._id);
+        expect(gotDoc).toEqual(doc);
+      }
+    }
+  });
+});

--- a/core/types/base/database-config.zod.ts
+++ b/core/types/base/database-config.zod.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { BuildURI, URI, type CoerceURI, type ReadonlyURL, type WritableURL } from "@adviser/cement";
+
+// CoerceURI transformer - converts various types to string using URI.from()
+// CoerceURI = string | URI | ReadonlyURL | WritableURL | URL | BuildURI | NullOrUndef
+const CoerceURISchema = z
+  .union([
+    z.string(),
+    z.custom<URI>(),
+    z.custom<BuildURI>(),
+    z.custom<URL>(),
+    z.custom<ReadonlyURL>(),
+    z.custom<WritableURL>(),
+    z.null(),
+    z.undefined(),
+  ])
+  .transform((val) => URI.from(val as CoerceURI).toString());
+
+export const StoreUrlsSchema = z.object({
+  // string means local storage
+  // URL means schema selects the storeType
+  meta: CoerceURISchema.readonly(),
+  car: CoerceURISchema.readonly(),
+  file: CoerceURISchema.readonly(),
+  wal: CoerceURISchema.readonly(),
+});
+
+export const StoreUrlsOptsSchema = z
+  .object({
+    base: CoerceURISchema.readonly(),
+    data: StoreUrlsSchema.partial(),
+    idx: StoreUrlsSchema.partial(),
+  })
+  .readonly();
+
+export type StoreUrls = z.infer<typeof StoreUrlsSchema>;
+export type StoreUrlsOpts = z.infer<typeof StoreUrlsOptsSchema>;
+
+const DatabaseConfigSchemaBase = z.object({
+  env: z.record(z.string(), z.string()),
+  ctx: z.record(z.string(), z.string()),
+  // public: z.boolean(),
+  writeQueue: z.object({
+    chunkSize: z.number(),
+  }),
+  autoCompact: z.number(),
+  compactStrategy: z.string(), // default "FULL" other "fireproof" , "no-op"
+  storeUrls: StoreUrlsOptsSchema.optional(),
+  threshold: z.number(),
+});
+
+export const DatabaseConfigSchema = DatabaseConfigSchemaBase.readonly();
+
+export type DatabaseConfig = z.infer<typeof DatabaseConfigSchema>;
+
+export const DatabaseConfigWithNameSchema = DatabaseConfigSchemaBase.extend({
+  name: z.string(),
+  refId: z.string(), // typically hash of the config
+}).readonly();
+
+export type DatabaseConfigWithName = z.infer<typeof DatabaseConfigWithNameSchema>;

--- a/core/types/base/doc-base.zod.ts
+++ b/core/types/base/doc-base.zod.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for DocFileMeta interface
+ */
+export const DocFileMetaSchema = z
+  .object({
+    type: z.string(),
+    size: z.number(),
+    cid: z.any(), // AnyLink type - would need proper schema if AnyLink has a specific structure
+    car: z.any().optional(), // AnyLink type
+    lastModified: z.number().optional(),
+    url: z.string().optional(),
+    // file is a function that returns Promise<File>, but Zod function validation is complex
+    // so we'll use z.any() for the function type
+    file: z.any().optional(),
+  })
+  .readonly();
+
+export type DocFileMeta = z.infer<typeof DocFileMetaSchema>;
+
+/**
+ * Schema for DocFiles - a record of DocFileMeta or File objects
+ */
+export const DocFilesSchema = z.record(z.string(), z.union([DocFileMetaSchema, z.instanceof(File)]));
+
+export type DocFiles = z.infer<typeof DocFilesSchema>;
+
+/**
+ * Zod schema for DocBase interface
+ */
+export const DocBaseSchema = z
+  .object({
+    _id: z.string(),
+    _files: DocFilesSchema.optional(),
+    _publicFiles: DocFilesSchema.optional(),
+    _deleted: z.boolean().optional(),
+  })
+  .readonly();
+
+export type DocBase = z.infer<typeof DocBaseSchema>;
+
+/**
+ * Partial version of DocBaseSchema for use in DocSet
+ */
+const PartialDocBaseSchema = z
+  .object({
+    _id: z.string(),
+    _files: DocFilesSchema.optional(),
+    _publicFiles: DocFilesSchema.optional(),
+    _deleted: z.boolean().optional(),
+  })
+  .partial()
+  .readonly();
+
+/**
+ * Schema factory for DocWithId<T> - creates a schema that intersects DocBase with T
+ * @param docSchema - The Zod schema for type T (the document type)
+ * @returns A Zod schema for DocWithId<T>
+ *
+ * @example
+ * const MyDocSchema = z.object({ name: z.string(), age: z.number() });
+ * const MyDocWithIdSchema = DocWithIdSchema(MyDocSchema);
+ * type MyDocWithId = z.infer<typeof MyDocWithIdSchema>;
+ */
+export function DocWithIdSchema<T extends z.ZodTypeAny>(docSchema: T) {
+  return DocBaseSchema.and(docSchema);
+}
+
+export type DocWithId<T> = z.infer<ReturnType<typeof DocWithIdSchema<z.ZodType<T>>>>;
+
+/**
+ * Schema factory for DocSet<T> - creates a schema that intersects Partial<DocBase> with T
+ * @param docSchema - The Zod schema for type T (the document type)
+ * @returns A Zod schema for DocSet<T>
+ *
+ * @example
+ * const MyDocSchema = z.object({ name: z.string(), age: z.number() });
+ * const MyDocSetSchema = DocSetSchema(MyDocSchema);
+ * type MyDocSet = z.infer<typeof MyDocSetSchema>;
+ */
+export function DocSetSchema<T extends z.ZodTypeAny>(docSchema: T) {
+  return PartialDocBaseSchema.and(docSchema);
+}
+
+export type DocSet<T> = z.infer<ReturnType<typeof DocSetSchema<z.ZodType<T>>>>;

--- a/core/types/base/index.ts
+++ b/core/types/base/index.ts
@@ -11,3 +11,4 @@ export * from "./device-id.js";
 export * from "./device-id-keybag-item.zod.js";
 
 export * from "./keybag-storage.zod.js";
+export * from "./database-config.zod.js";

--- a/core/types/base/package.json
+++ b/core/types/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@web3-storage/pail": "^0.6.2",

--- a/core/types/blockstore/package.json
+++ b/core/types/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-runtime": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/protocols/cloud/package.json
+++ b/core/types/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/runtime/package.json
+++ b/core/types/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/vendor": "workspace:0.0.0",
     "multiformats": "^13.4.0"
   }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,7 +25,7 @@
     "publish": "echo skip"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@clerk/backend": "^2.21.0",
     "@clerk/clerk-js": "^5.107.0",
     "@clerk/clerk-react": "^5.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,34 @@ importers:
         specifier: ^8.8.5
         version: 8.8.5
 
+  cloud/box-party:
+    dependencies:
+      '@adviser/cement':
+        specifier: 0.4.65
+        version: 0.4.65(typescript@5.9.3)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.0(react@19.2.0)
+      use-fireproof:
+        specifier: workspace:0.0.0
+        version: link:../../use-fireproof
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.3
+      '@types/react-dom':
+        specifier: ^19.2.2
+        version: 19.2.3(@types/react@19.2.3)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.0
+        version: 5.1.1(vite@7.2.2(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+      vite:
+        specifier: ^7.1.12
+        version: 7.2.2(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+
   cloud/todo-app:
     dependencies:
       '@adviser/cement':
@@ -855,10 +883,79 @@ importers:
       multiformats:
         specifier: ^13.4.0
         version: 13.4.1
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@fireproof/core-cli':
         specifier: workspace:^
         version: link:../../cli
+
+  core/svc/api:
+    dependencies:
+      '@adviser/cement':
+        specifier: ^0.4.65
+        version: 0.4.65(typescript@5.9.3)
+      '@fireproof/core-runtime':
+        specifier: workspace:0.0.0
+        version: link:../../runtime
+      '@fireproof/core-svc-protocol':
+        specifier: workspace:0.0.0
+        version: link:../protocol
+      '@fireproof/core-types-base':
+        specifier: workspace:0.0.0
+        version: link:../../types/base
+      '@fireproof/core-types-blockstore':
+        specifier: workspace:0.0.0
+        version: link:../../types/blockstore
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+
+  core/svc/host:
+    dependencies:
+      '@adviser/cement':
+        specifier: ^0.4.65
+        version: 0.4.65(typescript@5.9.3)
+      '@fireproof/core-base':
+        specifier: workspace:0.0.0
+        version: link:../../base
+      '@fireproof/core-runtime':
+        specifier: workspace:0.0.0
+        version: link:../../runtime
+      '@fireproof/core-svc-protocol':
+        specifier: workspace:0.0.0
+        version: link:../protocol
+      '@fireproof/core-types-base':
+        specifier: workspace:0.0.0
+        version: link:../../types/base
+      '@fireproof/core-types-blockstore':
+        specifier: workspace:0.0.0
+        version: link:../../types/blockstore
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+
+  core/svc/protocol:
+    dependencies:
+      '@adviser/cement':
+        specifier: ^0.4.65
+        version: 0.4.65(typescript@5.9.3)
+      '@fireproof/core-runtime':
+        specifier: workspace:0.0.0
+        version: link:../../runtime
+      '@fireproof/core-types-base':
+        specifier: workspace:0.0.0
+        version: link:../../types/base
+      '@fireproof/core-types-blockstore':
+        specifier: workspace:0.0.0
+        version: link:../../types/blockstore
+      cborg:
+        specifier: ^4.3.0
+        version: 4.3.0
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
 
   core/tests:
     dependencies:
@@ -901,6 +998,15 @@ importers:
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../runtime
+      '@fireproof/core-svc-api':
+        specifier: workspace:0.0.0
+        version: link:../svc/api
+      '@fireproof/core-svc-host':
+        specifier: workspace:0.0.0
+        version: link:../svc/host
+      '@fireproof/core-svc-protocol':
+        specifier: workspace:0.0.0
+        version: link:../svc/protocol
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../types/base
@@ -946,6 +1052,9 @@ importers:
       uuidv7:
         specifier: ^1.0.2
         version: 1.0.2
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@fireproof/core-cli':
         specifier: workspace:0.0.0
@@ -3602,10 +3711,6 @@ packages:
 
   carstream@2.3.0:
     resolution: {integrity: sha512-2YwFg5Kxs2tqVCJv7sthWbYoUpALCYBBfTdpQcpicV7ipi6bBb1h9M4MNb1vm+724f39lUNp5VWhW43IFxfPlA==}
-
-  cborg@4.2.15:
-    resolution: {integrity: sha512-T+YVPemWyXcBVQdp0k61lQp2hJniRNmul0lAwTj2DTS/6dI4eCq/MRMucGqqvFqMBfmnD8tJ9aFtPu5dEGAbgw==}
-    hasBin: true
 
   cborg@4.3.0:
     resolution: {integrity: sha512-vOXo1pB4mdeBw3LbpoynQlZNw/H3kZVHLtPYlp8kFMreL/2YfT54F70BM1s3iDoCtQ+3C9QmiRF4rfCSSTlhBw==}
@@ -7179,18 +7284,18 @@ snapshots:
   '@ipld/car@5.4.2':
     dependencies:
       '@ipld/dag-cbor': 9.2.5
-      cborg: 4.2.15
+      cborg: 4.3.0
       multiformats: 13.4.1
       varint: 6.0.0
 
   '@ipld/dag-cbor@9.2.5':
     dependencies:
-      cborg: 4.2.15
+      cborg: 4.3.0
       multiformats: 13.4.1
 
   '@ipld/dag-json@10.2.5':
     dependencies:
-      cborg: 4.2.15
+      cborg: 4.3.0
       multiformats: 13.4.1
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -8136,8 +8241,6 @@ snapshots:
       '@ipld/dag-cbor': 9.2.5
       multiformats: 13.4.1
       uint8arraylist: 2.4.8
-
-  cborg@4.2.15: {}
 
   cborg@4.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
   cli:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../core/runtime
@@ -135,8 +135,8 @@ importers:
   cloud/3rd-party:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -163,8 +163,8 @@ importers:
   cloud/backend/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251111.0
         version: 4.20251111.0
@@ -227,8 +227,8 @@ importers:
   cloud/backend/cf-d1:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251111.0
         version: 4.20251111.0
@@ -288,8 +288,8 @@ importers:
   cloud/backend/node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/cloud-backend-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -349,8 +349,8 @@ importers:
   cloud/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../../core/blockstore
@@ -389,8 +389,8 @@ importers:
   cloud/box-party:
     dependencies:
       '@adviser/cement':
-        specifier: 0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: 0.4.66
+        version: 0.4.66(typescript@5.9.3)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -417,8 +417,8 @@ importers:
   cloud/todo-app:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../vendor
@@ -448,8 +448,8 @@ importers:
   core/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -494,8 +494,8 @@ importers:
   core/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../gateways/base
@@ -554,8 +554,8 @@ importers:
   core/core:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -575,8 +575,8 @@ importers:
   core/device-id:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-keybag':
         specifier: workspace:0.0.0
         version: link:../keybag
@@ -606,8 +606,8 @@ importers:
   core/gateways/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -630,8 +630,8 @@ importers:
   core/gateways/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -660,8 +660,8 @@ importers:
   core/gateways/file:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -697,8 +697,8 @@ importers:
   core/gateways/file-deno:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -715,8 +715,8 @@ importers:
   core/gateways/file-node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -727,8 +727,8 @@ importers:
   core/gateways/indexeddb:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -751,8 +751,8 @@ importers:
   core/gateways/memory:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -782,8 +782,8 @@ importers:
   core/keybag:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-gateways-file':
         specifier: workspace:0.0.0
         version: link:../gateways/file
@@ -812,8 +812,8 @@ importers:
   core/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -836,8 +836,8 @@ importers:
   core/protocols/dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -854,8 +854,8 @@ importers:
   core/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@adviser/ts-xxhash':
         specifier: ^1.0.2
         version: 1.0.2
@@ -894,8 +894,8 @@ importers:
   core/svc/api:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -915,8 +915,8 @@ importers:
   core/svc/host:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -939,8 +939,8 @@ importers:
   core/svc/protocol:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -960,8 +960,8 @@ importers:
   core/tests:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core':
         specifier: workspace:0.0.0
         version: link:../core
@@ -1078,8 +1078,8 @@ importers:
   core/types/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-types-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -1105,8 +1105,8 @@ importers:
   core/types/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -1130,8 +1130,8 @@ importers:
   core/types/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -1158,8 +1158,8 @@ importers:
   core/types/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../../vendor
@@ -1170,8 +1170,8 @@ importers:
   dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@clerk/backend':
         specifier: ^2.21.0
         version: 2.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1339,8 +1339,8 @@ importers:
   use-fireproof:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../core/base
@@ -1409,8 +1409,8 @@ importers:
   vendor:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.4.65
-        version: 0.4.65(typescript@5.9.3)
+        specifier: ^0.4.66
+        version: 0.4.66(typescript@5.9.3)
       yocto-queue:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1442,8 +1442,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@adviser/cement@0.4.65':
-    resolution: {integrity: sha512-tq90p+n+gExR+ROEoJ95MK3qvJwO6b/qY9Y1dvbcl1th0d4Z6JaD/tv21ETnUCLu04NsSaXUYciiKrm6dktLXA==}
+  '@adviser/cement@0.4.66':
+    resolution: {integrity: sha512-XBILRw/kIOKiXpam6WYZ5GY2V/uPJXNNhzQAHPudXfUG9iK0rn6QFKxWq8cJft39xAl0MZjEKkiqNT0orebKVw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6156,7 +6156,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@adviser/cement@0.4.65(typescript@5.9.3)':
+  '@adviser/cement@0.4.66(typescript@5.9.3)':
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       yaml: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,13 +7,14 @@ packages:
   - "core/types/protocols/*"
   - "core/gateways/*"
   - "core/protocols/*"
+  - "core/svc/*"
   - "use-fireproof"
   - "dashboard"
   - "vendor"
 #catalog:
 #  adviserCement: ^0.4.20
 #
-overrides:
+#overrides:
 #  "@types/node": "^24.0.10"
 #  "@adviser/cement": "^0.4.20"
 #  "wrangler": "^4.24.0"

--- a/use-fireproof/package.json
+++ b/use-fireproof/package.json
@@ -22,7 +22,7 @@
   "license": "AFL-2.0",
   "gptdoc": "Fireproof/React/Usage: import { useFireproof } from 'use-fireproof'; function WordCounterApp() { const { useLiveQuery, useDocument } = useFireproof('my-word-app'); const { doc: wordInput, merge: updateWordInput, save: saveWordInput, reset: clearWordInput } = useDocument({ word: '', timestamp: Date.now() }); const recentWords = useLiveQuery('timestamp', { descending: true, limit: 10 }); const { doc: { totalSubmitted }, merge: updateTotalSubmitted, save: saveTotalSubmitted } = useDocument({ _id: 'word-counter', totalSubmitted: 0 }); const handleWordSubmission = (e) => { e.preventDefault(); updateTotalSubmitted({ totalSubmitted: totalSubmitted + 1 }); saveTotalSubmitted(); saveWordInput(); clearWordInput();}; return (<><p>{totalSubmitted} words submitted</p><form onSubmit={handleWordSubmission}><input type='text' value={wordInput.word} onChange={e => updateWordInput({ word: e.target.value })} placeholder='Enter a word' /></form><ul>{recentWords.docs.map(entry => (<li key={entry._id}>{entry.word}</li>))} </ul></>) } export default WordCounterApp;",
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -29,7 +29,7 @@
     "zx": "^8.8.5"
   },
   "dependencies": {
-    "@adviser/cement": "^0.4.65",
+    "@adviser/cement": "^0.4.66",
     "yocto-queue": "^1.2.2"
   }
 }


### PR DESCRIPTION
  Implement a new service architecture that decouples database operations through a proxy pattern with strongly-typed protocols.
  This enables remote database access and prepares for multi-process/cross-runtime support.

  - Add database-api with DatabaseProxy implementing the Database interface
  - Add database-host for serving database operations over a transport layer
  - Define Zod-based protocol schemas for type-safe message passing (get, bulk operations)
  - Implement transport abstraction for cross-context communication (PostMessage-based)
  - Add full round-trip integration tests for the service layer
  - Add database configuration protocol for remote database initialization

  This establishes the foundation for running Fireproof databases across different execution contexts (workers, iframes, remote
  processes) while maintaining type safety end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database proxy service layer enabling remote database operations.
  * Introduced message-driven database host service.
  * New validation schemas for database protocol messaging.

* **Chores**
  * Updated @adviser/cement dependency across multiple packages.
  * Added zod validation library.
  * Expanded workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->