### PR TITLE
feat: Add version pinning utility and improve JWK handling

### DIFF
--- a/actions/base/action.yaml
+++ b/actions/base/action.yaml
@@ -50,36 +50,17 @@ runs:
         pnpm exec playwright --version
         git config --global --add safe.directory $(pwd)
 
-    - name: test Attempt 1
+    - name: test
       shell: bash
       env:
         FP_CI: fp_ci
-      id: attempt1
-      continue-on-error: true
-      run: pnpm run test
+      run: pnpm exec core-cli retry -- pnpm run test
 
-    - name: test Attempt 2
+    - name: test:deno
       shell: bash
       env:
         FP_CI: fp_ci
-      if: steps.attempt1.outcome == 'failure'
-      run: pnpm run test
-
-    - name: test:deno 1
-      shell: bash
-      env:
-        FP_CI: fp_ci
-      id: denoattempt1
-      run: pnpm run test:deno
-      continue-on-error: true
-
-    - name: test:deno 2
-      shell: bash
-      env:
-        FP_CI: fp_ci
-      id: denoattempt2
-      if: steps.denoattempt1.outcome == 'failure'
-      run: pnpm run test:deno
+      run: pnpm exec core-cli retry -- pnpm run test:deno
 
     - name: start-esm + npm
       shell: bash
@@ -89,17 +70,8 @@ runs:
         bash smoke/setup-local-esm-npm.sh
         #cp ./dist/npmrc-smoke .npmrc
 
-    - name: smoke Attempt 1
+    - name: smoke
       shell: bash
       env:
         FP_CI: fp_ci
-      id: smoke_attempt1
-      continue-on-error: true
-      run: pnpm run smoke
-
-    - name: smoke Attempt 2
-      shell: bash
-      env:
-        FP_CI: fp_ci
-      if: steps.smoke_attempt1.outcome == 'failure'
-      run: pnpm run smoke-retry
+      run: pnpm exec core-cli retry -- pnpm run smoke

--- a/cli/build-cmd.test.ts
+++ b/cli/build-cmd.test.ts
@@ -41,14 +41,6 @@ it("should set package version but leave workspace dependencies as-is", async ()
   expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "workspace:0.0.0");
 });
 
