### PR TITLE
feat: add Device ID CA support to dashboard deployment

### DIFF
--- a/.github/workflows/dashboard-deploy.yaml
+++ b/.github/workflows/dashboard-deploy.yaml
@@ -44,3 +44,5 @@ jobs:
           MAX_LEDGERS: ${{ vars.MAX_LEDGERS }}
           MAX_MEMBER_USERS: ${{ vars.MAX_MEMBER_USERS}}
           MAX_TENANTS: ${{ vars.MAX_TENANTS }}
+          DEVICE_ID_CA_PRIV_KEY: ${{ secrets.DEVICE_ID_CA_PRIV_KEY }}
+          DEVICE_ID_CA_CERT: ${{ secrets.DEVICE_ID_CA_CERT }}

--- a/dashboard/actions/deploy/action.yaml
+++ b/dashboard/actions/deploy/action.yaml
@@ -41,6 +41,12 @@ inputs:
     description: "default how many invitest could be created per tenant"
   MAX_LEDGERS:
     description: "default how many ledgers per tenant are allowed"
+  DEVICE_ID_CA_PRIV_KEY:
+    description: "Device ID Certificate Authority private key"
+    required: false
+  DEVICE_ID_CA_CERT:
+    description: "Device ID Certificate Authority certificate"
+    required: false
 
 runs:
   using: "composite"
@@ -66,6 +72,8 @@ runs:
         MAX_MEMBER_USERS: ${{ inputs.MAX_MEMBER_USERS }}
         MAX_INVITES: ${{ inputs.MAX_INVITES }}
         MAX_LEDGERS: ${{ inputs.MAX_LEDGERS }}
+        DEVICE_ID_CA_PRIV_KEY: ${{ inputs.DEVICE_ID_CA_PRIV_KEY }}
+        DEVICE_ID_CA_CERT: ${{ inputs.DEVICE_ID_CA_CERT }}
         # need during build
         VITE_CLERK_PUBLISHABLE_KEY: ${{ inputs.CLERK_PUBLISHABLE_KEY }}
       run: |
@@ -82,7 +90,9 @@ runs:
           --fromEnv MAX_MEMBER_USERS \
           --fromEnv MAX_TENANTS \
           --fromEnv CLOUD_SESSION_TOKEN_SECRET \
-          --fromEnv CLOUD_SESSION_TOKEN_PUBLIC | \
+          --fromEnv CLOUD_SESSION_TOKEN_PUBLIC \
+          --fromEnv DEVICE_ID_CA_PRIV_KEY \
+          --fromEnv DEVICE_ID_CA_CERT | \
           pnpm exec wrangler -c ./wrangler.toml secret --env ${{inputs.CLOUDFLARE_ENV}} bulk
         pnpm run deploy:cf --env ${{inputs.CLOUDFLARE_ENV}}
 


### PR DESCRIPTION
## Summary
Adds Device ID Certificate Authority support to the dashboard deployment workflow, enabling device-based authentication alongside Clerk auth.

## Changes
- ✅ Add `DEVICE_ID_CA_PRIV_KEY` and `DEVICE_ID_CA_CERT` secrets to workflow
- ✅ Add optional inputs to deploy action
- ✅ Include Device ID CA vars in `writeEnv` deployment command
- ✅ Generated production CA certificate and stored as GitHub secrets

## Problem Solved
Fixes 500 Internal Server Error on `/api` PUT requests after successful login. The error occurred because `DeviceIdCA.from()` was failing when environment variables were missing, throwing an uncaught exception in the handler.

## Testing
- Generated CA certificate using `core-cli deviceId ca-cert`
- Set secrets in production environment
- Ready for deployment test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configuration with support for additional security credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->