### PR TITLE
Fix infinite re-render loops in React hooks

### DIFF
--- a/use-fireproof/base/react/use-all-docs.ts
+++ b/use-fireproof/base/react/use-all-docs.ts
@@ -35,7 +35,7 @@ export function createUseAllDocs(database: Database) {
         });
         setHydrated(true);
       }
-    }, [database, query, queryString]);
+    }, [database, queryString]);
 
     useEffect(() => {
       refreshRows();

--- a/use-fireproof/base/react/use-changes.ts
+++ b/use-fireproof/base/react/use-changes.ts
@@ -33,7 +33,7 @@ export function createUseChanges(database: Database) {
         setResult({ ...res, docs: res.rows.map((r) => r.value as DocWithId<T>) });
         setHydrated(true);
       }
-    }, [database, since, opts, sinceString, queryString]);
+    }, [database, sinceString, queryString]);
 
     useEffect(() => {
       refreshRows(); // Initial data fetch

--- a/use-fireproof/base/react/use-live-query.ts
+++ b/use-fireproof/base/react/use-live-query.ts
@@ -38,7 +38,7 @@ export function createUseLiveQuery(database: Database) {
         setResult(res);
         setHydrated(true);
       }
-    }, [database, mapFn, query, mapFnString, queryString]);
+    }, [database, mapFnString, queryString]);
 
     useEffect(() => {
       refreshRows();


### PR DESCRIPTION
## Summary
Fixed infinite re-render loops in all Fireproof React hooks by ensuring `useCallback` dependencies only use memoized string values instead of object references that change on every render.

## Changes

### Files Modified
- **use-live-query.ts** - Removed `mapFn` and `query` from `refreshRows` dependencies, kept only memoized `mapFnString` and `queryString`
- **use-all-docs.ts** - Removed `query` from `refreshRows` dependencies, kept only memoized `queryString`
- **use-changes.ts** - Removed `since` and `opts` from `refreshRows` dependencies, kept only memoized `sinceString` and `queryString`
- **use-document.ts** - Added `docIdString` memo and replaced all `doc._id` and `doc` object references in callbacks (`refresh`, `save`, `remove`) and useEffect dependencies

## Root Cause
The infinite loop occurred because:
1. Hooks returned new object references on every render
2. Component re-rendered with new reference
3. useCallback recreated function due to object dependency
4. useEffect ran again due to function change
5. Loop back to step 1

## Solution
Only depend on memoized string representations (like `JSON.stringify(query)`) in useCallback, not the actual object references. This breaks the infinite loop while still triggering re-renders when the actual data changes.

## Testing
- All existing tests pass (except 3 unrelated cloud timeout failures)
- Build completes successfully
- Type checking passes

## Impact
This fix resolves 100% CPU usage and infinite re-render issues in applications using these hooks, particularly affecting `useLiveQuery` and `useDocument`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary refreshes by stabilizing change detection for queries, options, and mappings.
  * Improved stability of document and live-data subscriptions via memoization and ref-based tracking to avoid redundant re-renders.
* **Bug Fixes**
  * Prevented potential infinite re-renders and stale-result races by tightening dependency tracking and refresh guards.
* **New Features**
  * Added a circuit-breaker for token refreshes to fail fast after repeated remote failures and improve resilience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->