### PR TITLE
implement Clerk integration for dashboard API

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-device-id": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/cloud/3rd-party/cli-fp.ts
+++ b/cloud/3rd-party/cli-fp.ts
@@ -6,7 +6,7 @@ import { Lazy, Result } from "@adviser/cement";
 import { hashObjectSync } from "@fireproof/core-runtime";
 import { getKeyBag } from "@fireproof/core-keybag";
 import { DeviceIdKey, DeviceIdSignMsg } from "@fireproof/core-device-id";
-import { DashAuthType, DashboardApi } from "@fireproof/core-protocols-dashboard";
+import { DashAuthType, DashboardApiImpl } from "@fireproof/core-protocols-dashboard";
 
 export class CliTokenStrategy implements TokenStrategie {
   readonly tc: TokenAndClaims;
@@ -95,12 +95,16 @@ async function main() {
     },
     { resetAfter: 60 },
   );
-  const dashApi = new DashboardApi({
-    apiUrl: "http://localhost:7370/api",
-    getToken: () => {
-      return getDashBoardToken();
+  const dashApi = new DashboardApiImpl({
+    gracePeriodMs: 5000,
+    getTokenCtx: {
+      template: "with-email",
     },
+    apiUrl: "http://localhost:7370/api",
     fetch: fetch.bind(globalThis),
+    getToken: async () => {
+      return Result.Ok(await getDashBoardToken());
+    },
   });
 
   const user = await dashApi.ensureUser({});

--- a/cloud/3rd-party/package.json
+++ b/cloud/3rd-party/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core": "workspace:*",
     "@fireproof/core-device-id": "workspace:*",
     "@fireproof/core-keybag": "workspace:*",

--- a/cloud/backend/base/package.json
+++ b/cloud/backend/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@cloudflare/workers-types": "^4.20251128.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/backend/cf-d1/package.json
+++ b/cloud/backend/cf-d1/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@cloudflare/workers-types": "^4.20251128.0",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",

--- a/cloud/backend/node/package.json
+++ b/cloud/backend/node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/cloud-backend-base": "workspace:0.0.0",
     "@fireproof/cloud-base": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",

--- a/cloud/base/package.json
+++ b/cloud/base/package.json
@@ -38,7 +38,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/cloud/todo-app/package.json
+++ b/cloud/todo-app/package.json
@@ -41,7 +41,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/react": "^19.2.7",
     "react-dom": "^19.2.0",

--- a/core/base/package.json
+++ b/core/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-blockstore": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/blockstore/package.json
+++ b/core/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-gateways-file": "workspace:0.0.0",

--- a/core/core/package.json
+++ b/core/core/package.json
@@ -39,7 +39,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/device-id/package.json
+++ b/core/device-id/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/base/package.json
+++ b/core/gateways/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/gateways/cloud/package.json
+++ b/core/gateways/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/gateways/file-deno/package.json
+++ b/core/gateways/file-deno/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@types/deno": "^2.5.0",

--- a/core/gateways/file-node/package.json
+++ b/core/gateways/file-node/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0"
   }

--- a/core/gateways/file/package.json
+++ b/core/gateways/file/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.10.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-gateways-file-deno": "workspace:0.0.0",
     "@fireproof/core-gateways-file-node": "workspace:0.0.0",

--- a/core/gateways/indexeddb/package.json
+++ b/core/gateways/indexeddb/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/gateways/memory/package.json
+++ b/core/gateways/memory/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^24.10.1"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/keybag/package.json
+++ b/core/keybag/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-gateways-file": "workspace:0.0.0",
     "@fireproof/core-gateways-indexeddb": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",

--- a/core/protocols/cloud/package.json
+++ b/core/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-protocols-cloud": "workspace:0.0.0",

--- a/core/protocols/dashboard/package.json
+++ b/core/protocols/dashboard/package.json
@@ -36,7 +36,8 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
+    "@clerk/clerk-js": "^5.111.0",
     "@fireproof/core-device-id": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/runtime/package.json
+++ b/core/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@adviser/ts-xxhash": "^1.0.2",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/runtime/sts-service/index.ts
+++ b/core/runtime/sts-service/index.ts
@@ -193,7 +193,7 @@ export class SessionTokenService {
   }
 }
 
-const keysFromWellKnownJwksCache = new KeyedResolvOnce<JWKPublic[]>({
+const keysFromWellKnownJwksCache = new KeyedResolvOnce<FetchWellKnownJwksResult>({
   resetAfter: 30 * 60 * 1000, // 30 minutes
 });
 

--- a/core/svc/api/database-api.ts
+++ b/core/svc/api/database-api.ts
@@ -383,11 +383,11 @@ export function fireproofProxy(name: string, cfg: DatabaseProxyConfig): Database
     })
     .once((x) => {
       const sthis = ensureSuperThis();
-      console.log("Creating DatabaseProxy for", name, "with config", cfg, x.refKey);
+      console.log("Creating DatabaseProxy for", name, "with config", cfg, x.ctx.refKey);
       return new DatabaseProxy({
-        ...x.givenKey,
+        ...x.ctx.givenKey,
         name,
-        refId: x.refKey,
+        refId: x.ctx.refKey,
         transport: cfg.transport ?? new FPApiPostMessageTransport(sthis, cfg.webWindow ?? window),
         webWindow: cfg.webWindow ?? window,
         target: cfg.target,

--- a/core/svc/api/package.json
+++ b/core/svc/api/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-svc-protocol": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",

--- a/core/svc/host/package.json
+++ b/core/svc/host/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-svc-protocol": "workspace:0.0.0",

--- a/core/svc/protocol/package.json
+++ b/core/svc/protocol/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",

--- a/core/tests/package.json
+++ b/core/tests/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core": "workspace:0.0.0",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-blockstore": "workspace:0.0.0",
@@ -52,6 +52,7 @@
     "@fireproof/core-gateways-memory": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",
     "@fireproof/core-protocols-cloud": "workspace:0.0.0",
+    "@fireproof/core-protocols-dashboard": "workspace:0.0.0",
     "@fireproof/core-runtime": "workspace:0.0.0",
     "@fireproof/core-svc-api": "workspace:0.0.0",
     "@fireproof/core-svc-host": "workspace:0.0.0",
@@ -73,6 +74,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@clerk/clerk-js": "^5.111.0",
     "@fireproof/core-cli": "workspace:0.0.0",
     "@vitest/browser": "^4.0.14",
     "playwright": "^1.57.0",

--- a/core/tests/protocols/dashboard/clerk-dash-api.test.ts
+++ b/core/tests/protocols/dashboard/clerk-dash-api.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import { clerkDashApi, ResEnsureUser } from "@fireproof/core-protocols-dashboard";
+import { Future, OnFunc } from "@adviser/cement";
+import type { Clerk } from "@clerk/clerk-js";
+
+describe("clerk-dash-api", () => {
+  function testClerk(getToken: () => Promise<string>): Clerk & {
+    invokeCallback: ReturnType<typeof OnFunc<() => void>>;
+  } {
+    const invokeCallback = OnFunc<() => void>();
+    return {
+      invokeCallback,
+      addListener: function (callback: Parameters<Clerk["addListener"]>[0]): () => void {
+        console.log("testClerk: addListener called");
+        invokeCallback(() => {
+          console.log("testClerk: onCallback invoked");
+          callback({ session: { getToken } } as Parameters<Parameters<Clerk["addListener"]>[0]>[0]);
+        });
+        return () => {
+          /* no-op */
+        };
+      },
+    } as unknown as Clerk & { invokeCallback: ReturnType<typeof OnFunc<() => void>> };
+  }
+
+  it("is a singleton", () => {
+    const ci = testClerk(async () => "token");
+    const m1 = clerkDashApi(ci, { apiUrl: "https://api.example.com" });
+    const m2 = clerkDashApi(ci, { apiUrl: "https://api.example.com" });
+    expect(m1).toBe(m2);
+  });
+
+  it("check if getToken fails work", async () => {
+    const fut = new Future<string>();
+    const futFn = vi.fn(() => fut.asPromise());
+    const ci = testClerk(futFn);
+    const api = clerkDashApi(ci, { apiUrl: "https://fails.example.com" });
+    ci.invokeCallback.invoke();
+    setTimeout(() => {
+      fut.reject(new Error("getToken failed"));
+    }, 5);
+    const res = await api.ensureUser({});
+    expect(res.isErr()).toBe(true);
+    expect(res.Err().message).toBe("getToken failed");
+  });
+
+  it("check if getToken works", async () => {
+    const fut = new Future<string>();
+    const futFn = vi.fn(() => fut.asPromise());
+    const ci = testClerk(futFn);
+    const actions = new Array(3).fill(0).map(async () => {
+      const api = clerkDashApi(ci, {
+        apiUrl: "https://ok.example.com",
+        fetch: async (_input: RequestInfo, init: RequestInit) => {
+          expect(JSON.parse(init.body as string)).toEqual({ type: "reqEnsureUser", auth: { type: "clerk", token: "valid-token" } });
+          return new Response(
+            JSON.stringify({
+              type: "resEnsureUser",
+              user: {
+                userId: "",
+                maxTenants: 0,
+                status: "active",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                byProviders: [],
+              },
+              tenants: [],
+            } satisfies ResEnsureUser),
+            { status: 200 },
+          );
+        },
+      });
+      const res = await api.ensureUser({});
+      expect(res.isOk()).toBe(true);
+    });
+    ci.invokeCallback.invoke();
+    setTimeout(() => {
+      fut.resolve("valid-token");
+    }, 5);
+    await Promise.all(actions);
+    expect(futFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("it gets new token on each listener call", async () => {
+    let tokenValue = `valid-token-first`;
+    const tokenFN = vi.fn(async () => {
+      console.log("tokenFN called", tokenValue);
+      return tokenValue;
+    });
+    const ci = testClerk(tokenFN);
+    const api = clerkDashApi(ci, {
+      apiUrl: "https://complex.example.com",
+      fetch: async (_input: RequestInfo, init: RequestInit) => {
+        const body = JSON.parse(init.body as string);
+        return new Response(
+          JSON.stringify({
+            type: "resEnsureUser",
+            user: {
+              userId: body.auth.token,
+              maxTenants: 0,
+              status: "active",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              byProviders: [],
+            },
+            tenants: [],
+          } satisfies ResEnsureUser),
+          { status: 200 },
+        );
+      },
+    });
+    console.log("First invoke");
+    ci.invokeCallback.invoke();
+    console.log("Check first token");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-first");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-first");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-first");
+    tokenValue = `valid-token-second`;
+    console.log("Second invoke-pre");
+    ci.invokeCallback.invoke();
+    console.log("Second invoke-post");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-second");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-second");
+    tokenValue = `valid-token-thrid`;
+    ci.invokeCallback.invoke();
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-thrid");
+    expect((await api.ensureUser({})).Ok().user.userId).toBe("valid-token-thrid");
+    expect(tokenFN).toBeCalledTimes(3);
+  });
+});

--- a/core/tests/runtime/device-id.test.ts
+++ b/core/tests/runtime/device-id.test.ts
@@ -526,7 +526,7 @@ describe("DeviceIdSignMsg", () => {
     });
 
     const ret = await deviceVerifyMsg.verifyWithCertificate(jwt);
-    console.log("Verify:", ret);
+    // console.log("Verify:", ret);
     expect(ret.valid).toBe(false);
   });
 });

--- a/core/types/base/package.json
+++ b/core/types/base/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",
     "@web3-storage/pail": "^0.6.2",

--- a/core/types/blockstore/package.json
+++ b/core/types/blockstore/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-runtime": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/protocols/cloud/package.json
+++ b/core/types/protocols/cloud/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-types-base": "workspace:0.0.0",
     "@fireproof/core-types-blockstore": "workspace:0.0.0",
     "@fireproof/vendor": "workspace:0.0.0",

--- a/core/types/runtime/package.json
+++ b/core/types/runtime/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/fireproof-storage/fireproof/issues"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/vendor": "workspace:0.0.0",
     "multiformats": "^13.4.0"
   }

--- a/dashboard/backend/package.json
+++ b/dashboard/backend/package.json
@@ -20,7 +20,7 @@
     "publish": "echo skip"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@clerk/backend": "^2.24.0",
     "@clerk/clerk-js": "^5.113.0",
     "@fireproof/core": "workspace:0.0.0",

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -25,7 +25,7 @@
     "publish": "echo skip"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@clerk/backend": "^2.24.0",
     "@clerk/clerk-js": "^5.113.0",
     "@clerk/clerk-react": "^5.57.0",

--- a/dashboard/frontend/src/pages/cloud/CsrToCert.tsx
+++ b/dashboard/frontend/src/pages/cloud/CsrToCert.tsx
@@ -55,7 +55,7 @@ export function CsrToCert() {
       setCertificate(null);
       // console.log("Submitting CSR:", data.csrContent);
 
-      const result = await cloud.api.getCertFromCsr({ csr: data.csrContent });
+      const result = await cloud.dashApi.getCertFromCsr({ csr: data.csrContent });
 
       if (result.isOk()) {
         const response = result.Ok();

--- a/dashboard/frontend/src/pages/cloud/api/token-auto.tsx
+++ b/dashboard/frontend/src/pages/cloud/api/token-auto.tsx
@@ -57,7 +57,7 @@ export function ApiTokenAuto() {
   // Create ledger mutation
   const createLedgerMutation = useMutation({
     mutationFn: async ({ tenantId, name }: { tenantId: string; name: string }) => {
-      const res = await cloud.api.createLedger({
+      const res = await cloud.dashApi.createLedger({
         ledger: {
           tenantId,
           name,
@@ -140,7 +140,7 @@ export function ApiTokenAuto() {
         throw new Error("No ledger selected or result_id missing");
       }
 
-      const rToken = await cloud.api.getCloudSessionToken({
+      const rToken = await cloud.dashApi.getCloudSessionToken({
         resultId: resultId,
         selected: {
           tenant: ledgerInfo.tenant,

--- a/dashboard/frontend/src/pages/cloud/api/token.tsx
+++ b/dashboard/frontend/src/pages/cloud/api/token.tsx
@@ -70,7 +70,7 @@ export function ApiToken() {
         throw new Error("No result_id");
       }
       console.log("call getCloudSession", redirectCountdown.state, resultId);
-      const rToken = await cloud.api.getCloudSessionToken({
+      const rToken = await cloud.dashApi.getCloudSessionToken({
         resultId,
         selected: createApiToken,
       });
@@ -317,7 +317,7 @@ function AddIfNotSelectedLedger({
   const { cloud } = useContext(AppContext);
   const mutation = useMutation({
     mutationFn: async ({ tenant, ledgerName }: { tenant: UserTenant; ledgerName: string }) => {
-      const res = await cloud.api.createLedger({
+      const res = await cloud.dashApi.createLedger({
         ledger: {
           tenantId: tenant.tenantId,
           name: ledgerName,

--- a/dashboard/frontend/src/pages/cloud/tenants/delete.tsx
+++ b/dashboard/frontend/src/pages/cloud/tenants/delete.tsx
@@ -17,7 +17,7 @@ export function CloudTenantDelete() {
 
   async function deleteCloudTenantAction(ctx: CloudContext, tenantId: string | undefined) {
     if (tenantId) {
-      await ctx.api.deleteTenant({ tenantId });
+      await ctx.dashApi.deleteTenant({ tenantId });
       console.log("deleted", tenantId);
       refetch();
       navigate(`/fp/cloud`);

--- a/dashboard/frontend/src/pages/cloud/tenants/ledgers/delete.tsx
+++ b/dashboard/frontend/src/pages/cloud/tenants/ledgers/delete.tsx
@@ -18,7 +18,7 @@ export function LedgerDelete() {
 
   async function deleteLedgerAction(ctx: CloudContext, tenantId?: string, ledgerId?: string) {
     if (tenantId && ledgerId) {
-      const res = await ctx.api.deleteLedger({ ledger: { tenantId, ledgerId } });
+      const res = await ctx.dashApi.deleteLedger({ ledger: { tenantId, ledgerId } });
       console.log("deleted", tenantId, ledgerId, res);
       refetch();
       navigate(`/fp/cloud`);

--- a/dashboard/frontend/src/pages/cloud/tenants/members.tsx
+++ b/dashboard/frontend/src/pages/cloud/tenants/members.tsx
@@ -61,7 +61,7 @@ function InviteMembers({ tenant, userId }: { tenant: UserTenant; userId: string 
 
   async function queryExistingUserOrNick(e: React.ChangeEvent<HTMLInputElement>) {
     setQueryValue(e.target.value);
-    const res = await cloud.api.findUser({
+    const res = await cloud.dashApi.findUser({
       query: {
         byString: e.target.value,
       },
@@ -86,7 +86,7 @@ function InviteMembers({ tenant, userId }: { tenant: UserTenant; userId: string 
           existingUserId: user.userId,
         };
       }
-      const res = await cloud.api.inviteUser({
+      const res = await cloud.dashApi.inviteUser({
         ticket: {
           invitedParams: {
             tenant: {
@@ -181,7 +181,7 @@ function CurrentInvites({ tenant }: { tenant: UserTenant }) {
   function handleRemoveInvite(inviteId: string) {
     return async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       e.preventDefault();
-      const res = await cloud.api.deleteInvite({ inviteId });
+      const res = await cloud.dashApi.deleteInvite({ inviteId });
       if (res.isErr()) {
         console.error(res.Err());
         return;

--- a/dashboard/frontend/src/pages/cloud/tenants/new.tsx
+++ b/dashboard/frontend/src/pages/cloud/tenants/new.tsx
@@ -12,7 +12,7 @@ export function newCloudAction(ctx: AppContextType) {
     if (!tenantName || tenantName.trim() === "") {
       return new Response("Tenant name is required", { status: 400 });
     }
-    const rTenant = await ctx.cloud.api.createTenant({
+    const rTenant = await ctx.cloud.dashApi.createTenant({
       tenant: {
         name: tenantName,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,10 @@ importers:
         version: 7.0.0-dev.20251207.1
       '@vitest/browser':
         specifier: ^4.0.14
-        version: 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)
+        version: 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)
       '@vitest/browser-playwright':
         specifier: ^4.0.14
-        version: 4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)
+        version: 4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)
       deno:
         specifier: ^2.5.6
         version: 2.5.6
@@ -69,7 +69,7 @@ importers:
         version: 8.48.1(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.53.0
         version: 4.53.0(@cloudflare/workers-types@4.20251128.0)
@@ -77,8 +77,8 @@ importers:
   cli:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-device-id':
         specifier: workspace:0.0.0
         version: link:../core/device-id
@@ -151,13 +151,13 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   cloud/3rd-party:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core':
         specifier: workspace:*
         version: link:../../core/core
@@ -197,16 +197,16 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.2.4
-        version: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   cloud/backend/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251128.0
         version: 4.20251128.0
@@ -261,7 +261,7 @@ importers:
         version: 0.30.6(patch_hash=9e79163b9304da5cbc3c787034937aeddaf678492ba5636df601baaa78e130d8)
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       zx:
         specifier: ^8.8.5
         version: 8.8.5
@@ -269,8 +269,8 @@ importers:
   cloud/backend/cf-d1:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20251128.0
         version: 4.20251128.0
@@ -319,7 +319,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.53.0
         version: 4.53.0(@cloudflare/workers-types@4.20251128.0)
@@ -330,8 +330,8 @@ importers:
   cloud/backend/node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/cloud-backend-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -373,7 +373,7 @@ importers:
         version: 4.10.7
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       '@fireproof/core-cli':
         specifier: workspace:0.0.0
@@ -391,8 +391,8 @@ importers:
   cloud/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../../core/blockstore
@@ -423,7 +423,7 @@ importers:
         version: link:../../cli
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       zx:
         specifier: ^8.8.5
         version: 8.8.5
@@ -431,8 +431,8 @@ importers:
   cloud/todo-app:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../vendor
@@ -457,13 +457,13 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       vite:
         specifier: ^7.2.4
-        version: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   core/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -508,8 +508,8 @@ importers:
   core/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../gateways/base
@@ -568,8 +568,8 @@ importers:
   core/core:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -589,8 +589,8 @@ importers:
   core/device-id:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-keybag':
         specifier: workspace:0.0.0
         version: link:../keybag
@@ -620,8 +620,8 @@ importers:
   core/gateways/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -644,8 +644,8 @@ importers:
   core/gateways/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -674,8 +674,8 @@ importers:
   core/gateways/file:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -711,8 +711,8 @@ importers:
   core/gateways/file-deno:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -729,8 +729,8 @@ importers:
   core/gateways/file-node:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../types/base
@@ -741,8 +741,8 @@ importers:
   core/gateways/indexeddb:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -765,8 +765,8 @@ importers:
   core/gateways/memory:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -796,8 +796,8 @@ importers:
   core/keybag:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-gateways-file':
         specifier: workspace:0.0.0
         version: link:../gateways/file
@@ -826,8 +826,8 @@ importers:
   core/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -850,8 +850,11 @@ importers:
   core/protocols/dashboard:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
+      '@clerk/clerk-js':
+        specifier: ^5.111.0
+        version: 5.113.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(zod@4.1.13)
       '@fireproof/core-device-id':
         specifier: workspace:0.0.0
         version: link:../../device-id
@@ -874,8 +877,8 @@ importers:
   core/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@adviser/ts-xxhash':
         specifier: ^1.0.2
         version: 1.0.2
@@ -914,8 +917,8 @@ importers:
   core/svc/api:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -935,8 +938,8 @@ importers:
   core/svc/host:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -959,8 +962,8 @@ importers:
   core/svc/protocol:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../../runtime
@@ -980,8 +983,8 @@ importers:
   core/tests:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core':
         specifier: workspace:0.0.0
         version: link:../core
@@ -1015,6 +1018,9 @@ importers:
       '@fireproof/core-protocols-cloud':
         specifier: workspace:0.0.0
         version: link:../protocols/cloud
+      '@fireproof/core-protocols-dashboard':
+        specifier: workspace:0.0.0
+        version: link:../protocols/dashboard
       '@fireproof/core-runtime':
         specifier: workspace:0.0.0
         version: link:../runtime
@@ -1065,7 +1071,7 @@ importers:
         version: 6.1.3
       react:
         specifier: '>=18.0.0'
-        version: 19.1.1
+        version: 19.2.0
       use-fireproof:
         specifier: workspace:0.0.0
         version: link:../../use-fireproof/base
@@ -1076,12 +1082,15 @@ importers:
         specifier: ^4.1.13
         version: 4.1.13
     devDependencies:
+      '@clerk/clerk-js':
+        specifier: ^5.111.0
+        version: 5.113.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(zod@4.1.13)
       '@fireproof/core-cli':
         specifier: workspace:0.0.0
         version: link:../../cli
       '@vitest/browser':
         specifier: ^4.0.14
-        version: 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)
+        version: 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)
       playwright:
         specifier: ^1.57.0
         version: 1.57.0
@@ -1090,7 +1099,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       zx:
         specifier: ^8.8.5
         version: 8.8.5
@@ -1098,8 +1107,8 @@ importers:
   core/types/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-types-blockstore':
         specifier: workspace:0.0.0
         version: link:../blockstore
@@ -1125,8 +1134,8 @@ importers:
   core/types/blockstore:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../base
@@ -1150,8 +1159,8 @@ importers:
   core/types/protocols/cloud:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-types-base':
         specifier: workspace:0.0.0
         version: link:../../base
@@ -1178,8 +1187,8 @@ importers:
   core/types/runtime:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/vendor':
         specifier: workspace:0.0.0
         version: link:../../../vendor
@@ -1190,8 +1199,8 @@ importers:
   dashboard/backend:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@clerk/backend':
         specifier: ^2.24.0
         version: 2.24.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1258,7 +1267,7 @@ importers:
         version: 3.7.4
       vitest:
         specifier: ^4.0.8
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.53.0
         version: 4.53.0(@cloudflare/workers-types@4.20251128.0)
@@ -1269,8 +1278,8 @@ importers:
   dashboard/frontend:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@clerk/backend':
         specifier: ^2.24.0
         version: 2.24.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1309,7 +1318,7 @@ importers:
         version: 4.7.0(monaco-editor@0.53.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
-        version: 0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.1))
+        version: 0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.0)
@@ -1355,7 +1364,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.15.2
-        version: 1.15.2(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20251202.0)(wrangler@4.53.0(@cloudflare/workers-types@4.20251128.0))
+        version: 1.15.2(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20251202.0)(wrangler@4.53.0(@cloudflare/workers-types@4.20251128.0))
       '@cloudflare/workers-types':
         specifier: ^4.20251128.0
         version: 4.20251128.0
@@ -1385,7 +1394,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.22
         version: 10.4.22(postcss@8.5.6)
@@ -1421,16 +1430,16 @@ importers:
         version: 6.0.5(rollup@4.53.3)
       tailwindcss:
         specifier: ^3.4.18
-        version: 3.4.18(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.4.18(tsx@4.21.0)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.2.4
-        version: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.53.0
         version: 4.53.0(@cloudflare/workers-types@4.20251128.0)
@@ -1441,8 +1450,8 @@ importers:
   use-fireproof/base:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       '@fireproof/core-base':
         specifier: workspace:0.0.0
         version: link:../../core/base
@@ -1518,8 +1527,8 @@ importers:
   vendor:
     dependencies:
       '@adviser/cement':
-        specifier: ^0.5.2
-        version: 0.5.2(typescript@5.9.3)
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@5.9.3)
       yocto-queue:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1551,8 +1560,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@adviser/cement@0.5.2':
-    resolution: {integrity: sha512-bCgOdxHCrBL12JAJNpyzigN3abg1gXcMdfdJaSrdG8nMpfzCAxOXV6dLgp+ZMnzckaBdJ2btDYRl/53B3GJF7Q==}
+  '@adviser/cement@0.5.5':
+    resolution: {integrity: sha512-dVHdT5JtkPzmguN7snZDFbb962ufJOFJfDe8dZ5LqoISEGBCdcGhejr8XK+CWYoi3SckDgAzgFkOqMJAmiuP4Q==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6466,8 +6475,8 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -6536,10 +6545,10 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@adviser/cement@0.5.2(typescript@5.9.3)':
+  '@adviser/cement@0.5.5(typescript@5.9.3)':
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
-      yaml: 2.8.1
+      yaml: 2.8.2
     transitivePeerDependencies:
       - typescript
 
@@ -6997,7 +7006,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20251202.0
 
-  '@cloudflare/vite-plugin@1.15.2(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20251202.0)(wrangler@4.53.0(@cloudflare/workers-types@4.20251128.0))':
+  '@cloudflare/vite-plugin@1.15.2(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20251202.0)(wrangler@4.53.0(@cloudflare/workers-types@4.20251128.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.7.11(unenv@2.0.0-rc.24)(workerd@1.20251202.0)
       '@remix-run/node-fetch-server': 0.8.1
@@ -7006,7 +7015,7 @@ snapshots:
       picocolors: 1.1.1
       tinyglobby: 0.2.15
       unenv: 2.0.0-rc.24
-      vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.53.0(@cloudflare/workers-types@4.20251128.0)
       ws: 8.18.0
     transitivePeerDependencies:
@@ -8141,9 +8150,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.1))':
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      tailwindcss: 3.4.18(tsx@4.21.0)(yaml@2.8.1)
+      tailwindcss: 3.4.18(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/query-core@5.87.4': {}
 
@@ -8390,7 +8399,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251207.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20251207.1
 
-  '@vitejs/plugin-react@5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@5.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -8398,33 +8407,33 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)':
+  '@vitest/browser-playwright@4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)':
     dependencies:
-      '@vitest/browser': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)
-      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/browser': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)
+      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)':
+  '@vitest/browser@4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)':
     dependencies:
-      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.14
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -8441,13 +8450,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.14':
     dependencies:
@@ -10563,14 +10572,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
       tsx: 4.21.0
-      yaml: 2.8.1
+      yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -11144,7 +11153,7 @@ snapshots:
 
   tabbable@6.3.0: {}
 
-  tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.1):
+  tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11163,7 +11172,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -11385,7 +11394,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11398,9 +11407,9 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.21.0
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11413,12 +11422,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.21.0
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  vitest@4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.14(@types/node@24.10.1)(@vitest/browser-playwright@4.0.14)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.14
-      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.14(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.14
       '@vitest/runner': 4.0.14
       '@vitest/snapshot': 4.0.14
@@ -11435,11 +11444,11 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.1
-      '@vitest/browser-playwright': 4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.14)
+      '@vitest/browser-playwright': 4.0.14(playwright@1.57.0)(vite@7.2.6(@types/node@24.10.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.14)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11578,7 +11587,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.8.1: {}
+  yaml@2.8.2: {}
 
   yargs-parser@20.2.9: {}
 

--- a/use-fireproof/base/package.json
+++ b/use-fireproof/base/package.json
@@ -22,7 +22,7 @@
   "license": "AFL-2.0",
   "gptdoc": "Fireproof/React/Usage: import { useFireproof } from 'use-fireproof'; function WordCounterApp() { const { useLiveQuery, useDocument } = useFireproof('my-word-app'); const { doc: wordInput, merge: updateWordInput, save: saveWordInput, reset: clearWordInput } = useDocument({ word: '', timestamp: Date.now() }); const recentWords = useLiveQuery('timestamp', { descending: true, limit: 10 }); const { doc: { totalSubmitted }, merge: updateTotalSubmitted, save: saveTotalSubmitted } = useDocument({ _id: 'word-counter', totalSubmitted: 0 }); const handleWordSubmission = (e) => { e.preventDefault(); updateTotalSubmitted({ totalSubmitted: totalSubmitted + 1 }); saveTotalSubmitted(); saveWordInput(); clearWordInput();}; return (<><p>{totalSubmitted} words submitted</p><form onSubmit={handleWordSubmission}><input type='text' value={wordInput.word} onChange={e => updateWordInput({ word: e.target.value })} placeholder='Enter a word' /></form><ul>{recentWords.docs.map(entry => (<li key={entry._id}>{entry.word}</li>))} </ul></>) } export default WordCounterApp;",
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "@fireproof/core-base": "workspace:0.0.0",
     "@fireproof/core-gateways-cloud": "workspace:0.0.0",
     "@fireproof/core-keybag": "workspace:0.0.0",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -29,7 +29,7 @@
     "zx": "^8.8.5"
   },
   "dependencies": {
-    "@adviser/cement": "^0.5.2",
+    "@adviser/cement": "^0.5.5",
     "yocto-queue": "^1.2.2"
   }
 }


### PR DESCRIPTION
…efresh

  Update DashboardApi to support Clerk authentication with automatic token
  refresh and caching. Add clerkDashApi factory function that integrates with
  Clerk's session management and provides a singleton interface. Implement
  grace period-based token refresh for ensureCloudToken to prevent expired
  tokens. Upgrade @adviser/cement to 0.5.5 across all packages for improved
  KeyedResolvOnce functionality.

  Key changes:
  - Rename DashboardApi to DashboardApiImpl and add ClerkDashboardApiConfig
  - Add clerkDashApi() factory that listens to Clerk session changes
  - Implement token caching with gracePeriodMs-based expiration
  - Replace sync getToken() with async Result-based getToken()
  - Add KeyedResolvOnce caching for ensureCloudToken requests
  - Update cli-fp.ts to use new DashboardApiImpl interface
  - Add comprehensive tests for Clerk integration
  - Bump @adviser/cement from 0.5.2 to 0.5.5 across workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clerk-based dashboard API integration with automatic token provisioning, per-request auth injection, and configurable token caching/grace period.

* **Chores**
  * Updated dependencies across the repo (@adviser/cement → ^0.5.5) and added Clerk SDK.

* **Tests**
  * Added comprehensive unit tests for the Clerk-integrated dashboard API and minor test cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->