### PR TITLE
Debug: Add JWKS configuration logging

### DIFF
--- a/core/runtime/sts-service/index.ts
+++ b/core/runtime/sts-service/index.ts
@@ -360,7 +360,14 @@ export async function verifyToken<R>(
       console.log("[DEBUG] JWT verify attempt - token kid:", tokenHeader.kid, "key kid:", pubKey.kid);
       const rRes = await exception2Result(() => jwtVerify(token, rKey.Ok().key));
       if (rRes.isErr()) {
-        console.log("[DEBUG] JWT verify FAILED - token kid:", tokenHeader.kid, "key kid:", pubKey.kid, "error:", rRes.Err().message);
+        console.log(
+          "[DEBUG] JWT verify FAILED - token kid:",
+          tokenHeader.kid,
+          "key kid:",
+          pubKey.kid,
+          "error:",
+          rRes.Err().message,
+        );
         return Result.Err(rRes);
       }
       const res = rRes.Ok();

--- a/core/runtime/sts-service/index.ts
+++ b/core/runtime/sts-service/index.ts
@@ -411,7 +411,9 @@ export async function verifyToken<R>(
       }
     }
   }
-  return Result.Err(`Verification failed. Tried ${presetPubKey.length} preset keys, ${wellKnownUrls.length} JWKS URLs. URL errors:\n${JSON.stringify(errors, null, 2)}`);
+  return Result.Err(
+    `Verification failed. Tried ${presetPubKey.length} preset keys, ${wellKnownUrls.length} JWKS URLs. URL errors:\n${JSON.stringify(errors, null, 2)}`,
+  );
 }
 
 async function internVerifyToken<R>(token: string, presetPubKey: JWK | JWKPublic, opts: VerifyTokenOptions<R>): Promise<Result<R>> {

--- a/core/runtime/sts-service/index.ts
+++ b/core/runtime/sts-service/index.ts
@@ -355,14 +355,19 @@ export async function verifyToken<R>(
       if (rKey.isErr()) {
         return Result.Err(rKey);
       }
+      const tokenParts = token.split(".");
+      const tokenHeader = JSON.parse(opts.sthis.txt.base64.decode(tokenParts[0]));
+      console.log("[DEBUG] JWT verify attempt - token kid:", tokenHeader.kid, "key kid:", pubKey.kid);
       const rRes = await exception2Result(() => jwtVerify(token, rKey.Ok().key));
       if (rRes.isErr()) {
+        console.log("[DEBUG] JWT verify FAILED - token kid:", tokenHeader.kid, "key kid:", pubKey.kid, "error:", rRes.Err().message);
         return Result.Err(rRes);
       }
       const res = rRes.Ok();
       if (!res) {
         return Result.Err("JWT verification failed");
       }
+      console.log("[DEBUG] JWT verify SUCCESS - token kid:", tokenHeader.kid, "key kid:", pubKey.kid);
       return Result.Ok(res);
     },
     ...iopts,

--- a/core/runtime/sts-service/index.ts
+++ b/core/runtime/sts-service/index.ts
@@ -369,10 +369,13 @@ export async function verifyToken<R>(
     sthis: iopts.sthis ?? ensureSuperThis(),
   };
 
+  console.log("[DEBUG] verifyToken: trying", presetPubKey.length, "preset keys");
   for (const pubKey of presetPubKey) {
     const coercedKeys = await coerceJWKPublic(opts.sthis, pubKey);
+    console.log("[DEBUG] Coerced", coercedKeys.length, "keys from preset");
     for (const key of coercedKeys) {
       const rVerify = await internVerifyToken(token, key, opts);
+      console.log("[DEBUG] Preset key verification:", rVerify.isOk() ? "SUCCESS" : "FAILED", key.kid);
       if (rVerify.isOk()) {
         return rVerify;
       }
@@ -408,7 +411,7 @@ export async function verifyToken<R>(
       }
     }
   }
-  return Result.Err(`No well-known JWKS URL could verify the token:\n${JSON.stringify(errors, null, 2)}`);
+  return Result.Err(`Verification failed. Tried ${presetPubKey.length} preset keys, ${wellKnownUrls.length} JWKS URLs. URL errors:\n${JSON.stringify(errors, null, 2)}`);
 }
 
 async function internVerifyToken<R>(token: string, presetPubKey: JWK | JWKPublic, opts: VerifyTokenOptions<R>): Promise<Result<R>> {

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -388,11 +388,10 @@ export async function createHandler<T extends DashSqlite>(db: T, env: Record<str
       const duration = endTime - startTime;
       return new Response(JSON.stringify(rRes.Ok()), {
         status: 200,
-        headers: {
-          ...DefaultHttpHeaders,
+        headers: DefaultHttpHeaders({
           "Content-Type": "application/json",
           "Server-Timing": `total;dur=${duration.toFixed(2)}`,
-        },
+        }),
       });
     } catch (e) {
       logger.Error().Any({ request: jso.type }).Err(e).Msg("global-Error");
@@ -405,11 +404,10 @@ export async function createHandler<T extends DashSqlite>(db: T, env: Record<str
         }),
         {
           status: 500,
-          headers: {
-            ...DefaultHttpHeaders,
+          headers: DefaultHttpHeaders({
             "Content-Type": "application/json",
             "Server-Timing": `total;dur=${duration.toFixed(2)}`,
-          },
+          }),
         },
       );
     }

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -64,6 +64,8 @@ class ClerkApiToken implements FPApiToken {
         );
       }
     }
