### PR TITLE
Enable observability logging for dev environment

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -32,6 +32,12 @@ routes = [
   { pattern = "dev.connect.fireproof.direct", custom_domain = true }
 ]
 
+[env.dev.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
 [[env.dev.d1_databases]]
 binding = "DB"
 database_name = "fp-connect-dev"


### PR DESCRIPTION
## Summary
- Adds observability.logs configuration to dev environment in wrangler.toml
- Mirrors the same logging config already enabled in production

## Why
We need detailed logs from the dev environment to debug Clerk token verification issues. Production already has this enabled.

## Test plan
- Verify PR checks pass
- Deploy to dev and verify logs are available via wrangler tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated development environment observability configuration for enhanced logging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->