-it("should set package version (duplicate test)", async () => {
-  const version = new Version("0.0.0-smoke", "^");
-  const { patchedPackageJson } = await patchPackageJson("package.json", version, undefined, mock);
-  expect(patchedPackageJson.version).toBe("0.0.0-smoke");
-  // Workspace dependencies are no longer replaced by patchPackageJson - use VersionPinner for that
-  expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "workspace:0.0.0");
-});
-
 it("should only use prefix version in dependencies", async () => {
   const version = new Version("0.0.0-smoke", "^");
   const { patchedPackageJson } = await patchPackageJson("package.json", version, undefined, mock);

--- a/cli/build-cmd.test.ts
+++ b/cli/build-cmd.test.ts
@@ -33,18 +33,20 @@ it("getVersion emptyString", async () => {
   expect(await getVersion("", { xenv: {} })).toContain("0.0.0-smoke");
 });
 
-it("should only use prefix version in dependencies", async () => {
+it("should set package version but leave workspace dependencies as-is", async () => {
   const version = new Version("0.0.0-smoke", "^");
   const { patchedPackageJson } = await patchPackageJson("package.json", version, undefined, mock);
   expect(patchedPackageJson.version).toBe("0.0.0-smoke");
-  expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "^0.0.0-smoke");
+  // Workspace dependencies are no longer replaced by patchPackageJson - use VersionPinner for that
+  expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "workspace:0.0.0");
 });
 
-it("should only use prefix version in dependencies", async () => {
+it("should set package version (duplicate test)", async () => {
   const version = new Version("0.0.0-smoke", "^");
   const { patchedPackageJson } = await patchPackageJson("package.json", version, undefined, mock);
   expect(patchedPackageJson.version).toBe("0.0.0-smoke");
-  expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "^0.0.0-smoke");
+  // Workspace dependencies are no longer replaced by patchPackageJson - use VersionPinner for that
+  expect(patchedPackageJson.dependencies).toHaveProperty("@fireproof/vendor", "workspace:0.0.0");
 });
 
 it("should only use prefix version in dependencies", async () => {

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -12,6 +12,7 @@ import { dependabotCmd } from "./dependabot-cmd.js";
 import { testContainerCmd } from "./test-container-cmd.js";
 import { deviceIdCmd } from "./device-id-cmd.js";
 import { wellKnownCmd } from "./well-known-cmd.js";
+import { retryCmd } from "./retry-cmd.js";
 
 (async () => {
   dotenv.config(process.env.FP_ENV ?? ".env");
@@ -38,6 +39,7 @@ import { wellKnownCmd } from "./well-known-cmd.js";
       testContainer: testContainerCmd(sthis),
       deviceId: deviceIdCmd(sthis),
       wellKnown: wellKnownCmd(sthis),
+      retry: retryCmd(sthis),
     },
   });
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -5,7 +5,7 @@ import { dotenv } from "zx";
 import { buildCmd } from "./build-cmd.js";
 import { setDependenciesCmd, setScriptsCmd } from "./set-scripts-cmd.js";
 import { handleTsc, tscCmd } from "./tsc-cmd.js";
-import { writeEnvCmd } from "./write-env.js";
+import { writeEnvCmd } from "./write-env-cmd.js";
 import { keyCmd } from "./cloud-token-key-cmd.js";
 import { preSignedUrlCmd } from "./pre-signed-url.js";
 import { dependabotCmd } from "./dependabot-cmd.js";

--- a/cli/package.json
+++ b/cli/package.json
@@ -62,7 +62,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/semver": "^7.7.1",
     "tsx": "^4.20.4",
-    "vitest": "^4.0.8",
-    "why-is-node-running": "^3.2.2"
+    "vitest": "^4.0.8"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,6 +55,7 @@
     "multiformats": "^13.4.0",
     "open": "^11.0.0",
     "semver": "^7.7.3",
+    "zod": "^4.1.13",
     "zx": "^8.8.5"
   },
   "devDependencies": {

--- a/cli/retry-cmd.ts
+++ b/cli/retry-cmd.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { command, option, string, restPositionals } from "cmd-ts";
+import { command, option, number, restPositionals } from "cmd-ts";
 import { SuperThis } from "@fireproof/core-types-base";
 import { $ } from "zx";
 import { timeouted, isSuccess, isTimeout, isAborted, isError } from "@adviser/cement";
@@ -13,15 +13,15 @@ export function retryCmd(_sthis: SuperThis) {
         long: "retry",
         short: "r",
         description: "Number of retry attempts (default: 2)",
-        type: string,
-        defaultValue: () => "2",
+        type: number,
+        defaultValue: () => 2,
       }),
       timeout: option({
         long: "timeout",
         short: "t",
         description: "Timeout in seconds for each attempt (0 = no timeout)",
-        type: string,
-        defaultValue: () => "0",
+        type: number,
+        defaultValue: () => 0,
       }),
       command: restPositionals({
         description: "Command and arguments to execute",
@@ -29,8 +29,8 @@ export function retryCmd(_sthis: SuperThis) {
       }),
     },
     handler: async function (args) {
-      const retryCount = parseInt(args.retry, 10);
-      const timeoutSec = parseInt(args.timeout, 10);
+      const retryCount = args.retry;
+      const timeoutSec = args.timeout;
 
       if (isNaN(retryCount) || retryCount < 1) {
         console.error("Error: --retry must be a positive number");

--- a/cli/retry-cmd.ts
+++ b/cli/retry-cmd.ts
@@ -1,0 +1,113 @@
+/* eslint-disable no-console */
+import { command, option, string, restPositionals } from "cmd-ts";
+import { SuperThis } from "@fireproof/core-types-base";
+import { $ } from "zx";
+import { timeouted, isSuccess, isTimeout, isAborted, isError } from "@adviser/cement";
+
+export function retryCmd(_sthis: SuperThis) {
+  return command({
+    name: "retry",
+    description: "Execute a command with retry logic and timeout support.",
+    args: {
+      retry: option({
+        long: "retry",
+        short: "r",
+        description: "Number of retry attempts (default: 2)",
+        type: string,
+        defaultValue: () => "2",
+      }),
+      timeout: option({
+        long: "timeout",
+        short: "t",
+        description: "Timeout in seconds for each attempt (0 = no timeout)",
+        type: string,
+        defaultValue: () => "0",
+      }),
+      command: restPositionals({
+        description: "Command and arguments to execute",
+        displayName: "command",
+      }),
+    },
+    handler: async function (args) {
+      const retryCount = parseInt(args.retry, 10);
+      const timeoutSec = parseInt(args.timeout, 10);
+
+      if (isNaN(retryCount) || retryCount < 1) {
+        console.error("Error: --retry must be a positive number");
+        process.exit(1);
+      }
+
+      if (isNaN(timeoutSec) || timeoutSec < 0) {
+        console.error("Error: --timeout must be a non-negative number");
+        process.exit(1);
+      }
+
+      if (!args.command || args.command.length === 0) {
+        console.error("Error: No command specified");
+        process.exit(1);
+      }
+
+      const commandStr = args.command.join(" ");
+      const maxAttempts = retryCount;
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const isLastAttempt = attempt === maxAttempts;
+
+        console.log(`[Attempt ${attempt}/${maxAttempts}] Running: ${commandStr}`);
+
+        const executeCommand = async () => {
+          $.verbose = true;
+          const result = await $`${args.command}`.nothrow();
+
+          if (result.exitCode !== 0) {
+            throw new Error(`Command failed with exit code ${result.exitCode}`);
+          }
+
+          return result;
+        };
+
+        const result = await timeouted(executeCommand(), { timeout: timeoutSec * 1000 });
+
+        switch (true) {
+          case isSuccess(result): {
+            console.log(`[Attempt ${attempt}/${maxAttempts}] Command succeeded`);
+            process.exit(0);
+            break;
+          }
+
+          case isTimeout(result): {
+            console.error(`[Attempt ${attempt}/${maxAttempts}] Command timed out after ${timeoutSec}s`);
+            if (isLastAttempt) {
+              console.error(`All ${maxAttempts} attempts failed. Last failure: timeout`);
+              process.exit(124);
+            }
+            break;
+          }
+
+          case isAborted(result): {
+            console.error(`[Attempt ${attempt}/${maxAttempts}] Command was aborted`);
+            if (isLastAttempt) {
+              console.error(`All ${maxAttempts} attempts failed. Last failure: aborted`);
+              process.exit(130);
+            }
+            break;
+          }
+
+          case isError(result): {
+            const errorMsg = result.error instanceof Error ? result.error.message : String(result.error);
+            console.error(`[Attempt ${attempt}/${maxAttempts}] Command failed: ${errorMsg}`);
+            if (isLastAttempt) {
+              console.error(`All ${maxAttempts} attempts failed. Last failure: ${errorMsg}`);
+              process.exit(1);
+            }
+            break;
+          }
+
+          default: {
+            throw new Error("Unhandled result state");
+          }
+        }
+      }
+    },
+  });
+}

--- a/cli/version-pinner.test.ts
+++ b/cli/version-pinner.test.ts
@@ -1,0 +1,270 @@
+import { expect, it, describe, beforeAll } from "vitest";
+import { VersionPinner } from "./version-pinner.js";
+import { PackageJson } from "./build-cmd.js";
+import { findUp } from "find-up";
+import { $ } from "zx";
+
+// Helper to get installed version from pnpm list
+async function getInstalledVersion(packageName: string): Promise<string> {
+  // eslint-disable-next-line no-restricted-globals
+  const curFileDirectory = new URL(".", import.meta.url).pathname;
+  const result = await $`cd ${curFileDirectory} && pnpm list ${packageName} --depth 1 --json`.quiet();
+  const json = JSON.parse(result.stdout);
+  const version = json[0]?.dependencies?.[packageName]?.version || json[0]?.devDependencies?.[packageName]?.version;
+  if (!version) {
+    throw new Error(`Could not find installed version for ${packageName}`);
+  }
+  return version;
+}
+
+// Template for test package.json
+const pkgTemplate: PackageJson = {
+  name: "@fireproof/test-package",
+  version: "1.0.0",
+  license: "MIT",
+  scripts: {},
+  exports: {},
+  dependencies: {},
+  devDependencies: {},
+};
+
+describe("VersionPinner", () => {
+  let pinner: VersionPinner;
+  let cmdTsVersion: string;
+  let semverVersion: string;
+  let multiformatsVersion: string;
+
+  beforeAll(async () => {
+    const lockfilePath = await findUp("pnpm-lock.yaml");
+    if (!lockfilePath) {
+      throw new Error("Could not find pnpm-lock.yaml");
+    }
+
+    pinner = await VersionPinner.create({ lockfilePath });
+
+    // Get actual installed versions from pnpm
+    cmdTsVersion = await getInstalledVersion("cmd-ts");
+    semverVersion = await getInstalledVersion("semver");
+    multiformatsVersion = await getInstalledVersion("multiformats");
+  });
+
+  describe("pinVersions", () => {
+    it("should pin unpinned dependencies with caret (^)", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "cmd-ts": `^${cmdTsVersion}`,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should pin the version
+      expect(result.dependencies["cmd-ts"]).toBe(cmdTsVersion);
+    });
+
+    it("should pin unpinned dependencies with tilde (~)", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          semver: `~${semverVersion}`,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should pin the version
+      expect(result.dependencies["semver"]).toBe(semverVersion);
+    });
+
+    it("should pin unpinned dependencies with asterisk (*)", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          multiformats: "*",
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should pin to the version from lockfile
+      expect(result.dependencies["multiformats"]).toBe(multiformatsVersion);
+    });
+
+    it("should keep already pinned versions as-is", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "cmd-ts": cmdTsVersion,
+          semver: semverVersion,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should keep already pinned versions unchanged
+      expect(result.dependencies["cmd-ts"]).toBe(cmdTsVersion);
+      expect(result.dependencies["semver"]).toBe(semverVersion);
+    });
+
+    it("should keep pinned versions as-is without looking in lockfile", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "fake-package": "1.2.3",
+          "another-fake": "4.5.6",
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should keep pinned versions even if they don't exist in lockfile
+      expect(result.dependencies["fake-package"]).toBe("1.2.3");
+      expect(result.dependencies["another-fake"]).toBe("4.5.6");
+    });
+
+    it("should replace workspace: dependencies with package version", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "@fireproof/vendor": "workspace:0.0.0",
+          "@fireproof/core": "workspace:*",
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Should replace workspace: with package version
+      expect(result.dependencies["@fireproof/vendor"]).toBe("1.0.0");
+      expect(result.dependencies["@fireproof/core"]).toBe("1.0.0");
+    });
+
+    it("should not include transitive dependencies", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "cmd-ts": `^${cmdTsVersion}`,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Only cmd-ts should be in the result, not its transitive dependencies
+      expect(Object.keys(result.dependencies)).toEqual(["cmd-ts"]);
+      expect(result.dependencies["cmd-ts"]).toBe(cmdTsVersion);
+    });
+
+    it("should sort dependencies alphabetically", async () => {
+      const zxVersion = await getInstalledVersion("zx");
+
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          zx: `^${zxVersion}`,
+          semver: `^${semverVersion}`,
+          "cmd-ts": `^${cmdTsVersion}`,
+          multiformats: `^${multiformatsVersion}`,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      // Dependencies should be sorted alphabetically
+      const keys = Object.keys(result.dependencies);
+      expect(keys).toEqual(["cmd-ts", "multiformats", "semver", "zx"]);
+    });
+
+    it("should handle mixed pinned and unpinned dependencies", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        version: "2.0.0",
+        dependencies: {
+          "cmd-ts": cmdTsVersion, // already pinned
+          semver: `^${semverVersion}`, // needs pinning
+          "@fireproof/vendor": "workspace:0.0.0", // workspace
+          multiformats: `~${multiformatsVersion}`, // needs pinning
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      expect(result.dependencies["cmd-ts"]).toBe(cmdTsVersion); // kept as-is
+      expect(result.dependencies["semver"]).toBe(semverVersion); // pinned
+      expect(result.dependencies["@fireproof/vendor"]).toBe("2.0.0"); // workspace replaced
+      expect(result.dependencies["multiformats"]).toBe(multiformatsVersion); // pinned
+    });
+
+    it("should remove devDependencies by default", async () => {
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "cmd-ts": `^${cmdTsVersion}`,
+        },
+        devDependencies: {
+          vitest: "^4.0.8",
+        },
+      };
+
+      const result = pinner.pinVersions(pkg);
+
+      expect(result.devDependencies).toBeUndefined();
+    });
+
+    it("should pin devDependencies when includeDevDeps option is true", async () => {
+      const vitestVersion = await getInstalledVersion("vitest");
+
+      const pkg: PackageJson = {
+        ...pkgTemplate,
+        dependencies: {
+          "cmd-ts": `^${cmdTsVersion}`,
+        },
+        devDependencies: {
+          vitest: `^${vitestVersion}`,
+        },
+      };
+
+      const result = pinner.pinVersions(pkg, { includeDevDeps: true });
+
+      expect(result.devDependencies).toBeDefined();
+      // devDependencies should also be pinned
+      expect(result.devDependencies?.vitest).toBe(vitestVersion);
+    });
+  });
+
+  describe("VersionPinner.create", () => {
+    it("should create instance with explicit lockfile path", async () => {
+      const lockfilePath = await findUp("pnpm-lock.yaml");
+      if (!lockfilePath) {
+        throw new Error("Could not find pnpm-lock.yaml");
+      }
+
+      const pinner = await VersionPinner.create({ lockfilePath });
+      expect(pinner).toBeInstanceOf(VersionPinner);
+    });
+
+    it("should create instance with auto-discovered lockfile", async () => {
+      const pinner = await VersionPinner.create();
+      expect(pinner).toBeInstanceOf(VersionPinner);
+    });
+
+    it("should throw error if lockfile not found with explicit path", async () => {
+      await expect(VersionPinner.create({ lockfilePath: "/non/existent/pnpm-lock.yaml" })).rejects.toThrow("No lockfile found");
+    });
+  });
+
+  describe("VersionPinner.fromLockfilePath", () => {
+    it("should create instance from lockfile path", async () => {
+      const lockfilePath = await findUp("pnpm-lock.yaml");
+      if (!lockfilePath) {
+        throw new Error("Could not find pnpm-lock.yaml");
+      }
+
+      const pinner = await VersionPinner.fromLockfilePath(lockfilePath);
+      expect(pinner).toBeInstanceOf(VersionPinner);
+    });
+
+    it("should throw error if lockfile does not exist", async () => {
+      await expect(VersionPinner.fromLockfilePath("/non/existent/pnpm-lock.yaml")).rejects.toThrow("No lockfile found");
+    });
+  });
+});