+    console.log("[DEBUG] CLERK keys loaded:", keys.length, "URLs:", urls.length);
+    console.log("[DEBUG] First key preview:", keys[0]?.substring(0, 100));
     const rt = await sts.verifyToken(token, keys, urls, {
       parseSchema: (payload: unknown): Result<FPClerkClaim> => {
         const r = FPClerkClaimSchema.safeParse(payload);

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -33,6 +33,7 @@ class ClerkApiToken implements FPApiToken {
     this.sthis = sthis;
   }
   async verify(token: string): Promise<Result<VerifiedAuth>> {
+    const sthis = this.sthis;
     const keys: string[] = [];
     const urls: string[] = [];
     // eslint-disable-next-line no-constant-condition

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -92,7 +92,14 @@ class ClerkApiToken implements FPApiToken {
           }),
         );
         if (r.isErr()) {
-          console.log("[DEBUG CLERK] ClerkVerifyToken FAILED - token kid:", tokenHeader.kid, "key kid:", key.kid, "error:", r.Err().message);
+          console.log(
+            "[DEBUG CLERK] ClerkVerifyToken FAILED - token kid:",
+            tokenHeader.kid,
+            "key kid:",
+            key.kid,
+            "error:",
+            r.Err().message,
+          );
           return Result.Err(r);
         }
         if (!r.Ok()) {

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -32,6 +32,12 @@ routes = [
   { pattern = "dev.connect.fireproof.direct", custom_domain = true }
 ]
 
+[env.dev.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
 [[env.dev.d1_databases]]
 binding = "DB"
 database_name = "fp-connect-dev"


### PR DESCRIPTION
## Summary
- Add temporary debug logging to diagnose JWT verification failures with preset keys
- Improve error messages to show both preset key and JWKS URL verification attempts
- Test deployment with dual-key configuration (production + development keys)

## Debug Logging Added

**dashboard/backend/create-handler.ts:67-68**
- Log number of keys and URLs loaded from environment
- Preview first key format

**core/runtime/sts-service/index.ts:372-378**
- Log preset key verification attempts
- Show coercion results
- Track success/failure for each key

**core/runtime/sts-service/index.ts:414**
- Enhanced error message to include preset key count

## Test Results

✅ Local test confirms `wellKnown --jsons` correctly parses both PEM blocks:
```json
{"keys":[{...key1...}, {...key2...}]}
```

## Next Steps

1. Deploy to dev environment
2. Check Cloudflare Workers logs via `wrangler tail --env dev`
3. Identify why preset keys aren't working
4. Fix root cause
5. Remove debug logging
6. Deploy fix to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)