### PR TITLE
feat: Expose ensureCloudToken via HTTP API

### DIFF
--- a/core/protocols/dashboard/msg-is.ts
+++ b/core/protocols/dashboard/msg-is.ts
@@ -19,6 +19,7 @@ import {
   ResTokenByResultId,
   ReqExtendToken,
   ReqCertFromCsr,
+  ReqEnsureCloudToken,
 } from "./msg-types.js";
 
 interface FPApiMsgInterface {
@@ -42,6 +43,7 @@ interface FPApiMsgInterface {
   isDeleteLedger(jso: unknown): jso is ReqDeleteLedger;
   isReqExtendToken(jso: unknown): jso is ReqExtendToken;
   isReqCertFromCsr(jso: unknown): jso is ReqCertFromCsr;
+  isEnsureCloudToken(jso: unknown): jso is ReqEnsureCloudToken;
 }
 
 function hasType(jso: unknown, t: string): jso is { type: string } {
@@ -107,5 +109,8 @@ export class FAPIMsgImpl implements FPApiMsgInterface {
   }
   isReqCertFromCsr(jso: unknown): jso is ReqCertFromCsr {
     return hasType(jso, "reqCertFromCsr");
+  }
+  isEnsureCloudToken(jso: unknown): jso is ReqEnsureCloudToken {
+    return hasType(jso, "reqEnsureCloudToken");
   }
 }

--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -364,6 +364,10 @@ export async function createHandler<T extends DashSqlite>(db: T, env: Record<str
         res = fpApi.extendToken(jso);
         break;
 
+      case FPAPIMsg.isEnsureCloudToken(jso):
+        res = fpApi.ensureCloudToken(jso);
+        break;
+
       case FPAPIMsg.isReqCertFromCsr(jso):
         res = fpApi.getCertFromCsr(jso);
         break;


### PR DESCRIPTION
## Summary
Expose `ensureCloudToken` method via HTTP API by adding missing handler in backend routing.

## Problem
The invite route (`/invite`) was failing with `400 Bad Request` when calling `dashApi.ensureCloudToken()`. The method exists in the backend but was not exposed via HTTP - the handler switch statement in `create-handler.ts` was missing a case for `isEnsureCloudToken`.

## Changes
- Added `ReqEnsureCloudToken` type guard to `msg-is.ts` (interface + implementation)
- Added handler case in `create-handler.ts` to route `ensureCloudToken` requests

## Technical Details
- **Files Changed**: 2 files, 9 insertions
  - `core/protocols/dashboard/msg-is.ts`: Added type guard
  - `dashboard/backend/create-handler.ts`: Added routing case
- **Testing**: Existing tests pass (pre-existing test failures unrelated to this change)

## Related
- Fixes invite route 400 errors
- Enables ledger lookup/creation by appId (database name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud token validation operations to enhance token management and system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->