--- a/cli/version-pinner.test.ts
+++ b/cli/version-pinner.test.ts
@@ -90,7 +90,7 @@ describe("VersionPinner", () => {
   });
 
   describe("pinVersions", () => {
-    it("should pin unpinned dependencies with caret (^)", async () => {
+    it("should pin unpinned dependencies with caret (^)", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -104,7 +104,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["cmd-ts"]).toBe(cmdTsVersion);
     });
 
-    it("should pin unpinned dependencies with tilde (~)", async () => {
+    it("should pin unpinned dependencies with tilde (~)", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -118,7 +118,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["semver"]).toBe(semverVersion);
     });
 
-    it("should pin unpinned dependencies with asterisk (*)", async () => {
+    it("should pin unpinned dependencies with asterisk (*)", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -132,7 +132,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["multiformats"]).toBe(multiformatsVersion);
     });
 
-    it("should keep already pinned versions as-is", async () => {
+    it("should keep already pinned versions as-is", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -148,7 +148,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["semver"]).toBe(semverVersion);
     });
 
-    it("should keep pinned versions as-is without looking in lockfile", async () => {
+    it("should keep pinned versions as-is without looking in lockfile", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -164,7 +164,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["another-fake"]).toBe("4.5.6");
     });
 
-    it("should replace workspace: dependencies with package version", async () => {
+    it("should replace workspace: dependencies with package version", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {
@@ -215,7 +215,7 @@ describe("VersionPinner", () => {
       expect(keys).toEqual(["cmd-ts", "multiformats", "semver", "zx"]);
     });
 
-    it("should handle mixed pinned and unpinned dependencies", async () => {
+    it("should handle mixed pinned and unpinned dependencies", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         version: "2.0.0",
@@ -235,7 +235,7 @@ describe("VersionPinner", () => {
       expect(result.dependencies["multiformats"]).toBe(multiformatsVersion); // pinned
     });
 
-    it("should remove devDependencies by default", async () => {
+    it("should remove devDependencies by default", () => {
       const pkg: PackageJson = {
         ...pkgTemplate,
         dependencies: {

--- a/cli/version-pinner.ts
+++ b/cli/version-pinner.ts
@@ -1,7 +1,6 @@
 import { readWantedLockfile } from "@pnpm/lockfile-file";
 import { PackageJson } from "./build-cmd.js";
 import { findUp } from "find-up";
-import path from "node:path";
 
 interface PinVersionOptions {
   readonly includeDevDeps?: boolean;

--- a/cli/version-pinner.ts
+++ b/cli/version-pinner.ts
@@ -1,0 +1,223 @@
+import { readWantedLockfile } from "@pnpm/lockfile-file";
+import { PackageJson } from "./build-cmd.js";
+import { findUp } from "find-up";
+import path from "node:path";
+
+interface PinVersionOptions {
+  readonly includeDevDeps?: boolean;
+  readonly workspaceVersion?: string;
+}
+
+interface CreateOptions {
+  readonly lockfilePath?: string;
+}
+
+export interface PackageDependencies {
+  name: string;
+  version: string;
+  dependencies: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  transitivePeerDependencies?: string[];
+}
+
+export class VersionPinner {
+  private allDeps: Record<string, string> = {};
+
+  private constructor(allDeps: Record<string, string>) {
+    this.allDeps = allDeps;
+  }
+
+  /**
+   * Helper function to pin dependencies
+   */
+  private pinDependencies(deps: Record<string, string> | undefined, workspaceVersion: string): Record<string, string> {
+    const pinnedDeps: Record<string, string> = {};
+
+    if (!deps) {
+      return pinnedDeps;
+    }
+
+    for (const [name, version] of Object.entries(deps)) {
+      // Check if version is not pinned (starts with ^ or ~ or *)
+      if (version.match(/^[\^~*]/) || version.match(/^[0-9]+-/)) {
+        // Look up the exact version in lockfile
+        if (this.allDeps[name]) {
+          pinnedDeps[name] = this.allDeps[name];
+        } else {
+          // Keep original version if not found in lockfile
+          pinnedDeps[name] = version;
+        }
+      } else if (version.startsWith("workspace:")) {
+        // Replace workspace dependencies with the workspace version
+        pinnedDeps[name] = workspaceVersion;
+      } else {
+        // Already pinned, keep as-is
+        pinnedDeps[name] = version;
+      }
+    }
+
+    return pinnedDeps;
+  }
+
+  /**
+   * Create a VersionPinner by reading the lockfile from a specific path
+   */
+  static async fromLockfilePath(lockfilePath: string): Promise<VersionPinner> {
+    const projectDir = lockfilePath.replace(/\/[^/]+$/, "");
+    const lockfile = await readWantedLockfile(projectDir, { ignoreIncompatible: false });
+
+    if (!lockfile) {
+      throw new Error(`No lockfile found at ${lockfilePath}`);
+    }
+
+    const allDeps: Record<string, string> = {};
+
+    // Extract all packages from lockfile
+    if (lockfile.packages) {
+      for (const [key, _pkgInfo] of Object.entries(lockfile.packages)) {
+        // key format for lockfile v9: "@babel/core@7.23.0" or "lodash@4.17.21"
+        // key format for lockfile v6: "/@babel/core@7.23.0" or "/lodash@4.17.21"
+        const match = key.match(/^\/?(@?[^@]+)@(.+?)(?:\(|$)/);
+        if (match) {
+          const [, name, version] = match;
+          allDeps[name] = version;
+        }
+      }
+    }
+
+    return new VersionPinner(allDeps);
+  }
+
+  /**
+   * Create a VersionPinner by finding pnpm-lock.yaml in parent directories or using provided path
+   */
+  static async create(options: CreateOptions = {}): Promise<VersionPinner> {
+    let lockfilePath = options.lockfilePath;
+
+    if (!lockfilePath) {
+      const foundPath = await findUp("pnpm-lock.yaml");
+      if (!foundPath) {
+        throw new Error("Could not find pnpm-lock.yaml in parent directories");
+      }
+      lockfilePath = foundPath;
+    }
+
+    return VersionPinner.fromLockfilePath(lockfilePath);
+  }
+
+  /**
+   * Pin the dependencies in a package.json
+   */
+  pinVersions(pkg: PackageJson, options: PinVersionOptions = {}): PackageJson {
+    const workspaceVersion = options.workspaceVersion ?? pkg.version;
+
+    // Pin dependencies
+    const pinnedDeps = this.pinDependencies(pkg.dependencies, workspaceVersion);
+
+    // Sort dependencies alphabetically
+    const sortedDeps: Record<string, string> = {};
+    for (const name of Object.keys(pinnedDeps).sort()) {
+      sortedDeps[name] = pinnedDeps[name];
+    }
+
+    // Pin devDependencies if includeDevDeps is true
+    let sortedDevDeps: Record<string, string> | undefined;
+    if (options.includeDevDeps && pkg.devDependencies) {
+      const pinnedDevDeps = this.pinDependencies(pkg.devDependencies, workspaceVersion);
+      sortedDevDeps = {};
+      for (const name of Object.keys(pinnedDevDeps).sort()) {
+        sortedDevDeps[name] = pinnedDevDeps[name];
+      }
+    }
+
+    // Create output package.json
+    const output: PackageJson = {
+      ...pkg,
+      dependencies: sortedDeps,
+    };
+
+    // Set or remove devDependencies based on includeDevDeps option
+    if (sortedDevDeps) {
+      output.devDependencies = sortedDevDeps;
+    } else if (!options.includeDevDeps) {
+      delete (output as { devDependencies?: unknown }).devDependencies;
+    }
+
+    return output;
+  }
+}
+
+/**
+ * Get the dependencies of a specific package from the lockfile
+ * @param packageName - Name of the package (e.g., "@adviser/cement")
+ * @param lockfilePath - Path to the directory containing pnpm-lock.yaml
+ * @returns Package dependencies information or null if not found
+ */
+export async function getPackageDependencies(packageName: string, lockfilePath: string): Promise<PackageDependencies | null> {
+  const projectDir = lockfilePath.replace(/\/[^/]+$/, "");
+  const lockfile = await readWantedLockfile(projectDir, { ignoreIncompatible: false });
+
+  if (!lockfile?.packages) {
+    throw new Error(`No lockfile found at ${lockfilePath}`);
+  }
+
+  // Find the package in the lockfile
+  // Key format examples:
+  // - "/@adviser/cement@0.5.2"
+  // - "/@adviser/cement@0.5.2(typescript@5.9.3)"
+  for (const [key, pkgInfo] of Object.entries(lockfile.packages)) {
+    const match = key.match(/^\/(@?[^@]+)@(.+?)(?:\(|$)/);
+    if (match) {
+      const [, name, version] = match;
+      if (name === packageName) {
+        return {
+          name,
+          version,
+          dependencies: pkgInfo.dependencies || {},
+          peerDependencies: pkgInfo.peerDependencies || {},
+          transitivePeerDependencies: pkgInfo.transitivePeerDependencies || [],
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get all transitive dependencies recursively for a package
+ * @param packageName - Name of the package
+ * @param lockfilePath - Path to the directory containing pnpm-lock.yaml
+ * @param depth - Maximum depth to traverse (default: Infinity)
+ * @returns Map of package name to version
+ */
+export async function getAllTransitiveDependencies(
+  packageName: string,
+  lockfilePath: string,
+  depth = Infinity,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  const visited = new Set<string>();
+
+  async function traverse(pkgName: string, currentDepth: number) {
+    if (currentDepth > depth || visited.has(pkgName)) {
+      return;
+    }
+    visited.add(pkgName);
+
+    const pkgInfo = await getPackageDependencies(pkgName, lockfilePath);
+    if (!pkgInfo) {
+      return;
+    }
+
+    result.set(pkgName, pkgInfo.version);
+
+    // Traverse dependencies
+    for (const [depName] of Object.entries(pkgInfo.dependencies)) {
+      await traverse(depName, currentDepth + 1);
+    }
+  }
+
+  await traverse(packageName, 0);
+  return result;
+}

--- a/cli/version-pinner.ts
+++ b/cli/version-pinner.ts
@@ -38,6 +38,7 @@ export class VersionPinner {
 
     for (const [name, version] of Object.entries(deps)) {
       // Check if version is not pinned (starts with ^ or ~ or *)
+      // Note: Also catch malformed versions like "1-beta" that should be resolved from lockfile
       if (version.match(/^[\^~*]/) || version.match(/^[0-9]+-/)) {
         // Look up the exact version in lockfile
         if (this.allDeps[name]) {
@@ -165,7 +166,7 @@ export async function getPackageDependencies(packageName: string, lockfilePath: 
   // - "/@adviser/cement@0.5.2"
   // - "/@adviser/cement@0.5.2(typescript@5.9.3)"
   for (const [key, pkgInfo] of Object.entries(lockfile.packages)) {
-    const match = key.match(/^\/(@?[^@]+)@(.+?)(?:\(|$)/);
+    const match = key.match(/^\/?(@?[^@]+)@(.+?)(?:\(|$)/);
     if (match) {
       const [, name, version] = match;
       if (name === packageName) {

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "core-cli",
+    exclude: ["dist/**", "node_modules/**", "react/**", "examples/**", "gateway/indexeddb"],
+    include: ["**/*test.?(c|m)[jt]s?(x)"],
   },
 });

--- a/cli/well-known-cmd.ts
+++ b/cli/well-known-cmd.ts
@@ -2,7 +2,7 @@
 import { SuperThis } from "@fireproof/core-types-base";
 import * as rt from "@fireproof/core-runtime";
 import { command, restPositionals, string, option, flag } from "cmd-ts";
-import { exportSPKI, importJWK } from "jose";
+import { exportSPKI } from "jose";
 
 export function wellKnownCmd(_sthis: SuperThis) {
   return command({
@@ -109,8 +109,12 @@ export function wellKnownCmd(_sthis: SuperThis) {
         case "pem":
           {
             for (const jwk of combinedOutput.keys) {
-              const publicKey = await importJWK(jwk, "RS256");
-              console.log(await exportSPKI(publicKey as CryptoKey));
+              const rKey = await rt.sts.importJWK(jwk);
+              if (rKey.isErr()) {
+                console.error(`Error importing JWK: ${rKey.Err()}`);
+                process.exit(1);
+              }
+              console.log(await exportSPKI(rKey.Ok().key));
             }
           }
           break;

--- a/cloud/backend/base/test-helper.ts
+++ b/cloud/backend/base/test-helper.ts
@@ -212,11 +212,19 @@ export async function mockJWK(sthis: SuperThis, claim: Partial<TokenForParam> = 
     sthis.env.get(sts.envKeyDefaults.PUBLIC) ??
     "zeWndr5LEoaySgKSo2aZniYqaZvsKKu1RhfpL2R3hjarNgfXfN7CvR1cAiT74TMB9MQtMvh4acC759Xf8rTwCgxXvGHCBjHngThNtYpK2CoysiAMRJFUi9irMY9H7WApJkfxB15n8ss8iaEojcGB7voQVyk2T6aFPRnNdkoB6v5zk";
   // that could be solved better now with globalSetup.v2-cloud.ts
-  const publicJWK = await sts.env2jwk(publicJWKStr, "ES256", sthis);
+  const publicJWKs = await sts.env2jwk(publicJWKStr, undefined, sthis);
+  if (publicJWKs.length !== 1) {
+    throw new Error(`Expected exactly one public JWK, found ${publicJWKs.length}`);
+  }
+  const publicJWK = publicJWKs[0];
   const privateJWKStr =
     sthis.env.get(sts.envKeyDefaults.SECRET) ??
     "z33KxHvFS3jLz72v9DeyGBqo79qkbpv5KNP43VKUKSh1fcLb629pFTFyiJEosZ9jCrr8r9TE44KXCPZ2z1FeWGsV1N5gKjGWmZvubUwNHPynxNjCYy4GeYoQ8ukBiKjcPG22pniWCnRMwZvueUBkVk6NdtNY1uwyPk2HAGTsfrw5CBJvTcYsaFeG11SKZ9Q55Xk1W2p4gtZQHzkYHdfQQhgZ73Ttq7zmFoms73kh7MsudYzErx";
-  const privateJWK = await sts.env2jwk(privateJWKStr, "ES256", sthis);
+  const privateJWKs = await sts.env2jwk(privateJWKStr, undefined, sthis);
+  if (privateJWKs.length !== 1) {
+    throw new Error(`Expected exactly one private JWK, found ${privateJWKs.length}`);
+  }
+  const privateJWK = privateJWKs[0];
   // console.log(">>>>>", publicJWKStr, privateJWKStr);
 
   sthis.env.set(sts.envKeyDefaults.PUBLIC, publicJWKStr);

--- a/core/protocols/dashboard/dashboard-api.ts
+++ b/core/protocols/dashboard/dashboard-api.ts
@@ -80,7 +80,7 @@ export class DashboardApi {
 
   private async getAuth() {
     return exception2Result(() => {
-      return this.cfg.getToken()?.then((token) => {
+      return this.cfg.getToken().then((token) => {
         if (!token) throw new Error("No token available");
         return token as DashAuthType;
       });

--- a/core/protocols/dashboard/package.json
+++ b/core/protocols/dashboard/package.json
@@ -42,6 +42,6 @@
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
-    "zod": "^4.1.12"
+    "zod": "^4.1.13"
   }
 }

--- a/core/svc/api/database-api.ts
+++ b/core/svc/api/database-api.ts
@@ -320,11 +320,8 @@ class DatabaseProxy implements Database {
           const parsed = MsgTypeSchema.safeParse(msg);
           console.log("DatabaseProxy received message", this.id, this.name, msg, parsed.success);
           if (!parsed.success) {
-            return this.logger
-              .Error()
-              .Any({ msg, origin: ctx.origin })
-              .Msg("Received invalid message in DatabaseProxy")
-              .ResultError();
+            this.logger.Error().Any({ msg, origin: ctx.origin }).Msg("Received invalid message in DatabaseProxy");
+            return;
           }
           switch (true) {
             case isResApplyDatabaseConfig(parsed.data):
@@ -334,13 +331,9 @@ class DatabaseProxy implements Database {
               this.onResDBGet.invoke(parsed.data, ctx);
               break;
             default:
-              return this.logger
-                .Warn()
-                .Any({ msg, origin: ctx.origin })
-                .Msg("Received unhandled message type in DatabaseProxy")
-                .ResultError();
+              this.logger.Warn().Any({ msg, origin: ctx.origin }).Msg("Received unhandled message type in DatabaseProxy");
+              break;
           }
-          return Promise.resolve(Result.Ok());
         });
         return this.appliedDatabaseConfig().then((res) => {
           if (res.isErr()) {

--- a/core/svc/host/database-host.ts
+++ b/core/svc/host/database-host.ts
@@ -128,9 +128,10 @@ export class FPDatabaseSvc {
 
   start(): Promise<Result<void>> {
     const action = new FPActionService(this.sthis);
+    // eslint-disable-next-line no-console
     console.log("FPDatabaseSvc started");
     this.stopRecv = this.transport.recv((msg: unknown, ctx: FPTransportOriginCTX) => {
-      return databaseMsgHandler(this.sthis, this.logger, action, msg, this.transport, ctx);
+      void databaseMsgHandler(this.sthis, this.logger, action, msg, this.transport, ctx);
     });
     return Promise.resolve(Result.Ok());
   }

--- a/core/svc/protocol/transport.ts
+++ b/core/svc/protocol/transport.ts
@@ -15,7 +15,7 @@ export interface FPTransportTargetCTX extends FPTransportOriginCTX {
 export interface FPTransport {
   start(): Promise<Result<void>>;
   send<R extends MsgType>(msg: R, ctx: FPTransportTargetCTX): Promise<Result<R>>;
-  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<Result<void>>): () => void;
+  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => void): () => void;
 
   onSend(fn: (msg: MsgType, ctx: FPTransportTargetCTX) => Promise<void>): () => void;
   // Handlers are invoked synchronously and not awaited. If async work is needed,
@@ -51,7 +51,7 @@ export class FPApiPostMessageTransport implements FPTransport {
     return Promise.resolve(Result.Ok());
   }
 
-  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<Result<void>>): () => void {
+  recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => void): () => void {
     const handleMessage = (event: MessageEvent) => {
       const msgCbor = event.data;
       if (!isUint8Array(msgCbor)) {

--- a/core/svc/protocol/transport.ts
+++ b/core/svc/protocol/transport.ts
@@ -18,7 +18,9 @@ export interface FPTransport {
   recv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<Result<void>>): () => void;
 
   onSend(fn: (msg: MsgType, ctx: FPTransportTargetCTX) => Promise<void>): () => void;
-  onRecv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => Promise<void>): () => void;
+  // Handlers are invoked synchronously and not awaited. If async work is needed,
+  // handlers must perform it independently and handle their own errors.
+  onRecv(fn: (msg: MsgType, ctx: FPTransportOriginCTX) => void): () => void;
 }
 
 export interface FPWebWindow {

--- a/core/tests/runtime/device-id.test.ts
+++ b/core/tests/runtime/device-id.test.ts
@@ -526,6 +526,7 @@ describe("DeviceIdSignMsg", () => {
     });
 
     const ret = await deviceVerifyMsg.verifyWithCertificate(jwt);
+    console.log("Verify:", ret);
     expect(ret.valid).toBe(false);
   });
 });

--- a/core/tests/svc/full-round-trip.test.ts
+++ b/core/tests/svc/full-round-trip.test.ts
@@ -24,7 +24,7 @@ class DirectSide implements FPWebWindow {
   postMessage(msg: Event, target: string): void {
     this.targetSides.find((side) => target === side.mySide)?.recvHandlers.forEach((h) => h({ ...msg, origin: this.mySide }));
   }
-  addEventListener<T>(type: string, listener: (msg: T) => void, _options?: boolean | AddEventListenerOptions): void {
+  addEventListener<T>(_type: string, listener: (msg: T) => void, _options?: boolean | AddEventListenerOptions): void {
     this.recvHandlers.push((msg: unknown) => {
       return listener(msg as T);
     });
@@ -62,7 +62,7 @@ describe("Full Round Trip Tests", () => {
       const transport = proxy.ledger.ctx.get("transport") as FPTransport;
       const sendMock = vi.fn((..._args: unknown[]) => Promise.resolve());
       transport.onSend(sendMock);
-      const recvMock = vi.fn((..._args: unknown[]) => Promise.resolve());
+      const recvMock = vi.fn((..._args: unknown[]) => undefined);
       transport.onRecv(recvMock);
       return {
         webWindow,

--- a/dashboard/actions/deploy/action.yaml
+++ b/dashboard/actions/deploy/action.yaml
@@ -23,7 +23,7 @@ inputs:
     description: "Clerk publishable key"
     required: true
   CLERK_PUB_JWT_URL:
-    description: "Clerk public JWT URL could be comma seperated for multiple"
+    description: "Clerk public JWT URL could be comma separated for multiple"
     required: true
   CLERK_PUB_JWT_KEY:
     description: "Clerk public JWT key if your key is not fetchable singleline PEM,JSON, its totally fine to have multiple keys"
@@ -72,7 +72,6 @@ runs:
         pnpm run drizzle:d1-remote
         pnpm exec core-cli wellKnown --jsons --presetKey "$CLERK_PUB_JWT_KEY" "$CLERK_PUB_JWT_URL" > key
         CLERK_PUB_JWT_KEY="$(cat key)"
-        echo "PubKeys:" $CLERK_PUB_JWT_KEY
         pnpm exec core-cli writeEnv --env ${{inputs.CLOUDFLARE_ENV}} --out /dev/stdout --json \
           --fromEnv CLERK_PUBLISHABLE_KEY \
           --fromEnv CLERK_PUB_JWT_URL \

--- a/dashboard/backend/api.ts
+++ b/dashboard/backend/api.ts
@@ -1978,10 +1978,13 @@ export class FPApiSQL implements FPApiInterface {
     const ctx = rCtx.Ok();
     try {
       // Get the public key for verification
-      const pubKey = await sts.env2jwk(ctx.publicToken, "ES256");
+      const pubKey = await sts.env2jwk(ctx.publicToken);
+      if (pubKey.length !== 1) {
+        return Result.Err("just one public key supported");
+      }
 
       // Verify the token
-      const verifyResult = await jwtVerify(req.token, pubKey, {
+      const verifyResult = await jwtVerify(req.token, pubKey[0], {
         issuer: ctx.issuer,
         audience: ctx.audience,
       });

--- a/dashboard/backend/create-fp-token.ts
+++ b/dashboard/backend/create-fp-token.ts
@@ -14,7 +14,11 @@ export interface FPTokenContext {
 }
 
 export async function createFPToken(ctx: FPTokenContext, claim: FPCloudClaim) {
-  const privKey = await sts.env2jwk(ctx.secretToken, "ES256");
+  const privKeys = await sts.env2jwk(ctx.secretToken);
+  if (privKeys.length !== 1) {
+    throw new Error(`Expected exactly one private JWK, found ${privKeys.length}`);
+  }
+  const privKey = privKeys[0];
   let validFor = ctx.validFor;
   if (validFor <= 0) {
     validFor = 60 * 60; // 1 hour

--- a/dashboard/backend/db-api.test.ts
+++ b/dashboard/backend/db-api.test.ts
@@ -1010,7 +1010,8 @@ describe("db-api", () => {
       "zeWndr5LEoaySgKSo2aZniYqcrEJBPswFRe3bwyxY7Nmr3bznXkHhFm77VxHprvCskpKVHEwVzgQpM6SAYkUZpZcEdEunwKmLUYd1yJ4SSteExyZw4GC1SvJPLDpGxKBKb6jkkCsaQ3MJ5YFMKuGUkqpKH31Dw7cFfjdQr5XUiXue",
       "ES256",
     );
-    const v = await jwtVerify(resSt.Ok().token, pub);
+    expect(pub.length).toBe(1);
+    const v = await jwtVerify(resSt.Ok().token, pub[0]);
     expect(v.payload.exp).toBeLessThanOrEqual(new Date().getTime() + 3700000);
 
     const res2 = await fpApi.getTokenByResultId({

--- a/dashboard/backend/get-cloud-pubkey-from-env.ts
+++ b/dashboard/backend/get-cloud-pubkey-from-env.ts
@@ -1,29 +1,41 @@
-import { Result, toCryptoRuntime } from "@adviser/cement";
+import { Result } from "@adviser/cement";
 import { ensureSuperThis, sts } from "@fireproof/core-runtime";
 import { JWKPublic, JWKPublicSchema, SuperThis, toJwksAlg } from "@fireproof/core-types-base";
+import { exportJWK } from "jose";
 import { isArrayBuffer, isUint8Array } from "util/types";
 
-export async function getCloudPubkeyFromEnv(cloudToken?: string, sthis: SuperThis = ensureSuperThis()): Promise<Result<JWKPublic>> {
+export async function getCloudPubkeyFromEnv(
+  cloudToken?: string,
+  sthis: SuperThis = ensureSuperThis(),
+): Promise<Result<{ keys: JWKPublic[] }>> {
   const cstPub = cloudToken ?? sthis.env.get("CLOUD_SESSION_TOKEN_PUBLIC");
   if (!cstPub) {
     return Result.Err("no public key: env:CLOUD_SESSION_TOKEN_PUBLIC");
   }
-  const key = await sts.env2jwk(cstPub, "ES256", sthis);
-  const jwKey = await toCryptoRuntime().exportKey("jwk", key);
-  if (isUint8Array(jwKey) || isArrayBuffer(jwKey)) {
-    return Result.Err("invalid key: jwk is ArrayBuffer or Uint8Array");
+  const cryptoKeys = await sts.env2jwk(cstPub, undefined, sthis);
+  const keys: JWKPublic[] = [];
+  for (const key of cryptoKeys) {
+    const jwKey = await exportJWK(key);
+    if (isUint8Array(jwKey) || isArrayBuffer(jwKey)) {
+      return Result.Err("invalid key: jwk is ArrayBuffer or Uint8Array");
+    }
+    const rAlg = toJwksAlg(jwKey);
+    if (rAlg.isErr()) {
+      return Result.Err(rAlg);
+    }
+    const rJwtPublicKey = JWKPublicSchema.safeParse({
+      use: "sig",
+      // kty: ktyFromAlg(key.algorithm.name),
+      ...jwKey,
+      alg: rAlg.Ok(),
+      ext: undefined,
+      key_ops: undefined,
+      kid: undefined,
+    });
+    if (!rJwtPublicKey.success) {
+      return Result.Err(rJwtPublicKey.error);
+    }
+    keys.push(rJwtPublicKey.data);
   }
-  const rJwtPublicKey = JWKPublicSchema.safeParse({
-    use: "sig",
-    // kty: ktyFromAlg(key.algorithm.name),
-    ...jwKey,
-    alg: toJwksAlg(key.algorithm.name, jwKey),
-    ext: undefined,
-    key_ops: undefined,
-    kid: undefined,
-  });
-  if (!rJwtPublicKey.success) {
-    return Result.Err(rJwtPublicKey.error);
-  }
-  return Result.Ok(rJwtPublicKey.data);
+  return Result.Ok({ keys });
 }

--- a/dashboard/backend/well-known-jwks.ts
+++ b/dashboard/backend/well-known-jwks.ts
@@ -1,37 +1,23 @@
-import { Lazy, toCryptoRuntime } from "@adviser/cement";
-import { ensureSuperThis, sts } from "@fireproof/core-runtime";
-import { JWKPublicSchema, toJwksAlg } from "@fireproof/core-types-base";
-import { isArrayBuffer, isUint8Array } from "util/types";
+import { Lazy } from "@adviser/cement";
+import { ensureSuperThis } from "@fireproof/core-runtime";
+import { getCloudPubkeyFromEnv } from "./get-cloud-pubkey-from-env.js";
 
 const getKey = Lazy(async (opts: Record<string, string>) => {
   const sthis = ensureSuperThis();
   const cstPub = opts.CLOUD_SESSION_TOKEN_PUBLIC ?? sthis.env.get("CLOUD_SESSION_TOKEN_PUBLIC");
-  if (!cstPub)
-    return {
-      status: 500,
-      value: { error: "no public key: env:CLOUD_SESSION_TOKEN_PUBLIC" },
-    };
 
-  const key = await sts.env2jwk(cstPub, "ES256", sthis);
-  const jwKey = await toCryptoRuntime().exportKey("jwk", key);
-  if (isUint8Array(jwKey) || isArrayBuffer(jwKey)) {
+  const result = await getCloudPubkeyFromEnv(cstPub, sthis);
+
+  if (result.isErr()) {
     return {
       status: 500,
-      value: { error: "invalid key is not a CTJsonWebKey" },
+      value: { error: result.Err().toString() },
     };
   }
-  const jwPublicKey = JWKPublicSchema.parse({
-    use: "sig",
-    // kty: ktyFromAlg(key.algorithm.name),
-    ...jwKey,
-    alg: toJwksAlg(key.algorithm.name, jwKey),
-    ext: undefined,
-    key_ops: undefined,
-    kid: undefined,
-  });
+
   return {
     status: 200,
-    value: { keys: [jwPublicKey] },
+    value: result.Ok(),
   };
 });
 

--- a/dashboard/src/cloud-context.ts
+++ b/dashboard/src/cloud-context.ts
@@ -69,14 +69,7 @@ export class CloudContext {
       apiUrl: DASHAPI_URL,
       fetch: window.fetch.bind(window),
       // apiUrl: API_URL,
-      getToken: async () => {
-        // console.log("CloudContext getToken");
-        const token = await this._clerkSession?.session?.getToken({ template: "with-email" });
-        return {
-          type: "clerk",
-          token: token || "",
-        };
-      },
+      getToken: () => this.getToken(),
     });
   }
 

--- a/dashboard/src/cloud-context.ts
+++ b/dashboard/src/cloud-context.ts
@@ -17,18 +17,6 @@ import {
 } from "@fireproof/core-protocols-dashboard";
 import { DASHAPI_URL } from "./helpers.js";
 
-// const emptyListTenantsByUser: ResListTenantsByUser = {
-//   type: "resListTenantsByUser",
-//   userId: "unk",
-//   authUserId: "unk",
-//   tenants: [] as UserTenant[],
-// };
-
-// const emptyListInvites: ResListInvites = {
-//   type: "resListInvites",
-//   tickets: [],
-// };
-
 export interface InviteItem {
   tenantId: string;
   invites: InviteTicket[];
@@ -46,10 +34,6 @@ function wrapResultToPromise<T>(pro: () => Promise<Result<T>>) {
   };
 }
 
-// const _betterAuthClient = createAuthClient({
-//   baseURL: API_URL,
-// });
-
 interface TokenType {
   readonly type: "clerk" | "better";
   readonly token: string;
@@ -61,51 +45,18 @@ export interface ListTenantsLedgersByUser {
 
 export class CloudContext {
   readonly api: DashboardApi;
-  // readonly betterAuthClient: ReturnType<typeof createAuthClient>;
 
   constructor() {
-    // this.betterAuthClient = _betterAuthClient;
     this.api = new DashboardApi({
       apiUrl: DASHAPI_URL,
       fetch: window.fetch.bind(window),
-      // apiUrl: API_URL,
       getToken: () => this.getToken(),
     });
   }
 
   _clerkSession?: ReturnType<typeof useSession>;
-  // private _betterAuthSession?: ReturnType<typeof _betterAuthClient.useSession>;
-  // private _queryClient?: QueryClient;
 
-  readonly betterToken = {
-    expires: -1,
-    token: undefined,
-  } as {
-    expires: number;
-    token?: string;
-  };
   async getToken(): Promise<TokenType | undefined> {
-    // console.log("getToken", this._betterAuthSession?.data);
-    // if (this._betterAuthSession?.data) {
-    //   if (this.betterToken.expires < Date.now()) {
-    //     const res = (await this.betterAuthClient.$fetch("/token")) as {
-    //       data: {
-    //         token: string;
-    //       };
-    //     };
-    //     this.betterToken.token = res.data.token;
-    //     console.log("betterToken", this.betterToken.token);
-    //     // jwt.verify(this.betterToken.token
-    //     // this.betterToken.expires = Date.now() + this._betterAuthSession.data.expiresIn;
-    //   }
-    //   if (!this.betterToken.token) {
-    //     return undefined;
-    //   }
-    //   return {
-    //     type: "better",
-    //     token: this.betterToken.token,
-    //   };
-    // }
     const token = await this._clerkSession?.session?.getToken({ template: "with-email" });
     return token
       ? {
@@ -128,7 +79,7 @@ export class CloudContext {
   }
 
   initContext() {
-    console.log("initContext");
+    // console.log("initContext");
 
     this._clerkSession = useSession();
     // this._betterAuthSession = _betterAuthClient.useSession();
@@ -184,7 +135,7 @@ export class CloudContext {
     });
 
     this.addTenantToListLedgerByUser(tenantId, () => {
-      console.log("ledger - refetch", tenantId, this.activeApi(this._tenantIdForLedgers.size > 0));
+      // console.log("ledger - refetch", tenantId, this.activeApi(this._tenantIdForLedgers.size > 0));
       if (this.activeApi(this._tenantIdForLedgers.size > 0)) {
         listLedgers.refetch();
       }
@@ -196,7 +147,7 @@ export class CloudContext {
     return useQuery({
       queryKey: ["listTenantsLedgersByUser", this._ensureUser.data?.user.userId],
       queryFn: async () => {
-        console.log("useListTenantsByUser", this._ensureUser.data?.user.userId);
+        // console.log("useListTenantsByUser", this._ensureUser.data?.user.userId);
         const listTenantsByUser = await this.api.listTenantsByUser({});
         const listLedgersByUser = await this.api.listLedgersByUser({
           tenantIds: listTenantsByUser.Ok().tenants.map((t) => t.tenantId),
@@ -220,7 +171,7 @@ export class CloudContext {
     return useQuery({
       queryKey: ["listTenantsByUser", this._ensureUser.data?.user.userId],
       queryFn: () => {
-        console.log("useListTenantsByUser", this._ensureUser.data?.user.userId);
+        // console.log("useListTenantsByUser", this._ensureUser.data?.user.userId);
         return wrapResultToPromise(() => this.api.listTenantsByUser({}))();
       },
       enabled: this.activeApi(),
@@ -252,8 +203,8 @@ export class CloudContext {
       mutationFn: ({ name }: { name: string }) => {
         return wrapResultToPromise(() => this.api.createTenant({ tenant: { name } }))();
       },
-      onSuccess: async (data, variables, context) => {
-        console.log("onSuccess", data, variables, context);
+      onSuccess: async () => {
+        // console.log("onSuccess", data, variables, context);
         listTenantsByUser.refetch();
       },
     });
@@ -272,10 +223,8 @@ export class CloudContext {
           }),
         )();
       },
-      onSuccess: async (data, variables, context) => {
-        console.log("onSuccess", data, variables, context);
+      onSuccess: async (_data, variables, _context) => {
         this.addTenantToListLedgerByUser(variables.tenantId, () => {
-          console.log("refetch");
           listLedgers.refetch();
         });
         listLedgers.refetch();

--- a/dashboard/src/pages/cloud/CsrToCert.tsx
+++ b/dashboard/src/pages/cloud/CsrToCert.tsx
@@ -123,7 +123,7 @@ export function CsrToCert() {
             <button
               onClick={() => {
                 navigator.clipboard.writeText(certificate);
-                alert("Certificate copied to clipboard!");
+                // alert("Certificate copied to clipboard!");
               }}
               className="mt-2 inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
             >

--- a/dashboard/src/pages/cloud/CsrToCert.tsx
+++ b/dashboard/src/pages/cloud/CsrToCert.tsx
@@ -41,7 +41,7 @@ export function CsrToCert() {
     if (certificate && returnUrl) {
       const timer = setTimeout(() => {
         const urlWithCert = BuildURI.from(returnUrl).setParam("cert", certificate).toString();
-        console.log(">>>>>", urlWithCert);
+        // console.log(">>>>>", urlWithCert);
         window.location.href = urlWithCert;
       }, 3000);
 
@@ -53,23 +53,23 @@ export function CsrToCert() {
     try {
       setError(null);
       setCertificate(null);
-      console.log("Submitting CSR:", data.csrContent);
+      // console.log("Submitting CSR:", data.csrContent);
 
       const result = await cloud.api.getCertFromCsr({ csr: data.csrContent });
 
       if (result.isOk()) {
         const response = result.Ok();
         setCertificate(response.certificate);
-        console.log("Certificate received:", response.certificate);
+        // console.log("Certificate received:", response.certificate);
       } else {
         const errorMsg = result.Err();
         setError(typeof errorMsg === "string" ? errorMsg : "Failed to get certificate");
-        console.error("Error getting certificate:", errorMsg);
+        // console.error("Error getting certificate:", errorMsg);
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : "An unexpected error occurred";
       setError(errorMsg);
-      console.error("Exception during CSR submission:", err);
+      // console.error("Exception during CSR submission:", err);
     }
   };
 
@@ -123,7 +123,7 @@ export function CsrToCert() {
             <button
               onClick={() => {
                 navigator.clipboard.writeText(certificate);
-                // alert("Certificate copied to clipboard!");
+                alert("Certificate copied to clipboard!");
               }}
               className="mt-2 inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
             >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       vitest:
         specifier: ^4.0.8
         version: 4.0.8(@types/node@24.10.1)(@vitest/browser-playwright@4.0.8)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
-      why-is-node-running:
-        specifier: ^3.2.2
-        version: 3.2.2
 
   cloud/3rd-party:
     dependencies:
@@ -868,8 +865,8 @@ importers:
         specifier: workspace:0.0.0
         version: link:../../../vendor
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.1.13
+        version: 4.1.13
 
   core/runtime:
     dependencies:
@@ -6524,11 +6521,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  why-is-node-running@3.2.2:
-    resolution: {integrity: sha512-NKUzAelcoCXhXL4dJzKIwXeR8iEVqsA0Lq6Vnd0UXvgaKbzVo4ZTHROF2Jidrv+SgxOQ03fMinnNhzZATxOD3A==}
-    engines: {node: '>=20.11'}
-    hasBin: true
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -6645,9 +6637,6 @@ packages:
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -11841,8 +11830,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  why-is-node-running@3.2.2: {}
-
   word-wrap@1.2.5: {}
 
   workerd@1.20251118.0:
@@ -11944,8 +11931,6 @@ snapshots:
       zod: 4.1.13
 
   zod@3.22.3: {}
-
-  zod@4.1.12: {}
 
   zod@4.1.13: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       semver:
         specifier: ^7.7.3
         version: 7.7.3
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
       zx:
         specifier: ^8.8.5
         version: 8.8.5


### PR DESCRIPTION
## Summary
- Added `VersionPinner` utility to pin workspace dependencies to specific versions from pnpm lockfile
- Integrated version pinning into the build command with `--no-pinned` flag to disable
- Added `--lockfile` option to specify custom lockfile path
- Improved JWK handling to support multiple key formats and better error handling
- Enhanced cloud token key command to output multiple JWKs properly
- Updated device ID validation and key handling for better type safety

## Key Changes

### New VersionPinner Utility (cli/version-pinner.ts)
- Reads pnpm-lock.yaml to extract exact package versions
- Pins unpinned dependencies (^, ~, *) to lockfile versions
- Replaces workspace: dependencies with the package version
- Supports both dependencies and devDependencies
- Includes comprehensive test suite (270 lines)

### Build Command Improvements (cli/build-cmd.ts)
- Integrated VersionPinner to pin dependencies before publishing
- Added `--no-pinned` flag to disable pinning (enabled by default)
- Added `--lockfile` option for custom lockfile paths
- Removed old `patchDeps` function in favor of VersionPinner
- Improved error handling with `.nothrow()` for publish commands

### JWK Handling Enhancements
- Updated `env2jwk` to return arrays of CryptoKeys supporting multiple key formats
- Added `importJWK` wrapper with proper error handling
- Enhanced cloud token key command to output multiple JWKs as JSON
- Updated well-known command to handle JWK arrays properly
- Improved PEM export with better error messages

### Device ID Improvements
- Updated DeviceIdKey to use new importJWK wrapper
- Enhanced DeviceIdValidator for better type safety
- Improved error handling throughout device ID flow

## Test Plan
- [x] Run existing build-cmd tests
- [x] Run new version-pinner test suite (270 lines of tests)
- [x] Test build command with version pinning
- [x] Test build command with `--no-pinned` flag
- [x] Verify JWK handling with multiple keys
- [x] Test cloud token key command output
- [x] Verify device ID validation still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: unified retry command and retry wrapper used for test/smoke runs; added dependency pinning options for reproducible builds.

* **Improvements**
  * Centralized retry logic replaces manual attempt handling.
  * Stronger key/JWT handling: multi-key support, improved import/validation and clearer error reporting.
  * Test selection refinements for test runner.

* **Bug Fixes**
  * Fixed typo in dashboard config description.

* **Tests**
  * Added extensive tests for version pinning and JWK coercion/handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->