### PR TITLE
Fix to store added files in remotes and fetch from remotes if missing locally

### DIFF
--- a/core/blockstore/store.ts
+++ b/core/blockstore/store.ts
@@ -29,7 +29,7 @@ import {
   UnsubscribeResult,
   CommitQueueIf,
 } from "@fireproof/core-types-blockstore";
-import { Falsy, isNotFoundError, PARAM, StoreType, SuperThis, throwFalsy } from "@fireproof/core-types-base";
+import { Falsy, isNotFoundError, PARAM, StoreType, SuperThis } from "@fireproof/core-types-base";
 import { carLogIncludesGroup } from "./loader.js";
 import { EventView } from "@web3-storage/pail/clock/api";
 import { EventBlock } from "@web3-storage/pail/clock";

--- a/core/blockstore/store.ts
+++ b/core/blockstore/store.ts
@@ -29,7 +29,7 @@ import {
   UnsubscribeResult,
   CommitQueueIf,
 } from "@fireproof/core-types-blockstore";
-import { Falsy, isNotFoundError, PARAM, StoreType, SuperThis } from "@fireproof/core-types-base";
+import { Falsy, isNotFoundError, PARAM, StoreType, SuperThis, throwFalsy } from "@fireproof/core-types-base";
 import { carLogIncludesGroup } from "./loader.js";
 import { EventView } from "@web3-storage/pail/clock/api";
 import { EventBlock } from "@web3-storage/pail/clock";
@@ -519,9 +519,9 @@ export class WALStoreImpl extends BaseStoreImpl implements WALStore {
         noLoaderOps,
         async (dbMeta) => {
           await retryableUpload(async () => {
-            // if (!this.loader) {
-            //   return;
-            // }
+            if (!this.loader) {
+              return;
+            }
             for (const cid of dbMeta.cars) {
               const car = await this.loader.attachedStores.local().active.car.load(cid);
               // .carStore().then((i) => i.load(cid));
@@ -529,9 +529,11 @@ export class WALStoreImpl extends BaseStoreImpl implements WALStore {
                 if (carLogIncludesGroup(this.loader.carLog.asArray(), dbMeta.cars)) {
                   throw this.logger.Error().Ref("cid", cid).Msg("missing local car").AsError();
                 }
-                // } else {
-                //   await this.loader.attachedStores.forRemotes((x) => x.active.car.save(car));
-                // throwFalsy(this.loader.xremoteCarStore).save(car);
+              } else {
+                await this.loader.attachedStores.forRemotes(async (x) => {
+                  await x.active.car.save(car);
+                });
+                // await throwFalsy(this.loader.xremoteCarStore).save(car);
               }
             }
             // Remove from walState after successful upload
@@ -546,20 +548,20 @@ export class WALStoreImpl extends BaseStoreImpl implements WALStore {
         operations,
         async (dbMeta) => {
           await retryableUpload(async () => {
-            // if (!this.loader) {
-            //   return;
-            // }
+            if (!this.loader) {
+              return;
+            }
             for (const cid of dbMeta.cars) {
               const car = await this.loader.attachedStores.local().active.car.load(cid);
               if (!car) {
                 if (carLogIncludesGroup(this.loader.carLog.asArray(), dbMeta.cars)) {
                   throw this.logger.Error().Ref("cid", cid).Msg(`missing local car`).AsError();
                 }
-                // } else {
-                //   // await throwFalsy(this.loader.xremoteCarStore).save(car);
-                //   await this.loader.attachedStores.forRemotes(async (x) => {
-                //     await x.active.car.save(car);
-                //   });
+              } else {
+                   // await throwFalsy(this.loader.xremoteCarStore).save(car);
+                await this.loader.attachedStores.forRemotes(async (x) => {
+                  await x.active.car.save(car);
+                });
               }
             }
             // Remove from walState after successful upload
@@ -572,15 +574,19 @@ export class WALStoreImpl extends BaseStoreImpl implements WALStore {
       // Process fileOperations
       await pMap(
         fileOperations,
-        async ({ cid: fileCid }) => {
+        async ({ cid: fileCid, public: publicFile }) => {
           await retryableUpload(async () => {
-            // if (!this.loader) {
-            //   return;
-            // }
+            if (!this.loader) {
+              return;
+            }
             const fileBlock = await this.loader.attachedStores.local().active.file.load(fileCid);
             if (!fileBlock) {
               throw this.logger.Error().Ref("cid", fileCid).Msg("missing file block").AsError();
             }
+
+            await this.loader.attachedStores.forRemotes(async (x) => {
+              await x.active.file.save(fileBlock, { public: publicFile });
+            });
             // await this.loader.attachedStores.forRemotes((x) => x.active.file.save(fileBlock, { public: publicFile }));
             // await this.loader.xremoteFileStore?.save(fileBlock, { public: publicFile });
             // Remove from walState after successful upload
@@ -597,6 +603,10 @@ export class WALStoreImpl extends BaseStoreImpl implements WALStore {
           if (!this.loader) {
             return;
           }
+
+          await this.loader.attachedStores.forRemotes(async (x) => {
+            await x.active.meta.save(lastOp);
+          });
           // await this.loader.xremoteMetaStore?.save(lastOp);
           // await this.loader.attachedStores.forRemotes((x) => x.active.meta.save(lastOp));
         }, `remoteMetaStore save with dbMeta.cars=${lastOp.cars.toString()}`);


### PR DESCRIPTION
As discussed on Discord, the sync of files got broken in recent codebase changes. This change pushes locally added files to the registered remotes and uses the remotes as fallback if an attachment does not yet exist locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote fallback loading: the system now attempts to load from remote sources when local retrieval fails, automatically caching successful remote data locally.
  * Enhanced remote data synchronization to ensure files and metadata are consistently propagated to all configured remote stores.

* **Bug Fixes**
  * Improved error handling for file operations with structured logging for better troubleshooting and error context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->