### PR TITLE
ensureCloudToken

### DIFF
--- a/cloud/backend/base/drizzle.cloud.meta-merger.config.ts
+++ b/cloud/backend/base/drizzle.cloud.meta-merger.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from "drizzle-kit";
+import fs from "fs";
+
+fs.mkdirSync("./dist", { recursive: true });
 
 export default defineConfig({
   dialect: "sqlite",

--- a/cloud/backend/base/globalSetup.cloud.meta-merger.ts
+++ b/cloud/backend/base/globalSetup.cloud.meta-merger.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { cd, $ } from "zx";
+import { $, path } from "zx";
 import type { TestProject } from "vitest/node";
 import { setTestEnv } from "@fireproof/cloud-base";
 
@@ -7,13 +7,12 @@ export async function setup(project: TestProject) {
   const root = project.toJSON().serializedConfig.root;
 
   $.verbose = true;
-  cd(root);
 
-  await fs.mkdir("dist", { recursive: true });
-  await $`pnpm exec drizzle-kit push --config ./drizzle.cloud.meta-merger.config.ts`;
+  await fs.mkdir(path.join(root, "dist"), { recursive: true });
+  await $`(cd ${root} && pnpm exec drizzle-kit push --config ./drizzle.cloud.meta-merger.config.ts)`;
 
   const env = {
-    FP_TEST_SQL_URL: `file://${process.cwd()}/dist/cloud-backend-meta-merger.sqlite`,
+    FP_TEST_SQL_URL: `file://${root}/dist/cloud-backend-meta-merger.sqlite`,
   };
   setTestEnv(project, env);
 }

--- a/cloud/backend/cf-d1/globalSetup.cloud.d1.ts
+++ b/cloud/backend/cf-d1/globalSetup.cloud.d1.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { cd, $, dotenv, path } from "zx";
+import { $, dotenv, path } from "zx";
 import { setupBackendD1 } from "./setup-backend-d1.js";
 import type { TestProject } from "vitest/node";
 import { ensureSuperThis, sts } from "@fireproof/core-runtime";

--- a/cloud/backend/cf-d1/setup-backend-d1.ts
+++ b/cloud/backend/cf-d1/setup-backend-d1.ts
@@ -5,6 +5,7 @@ import { Future } from "@adviser/cement";
 
 export async function setupBackendD1(
   sthis: SuperThis,
+  root: string,
   wranglerToml: string,
   env: string,
   port = portRandom(sthis),
@@ -16,9 +17,10 @@ export async function setupBackendD1(
 
   $.verbose = !!sthis.env.get("FP_DEBUG");
   // process.env["FP_STORAGE_URL"] = `fpcloud://localhost:${port}/?tenant=${sthis.nextId().str}&ledger=test-l&protocol=ws`;
-  await $`core-cli writeEnv --wranglerToml ${wranglerToml} --env ${env} --doNotOverwrite`;
+  await $`cd ${root} && core-cli writeEnv --wranglerToml ${wranglerToml} --env ${env} --doNotOverwrite`;
 
   const runningWrangler = $`
+                   cd ${root}
                    wrangler dev -c ${wranglerToml} --port ${port} --env ${envName} --no-show-interactive-dev-session --no-live-reload &
                    waitPid=$!
                    echo "PID:$waitPid"

--- a/cloud/backend/node/globalSetup.cloud.libsql.ts
+++ b/cloud/backend/node/globalSetup.cloud.libsql.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
-import { cd, $ } from "zx";
+import { $, path } from "zx";
 import type { TestProject } from "vitest/node";
 import { ensureSuperThis, sts } from "@fireproof/core-runtime";
 import { mockJWK, portRandom } from "@fireproof/cloud-backend-base";
@@ -12,14 +12,13 @@ export async function setup(project: TestProject) {
   const root = project.toJSON().serializedConfig.root;
 
   $.verbose = true;
-  cd(root);
 
   const sthis = ensureSuperThis();
   const keys = await mockJWK(sthis);
 
-  await fs.mkdir("dist", { recursive: true });
+  await fs.mkdir(path.join(root, "dist"), { recursive: true });
 
-  await $`pnpm exec drizzle-kit push --config ./drizzle.cloud.libsql.config.ts`;
+  await $`cd ${root} && pnpm exec drizzle-kit push --config ./drizzle.cloud.libsql.config.ts`;
 
   const port = portRandom(sthis);
   const env = {

--- a/core/protocols/dashboard/dashboard-api.ts
+++ b/core/protocols/dashboard/dashboard-api.ts
@@ -35,7 +35,14 @@ import {
   ResCloudSessionToken,
   ReqCertFromCsr,
   ResCertFromCsr,
+  ReqExtendToken,
+  ReqTokenByResultId,
+  ResExtendToken,
+  ResTokenByResultId,
+  ReqEnsureCloudToken,
+  ResEnsureCloudToken,
 } from "./msg-types.js";
+import { FPApiInterface } from "./fp-api-interface.js";
 import { Falsy } from "@fireproof/core-types-base";
 
 interface TypeString {
@@ -72,7 +79,7 @@ export interface DashboardApiConfig {
  * });
  * ```
  */
-export class DashboardApi {
+export class DashboardApi implements FPApiInterface {
   private readonly cfg: DashboardApiConfig;
   constructor(cfg: DashboardApiConfig) {
     this.cfg = cfg;
@@ -164,5 +171,19 @@ export class DashboardApi {
   }
   getCertFromCsr(req: WithoutTypeAndAuth<ReqCertFromCsr>): Promise<Result<ResCertFromCsr>> {
     return this.request<ReqCertFromCsr, ResCertFromCsr>({ ...req, type: "reqCertFromCsr" });
+  }
+
+  redeemInvite(req: ReqRedeemInvite): Promise<Result<ResRedeemInvite>> {
+    return this.request<ReqRedeemInvite, ResRedeemInvite>({ ...req, type: "reqRedeemInvite" });
+  }
+  getTokenByResultId(req: ReqTokenByResultId): Promise<Result<ResTokenByResultId>> {
+    return this.request<ReqTokenByResultId, ResTokenByResultId>({ ...req, type: "reqTokenByResultId" });
+  }
+  extendToken(req: ReqExtendToken): Promise<Result<ResExtendToken>> {
+    return this.request<ReqExtendToken, ResExtendToken>({ ...req, type: "reqExtendToken" });
+  }
+
+  ensureCloudToken(req: WithoutTypeAndAuth<ReqEnsureCloudToken>): Promise<Result<ResEnsureCloudToken>> {
+    return this.request<ReqEnsureCloudToken, ResEnsureCloudToken>({ ...req, type: "reqEnsureCloudToken" });
   }
 }

--- a/core/protocols/dashboard/fp-api-interface.ts
+++ b/core/protocols/dashboard/fp-api-interface.ts
@@ -1,0 +1,76 @@
+import { Result } from "@adviser/cement";
+import {
+  ReqEnsureUser,
+  ResEnsureUser,
+  ReqFindUser,
+  ResFindUser,
+  ReqCreateTenant,
+  ResCreateTenant,
+  ReqUpdateTenant,
+  ResUpdateTenant,
+  ReqDeleteTenant,
+  ResDeleteTenant,
+  ReqRedeemInvite,
+  ResRedeemInvite,
+  ReqListTenantsByUser,
+  ResListTenantsByUser,
+  ReqUpdateUserTenant,
+  ResUpdateUserTenant,
+  ReqInviteUser,
+  ResInviteUser,
+  ReqListInvites,
+  ResListInvites,
+  ReqDeleteInvite,
+  ResDeleteInvite,
+  ReqCreateLedger,
+  ResCreateLedger,
+  ReqListLedgersByUser,
+  ResListLedgersByUser,
+  ReqUpdateLedger,
+  ResUpdateLedger,
+  ReqDeleteLedger,
+  ResDeleteLedger,
+  ReqCloudSessionToken,
+  ResCloudSessionToken,
+  ReqTokenByResultId,
+  ResTokenByResultId,
+  ReqExtendToken,
+  ResExtendToken,
+  ReqCertFromCsr,
+  ResCertFromCsr,
+  ReqEnsureCloudToken,
+  ResEnsureCloudToken,
+} from "./msg-types.js";
+
+export interface FPApiInterface {
+  ensureUser(req: ReqEnsureUser): Promise<Result<ResEnsureUser>>;
+  findUser(req: ReqFindUser): Promise<Result<ResFindUser>>;
+
+  createTenant(req: ReqCreateTenant): Promise<Result<ResCreateTenant>>;
+  updateTenant(req: ReqUpdateTenant): Promise<Result<ResUpdateTenant>>;
+  deleteTenant(req: ReqDeleteTenant): Promise<Result<ResDeleteTenant>>;
+
+  redeemInvite(req: ReqRedeemInvite): Promise<Result<ResRedeemInvite>>;
+
+  listTenantsByUser(req: ReqListTenantsByUser): Promise<Result<ResListTenantsByUser>>;
+  updateUserTenant(req: ReqUpdateUserTenant): Promise<Result<ResUpdateUserTenant>>;
+
+  // creates / update invite
+  inviteUser(req: ReqInviteUser): Promise<Result<ResInviteUser>>;
+  listInvites(req: ReqListInvites): Promise<Result<ResListInvites>>;
+  deleteInvite(req: ReqDeleteInvite): Promise<Result<ResDeleteInvite>>;
+
+  createLedger(req: ReqCreateLedger): Promise<Result<ResCreateLedger>>;
+  listLedgersByUser(req: ReqListLedgersByUser): Promise<Result<ResListLedgersByUser>>;
+  updateLedger(req: ReqUpdateLedger): Promise<Result<ResUpdateLedger>>;
+  deleteLedger(req: ReqDeleteLedger): Promise<Result<ResDeleteLedger>>;
+
+  // listLedgersByTenant(req: ReqListLedgerByTenant): Promise<ResListLedgerByTenant>
+
+  // attachUserToLedger(req: ReqAttachUserToLedger): Promise<ResAttachUserToLedger>
+  getCloudSessionToken(req: ReqCloudSessionToken): Promise<Result<ResCloudSessionToken>>;
+  getTokenByResultId(req: ReqTokenByResultId): Promise<Result<ResTokenByResultId>>;
+  extendToken(req: ReqExtendToken): Promise<Result<ResExtendToken>>;
+  getCertFromCsr(req: ReqCertFromCsr): Promise<Result<ResCertFromCsr>>;
+  ensureCloudToken(req: ReqEnsureCloudToken): Promise<Result<ResEnsureCloudToken>>;
+}

--- a/core/protocols/dashboard/index.ts
+++ b/core/protocols/dashboard/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod/v4";
 export * from "./msg-types.js";
 export * from "./msg-is.js";
 export * from "./msg-api.js";
+export * from "./fp-api-interface.js";
 export * from "./dashboard-api.js";
 
 // export interface FPClerkClaim extends JWTPayload {

--- a/core/protocols/dashboard/msg-types.ts
+++ b/core/protocols/dashboard/msg-types.ts
@@ -134,6 +134,7 @@ export interface FPApiParameters {
   readonly maxMemberUsers: number;
   readonly maxInvites: number;
   readonly maxLedgers: number;
+  readonly maxAppIdBindings: number;
   readonly deviceCA: DeviceIdCA;
 }
 
@@ -517,4 +518,24 @@ export interface ReqCertFromCsr {
 export interface ResCertFromCsr {
   readonly type: "resCertFromCsr";
   readonly certificate: string;
+}
+
+export interface ReqEnsureCloudToken {
+  readonly type: "reqEnsureCloudToken";
+  readonly auth: DashAuthType;
+  readonly appId: string; // identifier for the client app should be hashed from
+  // localDbName + domain + firstpart of the pathname
+  readonly env?: string; // if the app wants to have seperate binding for prod/staging etc
+  // if not set, "prod" is used
+  readonly tenant?: string;
+  readonly ledger?: string;
+  readonly prevCloudToken?: string; // existing token for cheaper renewal
+}
+
+export interface ResEnsureCloudToken {
+  readonly type: "resEnsureCloudToken";
+  readonly cloudToken: string;
+  readonly appId: string;
+  readonly tenant: string;
+  readonly ledger: string;
 }

--- a/core/protocols/dashboard/msg-types.ts
+++ b/core/protocols/dashboard/msg-types.ts
@@ -538,4 +538,6 @@ export interface ResEnsureCloudToken {
   readonly appId: string;
   readonly tenant: string;
   readonly ledger: string;
+  readonly expiresInSec: number;
+  readonly expiresDate: string; // ISO string
 }

--- a/core/tests/global-setup.ts
+++ b/core/tests/global-setup.ts
@@ -1,4 +1,3 @@
-import { $ } from "zx";
 import type { TestProject } from "vitest/node";
 
 export async function setup(_project: TestProject) {

--- a/core/tests/global-setup.ts
+++ b/core/tests/global-setup.ts
@@ -1,10 +1,9 @@
-import { cd, $ } from "zx";
+import { $ } from "zx";
 import type { TestProject } from "vitest/node";
 
-export async function setup(project: TestProject) {
-  const root = project.toJSON().serializedConfig.root;
-  $.verbose = true;
-  cd(root);
+export async function setup(_project: TestProject) {
+  // const root = project.toJSON().serializedConfig.root;
+  // $.verbose = true;
   return () => {
     /* no-op */
   };

--- a/core/types/protocols/cloud/msg-types.zod.ts
+++ b/core/types/protocols/cloud/msg-types.zod.ts
@@ -23,6 +23,7 @@ export const LedgerClaimSchema = z
 
 export const TenantLedgerSchema = z
   .object({
+    appId: z.string().optional(),
     tenant: z.string(),
     ledger: z.string(),
   })

--- a/dashboard/backend/api.ts
+++ b/dashboard/backend/api.ts
@@ -2077,7 +2077,7 @@ export class FPApiSQL implements FPApiInterface {
         }
       }
       if (!tenantId) {
-        return Result.Err(`no tenant found for binding of ${req.appId}${auth.user.userId}`);
+        return Result.Err(`no tenant found for binding of appId:${req.appId} userId:${auth.user.userId}`);
       }
       if (!ledgerId) {
         // create ledger

--- a/dashboard/backend/app-id-bind.ts
+++ b/dashboard/backend/app-id-bind.ts
@@ -1,0 +1,19 @@
+import { primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sqlLedgers } from "./ledgers.js";
+import { sqlTenants } from "./db-api-schema.js";
+
+export const sqlAppIdBinding = sqliteTable(
+  "AppIdBinding",
+  {
+    appId: text().notNull(),
+    env: text().notNull(),
+    ledgerId: text()
+      .notNull()
+      .references(() => sqlLedgers.ledgerId),
+    tenantId: text()
+      .notNull()
+      .references(() => sqlTenants.tenantId),
+    createdAt: text().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.appId, table.env] })],
+);

--- a/dashboard/backend/cf-serve.ts
+++ b/dashboard/backend/cf-serve.ts
@@ -14,6 +14,7 @@ export interface Env {
   MAX_MEMBER_USERS?: number;
   MAX_INVITES?: number;
   MAX_LEDGERS?: number;
+  MAX_APPID_BINDINGS?: number;
 
   CLERK_PUBLISHABLE_KEY: string;
   CLOUD_SESSION_TOKEN_PUBLIC: string;

--- a/dashboard/backend/create-fp-token.ts
+++ b/dashboard/backend/create-fp-token.ts
@@ -23,13 +23,20 @@ export async function createFPToken(ctx: FPTokenContext, claim: FPCloudClaim) {
   if (validFor <= 0) {
     validFor = 60 * 60; // 1 hour
   }
-  return new SignJWT(claim)
-    .setProtectedHeader({ alg: "ES256" }) // algorithm
-    .setIssuedAt()
-    .setIssuer(ctx.issuer) // issuer
-    .setAudience(ctx.audience) // audience
-    .setExpirationTime(Math.floor((Date.now() + validFor * 1000) / 1000)) // expiration time
-    .sign(privKey);
+  const expiresDate = new Date(Date.now() + validFor * 1000); // epoch sec
+  const expiresInSec = Math.floor((Math.floor(expiresDate.getTime() / 1000) + validFor) / 1000);
+  const epochExp = Math.floor(expiresDate.getTime() / 1000);
+  return {
+    expiresDate,
+    expiresInSec,
+    token: await new SignJWT(claim)
+      .setProtectedHeader({ alg: "ES256" }) // algorithm
+      .setIssuedAt()
+      .setIssuer(ctx.issuer) // issuer
+      .setAudience(ctx.audience) // audience
+      .setExpirationTime(epochExp) // expiration time
+      .sign(privKey),
+  };
 }
 
 export async function getFPTokenContext(sthis: SuperThis, ictx: Partial<FPTokenContext> = {}): Promise<Result<FPTokenContext>> {

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -279,6 +279,7 @@ export async function createHandler<T extends DashSqlite>(db: T, env: Record<str
     maxMemberUsers: coerceInt(env.MAX_MEMBER_USERS, 5),
     maxInvites: coerceInt(env.MAX_INVITES, 10),
     maxLedgers: coerceInt(env.MAX_LEDGERS, 5),
+    maxAppIdBindings: coerceInt(env.MAX_APPID_BINDINGS, 10),
     deviceCA: rDeviceIdCA.Ok(),
   });
   return async (req: Request, bindPromise: BindPromise<Result<unknown>> = (p) => p): Promise<Response> => {

--- a/dashboard/backend/db-api-schema.ts
+++ b/dashboard/backend/db-api-schema.ts
@@ -3,3 +3,4 @@ export * from "./tenants.js";
 export * from "./ledgers.js";
 export * from "./invites.js";
 export * from "./token-by-result-id.js";
+export * from "./app-id-bind.js";

--- a/dashboard/backend/db-api.test.ts
+++ b/dashboard/backend/db-api.test.ts
@@ -1034,7 +1034,7 @@ describe("db-api", () => {
         jwkPack.opts,
       );
       expect(initial.isOk()).toBeTruthy();
-      const initToken = jwtVerify(initial.Ok().cloudToken, jwkPack.pub);
+      const initToken = await jwtVerify(initial.Ok().cloudToken, jwkPack.pub);
       const reEnsure = await fpApi.ensureCloudToken(
         {
           type: "reqEnsureCloudToken",
@@ -1044,8 +1044,8 @@ describe("db-api", () => {
         jwkPack.opts,
       );
       expect(reEnsure.isOk()).toBeTruthy();
-      const reEnsureToken = jwtVerify(reEnsure.Ok().cloudToken, jwkPack.pub);
-      expect(reEnsureToken).toEqual(initToken);
+      const reEnsureToken = await jwtVerify(reEnsure.Ok().cloudToken, jwkPack.pub);
+      expect(reEnsureToken.payload).toEqual(initToken.payload);
     });
 
     it("ensurCloudToken appId but non accessable tenant", async () => {

--- a/dashboard/backend/db-api.test.ts
+++ b/dashboard/backend/db-api.test.ts
@@ -126,7 +126,6 @@ describe("db-api", () => {
   }
   beforeAll(async () => {
     const url = inject("DASH_FP_TEST_SQL_URL" as never) as string;
-    console.log("DASH_FP_TEST_SQL_URL Using test db url:", url);
     const client = createClient({ url });
     db = drizzle(client);
 
@@ -1048,7 +1047,7 @@ describe("db-api", () => {
       expect(reEnsureToken.payload).toEqual(initToken.payload);
     });
 
-    it("ensurCloudToken appId but non accessable tenant", async () => {
+    it("ensureCloudToken appId but non accessable tenant", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const outerTenant = await fpApi.ensureCloudToken({
@@ -1060,7 +1059,7 @@ describe("db-api", () => {
       expect(outerTenant.isErr()).toBeTruthy();
     });
 
-    it("ensurCloudToken appId but non accessable ledger", async () => {
+    it("ensureCloudToken appId but non accessable ledger", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const outerTenant = await fpApi.ensureCloudToken(
@@ -1075,7 +1074,7 @@ describe("db-api", () => {
       expect(outerTenant.isErr()).toBeTruthy();
     });
 
-    it("ensurCloudToken appId valid tenantId", async () => {
+    it("ensureCloudToken appId valid tenantId", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const validTenant = await fpApi.ensureCloudToken(
@@ -1095,7 +1094,7 @@ describe("db-api", () => {
       expect(token.payload.selected.tenant).toBe(validTenant.Ok().tenant);
     });
 
-    it("ensurCloudToken appId invalid tenantId", async () => {
+    it("ensureCloudToken appId invalid tenantId", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const validTenant = await fpApi.ensureCloudToken(
@@ -1110,7 +1109,7 @@ describe("db-api", () => {
       expect(validTenant.isErr()).toBeTruthy();
     });
 
-    it("ensurCloudToken appId valid tenantId, ledgerId", async () => {
+    it("ensureCloudToken appId valid tenantId, ledgerId", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const validTenant = await fpApi.ensureCloudToken(
@@ -1130,7 +1129,7 @@ describe("db-api", () => {
       expect(token.payload.selected.ledger).toBe(ledger.ledger.ledgerId);
     });
 
-    it("ensurCloudToken appId valid tenantId, invalid ledgerId", async () => {
+    it("ensureCloudToken appId valid tenantId, invalid ledgerId", async () => {
       const id = sthis.nextId().str;
       const appId = `TEST_APP-${id}`;
       const validTenant = await fpApi.ensureCloudToken(

--- a/dashboard/backend/drizzle.libsql.config.ts
+++ b/dashboard/backend/drizzle.libsql.config.ts
@@ -1,9 +1,21 @@
+import { URI } from "@adviser/cement";
 import { defineConfig } from "drizzle-kit";
+import fs from "fs";
+import path from "path";
+
+let url: string;
+if (process.env.DASH_FP_TEST_SQL_URL) {
+  url = URI.from(process.env.DASH_FP_TEST_SQL_URL).pathname;
+  console.warn("DASH_FP_TEST_SQL_URL set to:", url);
+} else {
+  url = "./dist/dash-backend.sqlite";
+}
+
+fs.mkdirSync(path.dirname(url), { recursive: true });
+
 export default defineConfig({
   dialect: "sqlite",
   schema: "../backend/db-api-schema.ts",
   out: "./dist",
-  dbCredentials: {
-    url: "./dist/sqlite.db",
-  },
+  dbCredentials: { url },
 });

--- a/dashboard/backend/globalSetup.libsql.ts
+++ b/dashboard/backend/globalSetup.libsql.ts
@@ -1,15 +1,19 @@
 import fs from "fs/promises";
 import path from "node:path";
-import { cd, $ } from "zx";
+import { $ } from "zx";
 import type { TestProject } from "vitest/node";
 
 export async function setup(project: TestProject) {
   const root = project.toJSON().serializedConfig.root;
 
   $.verbose = true;
-  cd(root);
+  // cd(root);
   await fs.mkdir(path.join(root, "dist"), { recursive: true });
-  await $`pnpm exec drizzle-kit push --config ./drizzle.libsql.config.ts`;
+  const dashSQLite = `file://${root}/dist/dash-backend.sqlite`;
+  await $`(cd ${root} && DASH_FP_TEST_SQL_URL=${dashSQLite} pnpm exec drizzle-kit push --config ./drizzle.libsql.config.ts)`;
+
+  project.provide("DASH_FP_TEST_SQL_URL" as never, dashSQLite as never);
+  console.log("Provided DASH_FP_TEST_SQL_URL:", dashSQLite);
 
   return () => {
     /* */

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ const opts = tseslint.config(
   },
   {
     ignores: [
-      "x/**",
+      "xx/**",
       "babel.config.cjs",
       "jest.config.js",
       "**/dist/",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,8 @@ packages:
   - "core/protocols/*"
   - "core/svc/*"
   - "use-fireproof/*"
-  - "dashboard/*"
+  - "dashboard/frontend"
+  - "dashboard/backend"
   - "vendor"
 #catalog:
 #  adviserCement: ^0.4.20


### PR DESCRIPTION
This API method provides an almost frictionless cloud sync. 
There are no ambiguous tests if no binding for the APPId is found, a new tenant/ledger combination is created.
So to have that working, the caller has to provide a stable APPId for vibes to use: localdb + domain + the first part of the path for the node application, localdbname + deviceId. 
the API receives:

export interface ReqEnsureCloudToken {
  readonly type: "reqEnsureCloudToken";
  readonly auth: DashAuthType; // is a ClerkToken or deviceId
  readonly appId: string; // identifier for the client app should be hashed from
  // localDbName + domain + firstpart of the pathname
  readonly env?: string; // if the app wants to have a seperate binding for prod/staging, etc
  // if not set, "prod" is used
  readonly tenant?: string;
  readonly ledger?: string;
  readonly prevCloudToken?: string; // existing token for cheaper renewal
}

if tenant or ledger are set a new binding to a APPID could be create 

it returns:
export interface ResEnsureCloudToken {
  readonly type: "resEnsureCloudToken";
  readonly cloudToken: string;
  readonly appId: string;
  readonly tenant: string;
  readonly ledger: string;
}
Is important that the Token contains the selected { appid, tenant, ledger } so that the cloud backend can act.

And the token needs to be renewed accordingly to its expiration time. I wil provide soon a ResolveOnce/Lazy which is able to set the an expire during the once action --- so this code just a ResolveOnce or Lazy Wrapper.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud token provisioning now supports appId-based bindings with configurable per-app quotas.
  * New dashboard API methods for invite redemption, token lookup, token extension, and ensuring cloud tokens.
  * Tenant ledger records may include an optional appId field.

* **Tests**
  * Expanded cloud token generation, re-issuance, verification, and binding quota tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->