### PR TITLE
feat: Expose ensureCloudToken via HTTP API

### DIFF
--- a/.github/workflows/ci-core-cf-deploy.yaml
+++ b/.github/workflows/ci-core-cf-deploy.yaml
@@ -14,11 +14,6 @@ jobs:
       docker:
         image: docker:dind
         options: --privileged
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
-      options: --privileged --add-host=host.docker.internal:host-gateway --env STORAGE_URL=http://host.docker.internal:9000/testbucket --env FP_ESM=http://host.docker.internal:4874 --env FP_NPM_REGISTRY=http://host.docker.internal:4873
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     environment: ${{ startsWith(github.ref, 'refs/tags/core-cf@s') && 'staging' || startsWith(github.ref, 'refs/tags/core-cf@p') && 'production' || 'dev' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-core-publish.yaml
+++ b/.github/workflows/ci-core-publish.yaml
@@ -11,12 +11,12 @@ permissions:
 
 jobs:
   ci_core_publish:
+    name: CI Core Publish
+    runs-on: ubuntu-latest
     services:
       docker:
         image: docker:dind
         options: --privileged
-    name: CI Core Publish
-    runs-on: ubuntu-latest
     environment: ${{ startsWith(github.ref, 'refs/tags/core@s') && 'staging' || startsWith(github.ref, 'refs/tags/core@p') && 'production' || 'dev' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-core-publish.yaml
+++ b/.github/workflows/ci-core-publish.yaml
@@ -4,6 +4,11 @@ on:
     tags:
       - 'core@*'
 
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
 jobs:
   ci_core_publish:
     name: CI Core Publish

--- a/.github/workflows/ci-core-publish.yaml
+++ b/.github/workflows/ci-core-publish.yaml
@@ -11,17 +11,12 @@ permissions:
 
 jobs:
   ci_core_publish:
-    name: CI Core Publish
-    runs-on: ubuntu-latest
     services:
       docker:
         image: docker:dind
         options: --privileged
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
-      options: --privileged --add-host=host.docker.internal:host-gateway --env STORAGE_URL=http://host.docker.internal:9000/testbucket --env FP_ESM=http://host.docker.internal:4874 --env FP_NPM_REGISTRY=http://host.docker.internal:4873
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+    name: CI Core Publish
+    runs-on: ubuntu-latest
     environment: ${{ startsWith(github.ref, 'refs/tags/core@s') && 'staging' || startsWith(github.ref, 'refs/tags/core@p') && 'production' || 'dev' }}
     steps:
       - uses: actions/checkout@v4
@@ -29,5 +24,3 @@ jobs:
       - uses: ./actions/base
 
       - uses: ./actions/core-publish
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,6 @@ jobs:
       docker:
         image: docker:dind
         options: --privileged
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
-      options: --privileged --add-host=host.docker.internal:host-gateway --env STORAGE_URL=http://host.docker.internal:9000/testbucket --env FP_ESM=http://host.docker.internal:4874 --env FP_NPM_REGISTRY=http://host.docker.internal:4873
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
     environment:
       name: external-pr
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/dashboard-deploy.yaml
+++ b/.github/workflows/dashboard-deploy.yaml
@@ -11,12 +11,6 @@ jobs:
       docker:
         image: docker:dind
         options: --privileged
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
-      options: --privileged --add-host=host.docker.internal:host-gateway --env STORAGE_URL=http://host.docker.internal:9000/testbucket --env FP_ESM=http://host.docker.internal:4874 --env FP_NPM_REGISTRY=http://host.docker.internal:4873
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-    environment: ${{ startsWith(github.ref, 'refs/tags/dashboard@s') && 'staging' || startsWith(github.ref, 'refs/tags/dashboard@p') && 'production' || 'dev' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/actions/base/action.yaml
+++ b/actions/base/action.yaml
@@ -10,19 +10,16 @@ runs:
     - name: install
       shell: bash
       run: |
-        env
+        pnpm remove -r playwright-chromium
         pnpm install
 
     - name: format-check
       shell: bash
       run: pnpm run format --check
+
     - name: lint
       shell: bash
       run: pnpm run lint
-
-    - name: install
-      shell: bash
-      run: pnpm install
 
     - name: build
       shell: bash
@@ -31,24 +28,8 @@ runs:
     - name: playwright
       shell: bash
       run: |
-        apt-get update
-        apt-get install -y ca-certificates curl gnupg lsb-release jq rsync
-        # Add Docker's official GPG key
-        install -m 0755 -d /etc/apt/keyrings
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-        chmod a+r /etc/apt/keyrings/docker.gpg
-        # Set up Docker repository
-        echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          tee /etc/apt/sources.list.d/docker.list > /dev/null
-        # Install Docker Compose plugin
-        apt-get update
-        apt-get install -y docker-ce-cli docker-compose-plugin
-        docker ps
-        docker compose version
+        pnpm exec playwright install --with-deps chromium
         pnpm exec playwright --version
-        git config --global --add safe.directory $(pwd)
 
     - name: test
       shell: bash

--- a/actions/base/action.yaml
+++ b/actions/base/action.yaml
@@ -28,6 +28,25 @@ runs:
     - name: playwright
       shell: bash
       run: |
+        docker version || true
+        docker compose version || true
+        #sudo apt-get update
+        #sudo apt-get install -y ca-certificates curl gnupg lsb-release jq rsync
+        # Add Docker's official GPG key
+        #sudo install -m 0755 -d /etc/apt/keyrings
+        #curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        #sudo chmod a+r /etc/apt/keyrings/docker.gpg
+        # Set up Docker repository
+        #echo \
+        #  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        #  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        #  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        # Install Docker Compose plugin
+        #sudo apt-get update
+        #sudo apt-get install -y docker-ce-cli docker-compose-plugin
+        #docker ps
+        #docker compose version
+
         pnpm exec playwright install --with-deps chromium
         pnpm exec playwright --version
 

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -1,9 +1,6 @@
 name: "@fireproof/core-publish"
 description: "setup  runtime"
 inputs:
-  NPM_TOKEN:
-    description: "NPM token for publishing packages"
-    required: true
 # your inputs here
 runs:
   using: "composite"
@@ -14,7 +11,7 @@ runs:
         rm -f ~/.npmrc $(find . -name .npmrc -o -name npmrc-smoke -print)
         npm install -g npm@11
         npm --version
-        git fetch --tags --force > /dev/null
+        git fetch --tags --force > /dev/null 2>&1
         git config --local --add gpg.ssh.allowedSignersFile ./allowed_signers
         echo "GITHUB_REF->"$GITHUB_REF
         git tag -v $(git describe --tags --abbrev=0)

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -10,18 +10,11 @@ runs:
   steps:
     - name: publish
       shell: bash
-      env:
-        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
-        rm -f **/.npmrc # publish to the world
+        npm install -g npm@11
+        npm --version
         git fetch --tags --force
-        # we need to have a safe way to store of allowedSigners
         git config --local --add gpg.ssh.allowedSignersFile ./allowed_signers
         echo "GITHUB_REF->"$GITHUB_REF
-        # test tag signature
         git tag -v $(git describe --tags --abbrev=0)
-        # should only run if a tag is set
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.NPM_TOKEN }}" > ~/.npmrc
-        mkdir -p dist
-        echo "//registry.npmjs.org/:_authToken=${{ inputs.NPM_TOKEN }}" > dist/npmrc-smoke
         pnpm run publish --registry https://registry.npmjs.org/

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -9,8 +9,13 @@ runs:
         rm -f ~/.npmrc $(find . -name .npmrc -o -name npmrc-smoke -print)
         npm install -g npm@11
         npm --version
+        echo "X1 $(pwd):$(ls)"
         git fetch --tags --force > /dev/null 2>&1
+        echo "X2"
+        git checkout origin/main ./allowed_signers
+        echo "X3"
         git config --local --add gpg.ssh.allowedSignersFile ./allowed_signers
+        echo "X4"
         echo "GITHUB_REF->"$GITHUB_REF
         git tag -v $(git describe --tags --abbrev=0)
         pnpm run publish --registry https://registry.npmjs.org/ --npm npm

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -11,9 +11,10 @@ runs:
     - name: publish
       shell: bash
       run: |
+        rm -f ~/.npmrc $(find . -name .npmrc -o -name npmrc-smoke -print)
         npm install -g npm@11
         npm --version
-        git fetch --tags --force
+        git fetch --tags --force > /dev/null
         git config --local --add gpg.ssh.allowedSignersFile ./allowed_signers
         echo "GITHUB_REF->"$GITHUB_REF
         git tag -v $(git describe --tags --abbrev=0)

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -1,7 +1,5 @@
 name: "@fireproof/core-publish"
 description: "setup  runtime"
-inputs:
-# your inputs here
 runs:
   using: "composite"
   steps:

--- a/actions/core-publish/action.yaml
+++ b/actions/core-publish/action.yaml
@@ -18,4 +18,4 @@ runs:
         git config --local --add gpg.ssh.allowedSignersFile ./allowed_signers
         echo "GITHUB_REF->"$GITHUB_REF
         git tag -v $(git describe --tags --abbrev=0)
-        pnpm run publish --registry https://registry.npmjs.org/
+        pnpm run publish --registry https://registry.npmjs.org/ --npm npm

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -610,9 +610,10 @@ export function buildCmd(sthis: SuperThis) {
 
         const registry = ["--registry", args.registry];
         const tagsOpts = tags.map((tag) => ["--tag", tag]).flat();
+        $.verbose = true;
         const res = await $`${[args.npm, "publish", "--access", "public", ...registry, "--no-git-checks", ...tagsOpts]}`.nothrow();
         if (res.exitCode !== 0) {
-          console.error(`Failed to publish the package.`);
+          console.error(`Failed to publish the package.`, JSON.stringify(process.env, null, 2));
           process.exit(res.exitCode);
         }
       }

--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -62,10 +62,12 @@ export async function getVersion(
     }
   }
   const gitHeadRes = await $`git rev-parse --short HEAD`.nothrow();
+  let gitHead = "";
   if (gitHeadRes.exitCode !== 0) {
-    process.exit(gitHeadRes.exitCode);
+    gitHead = "unknown";
+  } else {
+    gitHead = gitHeadRes.stdout.trim();
   }
-  const gitHead = gitHeadRes.stdout.trim();
   const dateTickRes = await $`date +%s`.nothrow();
   if (dateTickRes.exitCode !== 0) {
     process.exit(dateTickRes.exitCode);
@@ -613,7 +615,7 @@ export function buildCmd(sthis: SuperThis) {
         $.verbose = true;
         const res = await $`${[args.npm, "publish", "--access", "public", ...registry, "--no-git-checks", ...tagsOpts]}`.nothrow();
         if (res.exitCode !== 0) {
-          console.error(`Failed to publish the package.`, JSON.stringify(process.env, null, 2));
+          console.error(`Failed to publish the package.`); //, JSON.stringify(process.env, null, 2));
           process.exit(res.exitCode);
         }
       }

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "node ./run.js tsc",
     "test": "vitest --run",
-    "pack": "FP_TSC=tsc tsx ./main.ts build --doPack",
-    "publish": "FP_TSC=tsc tsx ./main.ts build"
+    "pack": "FP_TSC=tsgo tsx ./main.ts build --doPack",
+    "publish": "FP_TSC=tsgo tsx ./main.ts build"
   },
   "keywords": [
     "ledger",

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "description": "Live ledger for the web.",
   "type": "module",
-  "bin": "./run.js",
+  "bin": {
+    "core-cli": "run.js"
+  },
   "scripts": {
     "build": "node ./run.js tsc",
     "test": "vitest --run",

--- a/core/protocols/dashboard/msg-is.ts
+++ b/core/protocols/dashboard/msg-is.ts
@@ -19,6 +19,7 @@ import {
   ResTokenByResultId,
   ReqExtendToken,
   ReqCertFromCsr,
+  ReqEnsureCloudToken,
 } from "./msg-types.js";
 
 interface FPApiMsgInterface {
@@ -42,6 +43,7 @@ interface FPApiMsgInterface {
   isDeleteLedger(jso: unknown): jso is ReqDeleteLedger;
   isReqExtendToken(jso: unknown): jso is ReqExtendToken;
   isReqCertFromCsr(jso: unknown): jso is ReqCertFromCsr;
+  isEnsureCloudToken(jso: unknown): jso is ReqEnsureCloudToken;
 }
 
 function hasType(jso: unknown, t: string): jso is { type: string } {
@@ -107,5 +109,8 @@ export class FAPIMsgImpl implements FPApiMsgInterface {
   }
   isReqCertFromCsr(jso: unknown): jso is ReqCertFromCsr {
     return hasType(jso, "reqCertFromCsr");
+  }
+  isEnsureCloudToken(jso: unknown): jso is ReqEnsureCloudToken {
+    return hasType(jso, "reqEnsureCloudToken");
   }
 }

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -364,6 +364,10 @@ export async function createHandler<T extends DashSqlite>(db: T, env: Record<str
         res = fpApi.extendToken(jso);
         break;
 
+      case FPAPIMsg.isEnsureCloudToken(jso):
+        res = fpApi.ensureCloudToken(jso);
+        break;
+
       case FPAPIMsg.isReqCertFromCsr(jso):
         res = fpApi.getCertFromCsr(jso);
         break;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "drizzle:d1-remote": "drizzle-kit push --config ./cloud/backend/cf-d1/drizzle.cloud.d1-remote.config.ts",
     "wrangler:cf-d1": "wrangler deploy -c cloud/backend/cf-d1/wrangler.toml --env dev",
     "prepublish": "core-cli build --prepare-version",
-    "publish": "pnpm run -r --sequential publish"
+    "publish": "pnpm run -r publish"
   },
   "keywords": [
     "ledger",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "drizzle:d1-remote": "drizzle-kit push --config ./cloud/backend/cf-d1/drizzle.cloud.d1-remote.config.ts",
     "wrangler:cf-d1": "wrangler deploy -c cloud/backend/cf-d1/wrangler.toml --env dev",
     "prepublish": "core-cli build --prepare-version",
-    "publish": "pnpm run -r publish"
+    "publish": "pnpm run -r --sequential publish"
   },
   "keywords": [
     "ledger",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -10,6 +10,10 @@
     "pack": "core-cli build --doPack",
     "publish": "core-cli build"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fireproof-storage/fireproof.git"
+  },
   "exports": {
     "./p-limit": {
       "types": "./p-limit/index.d.ts",


### PR DESCRIPTION
## Summary
Exposes the `ensureCloudToken` endpoint via HTTP to enable frontend invite functionality in vibes.diy.

## Changes

### core/protocols/dashboard/msg-is.ts
- Add `ReqEnsureCloudToken` import
- Add `isEnsureCloudToken()` to `FPApiMsgInterface`
- Implement `isEnsureCloudToken()` type guard in `FAPIMsgImpl`

### dashboard/backend/create-handler.ts
- Add case for `FPAPIMsg.isEnsureCloudToken()` in switch statement
- Route HTTP requests to `fpApi.ensureCloudToken()`

## Context

The `ensureCloudToken` method resolves an appId (database name) to a ledger ID, creating the ledger if it doesn't exist. This is required for the vibes.diy invite feature to get ledger IDs when inviting users to shared vibe databases.

The method existed in the backend but was only used by tests (direct calls). This PR exposes it via the HTTP RPC mechanism so frontend code can call `dashApi.ensureCloudToken()` over HTTP.

## What it fixes

Fixes 400 "Invalid request" errors from vibes.diy invite route when calling `dashApi.ensureCloudToken()`.

## Test plan

- [x] TypeScript compilation passes (pre-existing Clerk version errors unrelated to changes)
- [x] Backend method exists and works (tested via unit tests)
- [x] Type guard follows existing patterns
- [ ] Integration test: vibes.diy invite route should work once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cloud token management functionality.
  * Introduced package manager selection option in build command (pnpm, npm, yarn, bun).

* **Chores**
  * Optimized CI/CD workflows by streamlining container and build dependencies.
  * Updated build scripts and package configuration for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->