### PR TITLE
feat: shared ledger access for invited users

### DIFF
--- a/dashboard/backend/api.ts
+++ b/dashboard/backend/api.ts
@@ -155,12 +155,15 @@ export class FPApiSQL implements FPApiInterface {
     return this.#checkAuth(req, (req) => getCertFromCsr(this.ctx, req));
   }
   async ensureCloudToken(req: ReqEnsureCloudToken, ictx: Partial<FPTokenContext> = {}): Promise<Result<ResEnsureCloudToken>> {
-    // For new users, ensureUser must be called first to create them
+    // p0.46 - For new users, ensureUser must be called first to create them
     // This allows invited users to access shared ledgers on first visit
+    console.log("[ensureCloudToken p0.46] starting for appId:", req.appId);
     const rUser = await ensureUser(this.ctx, { type: "reqEnsureUser", auth: req.auth });
     if (rUser.isErr()) {
+      console.log("[ensureCloudToken p0.46] ensureUser failed:", rUser.Err());
       return Result.Err(rUser.Err());
     }
+    console.log("[ensureCloudToken p0.46] ensureUser succeeded, userId:", rUser.Ok().user.userId);
     return this.#checkAuth(req, (req) => ensureCloudToken(this.ctx, req, ictx));
   }
 

--- a/dashboard/backend/api.ts
+++ b/dashboard/backend/api.ts
@@ -154,7 +154,13 @@ export class FPApiSQL implements FPApiInterface {
   getCertFromCsr(req: ReqCertFromCsr): Promise<Result<ResCertFromCsr>> {
     return this.#checkAuth(req, (req) => getCertFromCsr(this.ctx, req));
   }
-  ensureCloudToken(req: ReqEnsureCloudToken, ictx: Partial<FPTokenContext> = {}): Promise<Result<ResEnsureCloudToken>> {
+  async ensureCloudToken(req: ReqEnsureCloudToken, ictx: Partial<FPTokenContext> = {}): Promise<Result<ResEnsureCloudToken>> {
+    // For new users, ensureUser must be called first to create them
+    // This allows invited users to access shared ledgers on first visit
+    const rUser = await ensureUser(this.ctx, { type: "reqEnsureUser", auth: req.auth });
+    if (rUser.isErr()) {
+      return Result.Err(rUser.Err());
+    }
     return this.#checkAuth(req, (req) => ensureCloudToken(this.ctx, req, ictx));
   }
 

--- a/dashboard/backend/public/ensure-cloud-token.ts
+++ b/dashboard/backend/public/ensure-cloud-token.ts
@@ -97,7 +97,12 @@ export async function ensureCloudToken(
         .where(and(eq(sqlAppIdBinding.appId, req.appId), eq(sqlAppIdBinding.env, req.env ?? "prod")))
         .get();
       if (existingBinding) {
-        console.log("[ensureCloudToken p0.49] existingBinding found for appId:", req.appId, "ledgerId:", existingBinding.Ledgers.ledgerId);
+        console.log(
+          "[ensureCloudToken p0.49] existingBinding found for appId:",
+          req.appId,
+          "ledgerId:",
+          existingBinding.Ledgers.ledgerId,
+        );
         // Auto-redeem any pending invites for this user (ensureUser calls redeemInvite)
         await ensureUser(ctx, {
           type: "reqEnsureUser",
@@ -115,7 +120,14 @@ export async function ensureCloudToken(
             ),
           )
           .get();
-        console.log("[ensureCloudToken p0.49] userInLedger check for ledgerId:", existingBinding.Ledgers.ledgerId, "userId:", req.auth.user.userId, "found:", !!userInLedger);
+        console.log(
+          "[ensureCloudToken p0.49] userInLedger check for ledgerId:",
+          existingBinding.Ledgers.ledgerId,
+          "userId:",
+          req.auth.user.userId,
+          "found:",
+          !!userInLedger,
+        );
         if (!userInLedger) {
           return Result.Err(`user not authorized for ledger - please accept the invite first`);
         }

--- a/dashboard/backend/public/ensure-cloud-token.ts
+++ b/dashboard/backend/public/ensure-cloud-token.ts
@@ -97,6 +97,7 @@ export async function ensureCloudToken(
         .where(and(eq(sqlAppIdBinding.appId, req.appId), eq(sqlAppIdBinding.env, req.env ?? "prod")))
         .get();
       if (existingBinding) {
+        console.log("[ensureCloudToken p0.49] existingBinding found for appId:", req.appId, "ledgerId:", existingBinding.Ledgers.ledgerId);
         // Auto-redeem any pending invites for this user (ensureUser calls redeemInvite)
         await ensureUser(ctx, {
           type: "reqEnsureUser",
@@ -114,6 +115,7 @@ export async function ensureCloudToken(
             ),
           )
           .get();
+        console.log("[ensureCloudToken p0.49] userInLedger check for ledgerId:", existingBinding.Ledgers.ledgerId, "userId:", req.auth.user.userId, "found:", !!userInLedger);
         if (!userInLedger) {
           return Result.Err(`user not authorized for ledger - please accept the invite first`);
         }

--- a/dashboard/backend/public/ensure-cloud-token.ts
+++ b/dashboard/backend/public/ensure-cloud-token.ts
@@ -97,6 +97,11 @@ export async function ensureCloudToken(
         .where(and(eq(sqlAppIdBinding.appId, req.appId), eq(sqlAppIdBinding.env, req.env ?? "prod")))
         .get();
       if (existingBinding) {
+        // Auto-redeem any pending invites for this user (ensureUser calls redeemInvite)
+        await ensureUser(ctx, {
+          type: "reqEnsureUser",
+          auth: req.auth.verifiedAuth,
+        });
         // Verify the user is actually in LedgerUsers before granting access (strict policy)
         const userInLedger = await ctx.db
           .select()

--- a/dashboard/backend/public/ensure-cloud-token.ts
+++ b/dashboard/backend/public/ensure-cloud-token.ts
@@ -1,7 +1,7 @@
 import { Result } from "@adviser/cement";
 import { DashAuthType, ReqEnsureCloudToken, ResEnsureCloudToken } from "@fireproof/core-protocols-dashboard";
 import { FPCloudClaimSchema } from "@fireproof/core-types-protocols-cloud";
-import { eq, and, count } from "drizzle-orm";
+import { eq, and, count, like } from "drizzle-orm";
 import { sqlAppIdBinding } from "../sql/app-id-bind.js";
 import { sqlLedgers, sqlLedgerUsers } from "../sql/ledgers.js";
 import { FPApiSQLCtx, FPTokenContext, ReqWithVerifiedAuthUser, VerifiedAuthUser } from "../types.js";
@@ -86,6 +86,25 @@ export async function ensureCloudToken(
     }
     if (!tenantId) {
       return Result.Err(`no tenant found for binding of appId:${req.appId} userId:${req.auth.user.userId}`);
+    }
+    if (!ledgerId) {
+      // Check if user has access to a ledger with name starting with appId (for shared/invited users)
+      const sharedLedger = await ctx.db
+        .select()
+        .from(sqlLedgerUsers)
+        .innerJoin(sqlLedgers, eq(sqlLedgers.ledgerId, sqlLedgerUsers.ledgerId))
+        .where(
+          and(
+            eq(sqlLedgerUsers.userId, req.auth.user.userId),
+            eq(sqlLedgerUsers.status, "active"),
+            like(sqlLedgers.name, `${req.appId}%`),
+          ),
+        )
+        .get();
+      if (sharedLedger) {
+        ledgerId = sharedLedger.Ledgers.ledgerId;
+        tenantId = sharedLedger.Ledgers.tenantId;
+      }
     }
     if (!ledgerId) {
       // create ledger

--- a/dashboard/backend/public/ensure-user.ts
+++ b/dashboard/backend/public/ensure-user.ts
@@ -121,10 +121,12 @@ export async function ensureUser(ctx: FPApiSQLCtx, req: ReqEnsureUser): Promise<
     }
   }
   // Auto-redeem any pending invites for this user
-  await redeemInvite(ctx, {
+  console.log("[ensureUser p0.47] calling redeemInvite for email:", auth.verifiedAuth.params.email);
+  const redeemResult = await redeemInvite(ctx, {
     type: "reqRedeemInvite",
     auth,
   });
+  console.log("[ensureUser p0.47] redeemInvite result:", JSON.stringify(redeemResult));
   return Result.Ok({
     type: "resEnsureUser",
     user: user,

--- a/dashboard/backend/public/invite-user.ts
+++ b/dashboard/backend/public/invite-user.ts
@@ -9,17 +9,30 @@ import { createInviteTicket } from "../internal/create-invite-ticket.js";
 import { updateInviteTicket } from "../internal/update-invite.ticket.js";
 
 export async function inviteUser(ctx: FPApiSQLCtx, req: ReqWithVerifiedAuthUser<ReqInviteUser>): Promise<Result<ResInviteUser>> {
+  console.log(
+    "[inviteUser p0.48] starting with request:",
+    JSON.stringify({
+      query: req.ticket.query,
+      invitedParams: req.ticket.invitedParams,
+      inviteId: req.ticket.inviteId,
+    }),
+  );
   if (!isVerifiedUserActive(req.auth)) {
+    console.log("[inviteUser p0.48] user not active");
     return Result.Err(new UserNotFoundError());
   }
   const findUser = await queryUser(ctx.db, req.ticket.query);
   if (findUser.isErr()) {
+    console.log("[inviteUser p0.48] queryUser failed:", findUser.Err());
     return Result.Err(findUser.Err());
   }
+  console.log("[inviteUser p0.48] queryUser found:", findUser.Ok().length, "users");
   if (req.ticket.query.existingUserId && findUser.Ok().length !== 1) {
+    console.log("[inviteUser p0.48] existingUserId not found");
     return Result.Err("existingUserId not found");
   }
   if (req.ticket.query.existingUserId === req.auth.user.userId) {
+    console.log("[inviteUser p0.48] cannot invite self");
     return Result.Err("cannot invite self");
   }
 
@@ -34,38 +47,60 @@ export async function inviteUser(ctx: FPApiSQLCtx, req: ReqWithVerifiedAuthUser<
   let tenantId: string | undefined;
   let ledgerId: string | undefined;
   if (req.ticket.invitedParams?.ledger) {
+    console.log("[inviteUser p0.48] looking for ledger:", req.ticket.invitedParams.ledger.id);
     const ledger = await ctx.db.select().from(sqlLedgers).where(eq(sqlLedgers.ledgerId, req.ticket.invitedParams.ledger.id)).get();
     if (!ledger) {
+      console.log("[inviteUser p0.48] ledger not found");
       return Result.Err("ledger not found");
     }
     ledgerId = ledger.ledgerId;
     tenantId = ledger.tenantId;
+    console.log("[inviteUser p0.48] found ledger:", ledgerId, "tenantId:", tenantId);
   }
   if (req.ticket.invitedParams?.tenant) {
+    console.log("[inviteUser p0.48] looking for tenant:", req.ticket.invitedParams.tenant.id);
     const tenant = await ctx.db.select().from(sqlTenants).where(eq(sqlTenants.tenantId, req.ticket.invitedParams.tenant.id)).get();
     if (!tenant) {
+      console.log("[inviteUser p0.48] tenant not found");
       return Result.Err("tenant not found");
     }
     tenantId = tenant.tenantId;
+    console.log("[inviteUser p0.48] found tenant:", tenantId);
   }
   if (!tenantId) {
+    console.log("[inviteUser p0.48] no tenant found");
     return Result.Err("tenant not found");
   }
 
   let inviteTicket: InviteTicket;
   if (!req.ticket.inviteId) {
+    console.log("[inviteUser p0.48] creating new invite for tenantId:", tenantId, "ledgerId:", ledgerId);
     const rInviteTicket = await createInviteTicket(ctx, req.auth.user.userId, tenantId, ledgerId, req);
     if (rInviteTicket.isErr()) {
+      console.log("[inviteUser p0.48] createInviteTicket failed:", rInviteTicket.Err());
       return Result.Err(rInviteTicket.Err());
     }
     inviteTicket = rInviteTicket.Ok();
+    console.log(
+      "[inviteUser p0.48] created invite:",
+      JSON.stringify({
+        inviteId: inviteTicket.inviteId,
+        ledgerId: inviteTicket.invitedParams.ledger?.id,
+        tenantId: inviteTicket.invitedParams.tenant?.id,
+        queryEmail: inviteTicket.query.byEmail,
+      }),
+    );
   } else {
+    console.log("[inviteUser p0.48] updating invite:", req.ticket.inviteId);
     const rInviteTicket = await updateInviteTicket(ctx, req.auth.user.userId, tenantId, ledgerId, req);
     if (rInviteTicket.isErr()) {
+      console.log("[inviteUser p0.48] updateInviteTicket failed:", rInviteTicket.Err());
       return Result.Err(rInviteTicket.Err());
     }
     inviteTicket = rInviteTicket.Ok();
+    console.log("[inviteUser p0.48] updated invite:", inviteTicket.inviteId);
   }
+  console.log("[inviteUser p0.48] success, returning invite:", inviteTicket.inviteId);
   return Result.Ok({
     type: "resInviteUser",
     invite: inviteTicket,

--- a/dashboard/backend/public/redeem-invite.ts
+++ b/dashboard/backend/public/redeem-invite.ts
@@ -20,9 +20,24 @@ export async function redeemInvite(
   };
   console.log("[redeemInvite p0.47] searching with query:", JSON.stringify(query));
   const foundInvites = await findInvite(ctx, { query });
-  console.log("[redeemInvite p0.47] found invites:", foundInvites.length, "pending:", foundInvites.filter((i) => i.status === "pending").length);
+  console.log(
+    "[redeemInvite p0.47] found invites:",
+    foundInvites.length,
+    "pending:",
+    foundInvites.filter((i) => i.status === "pending").length,
+  );
   if (foundInvites.length > 0) {
-    console.log("[redeemInvite p0.47] invite details:", JSON.stringify(foundInvites.map((i) => ({ id: i.inviteId, status: i.status, queryEmail: i.query.byEmail, ledger: i.invitedParams.ledger?.id }))));
+    console.log(
+      "[redeemInvite p0.47] invite details:",
+      JSON.stringify(
+        foundInvites.map((i) => ({
+          id: i.inviteId,
+          status: i.status,
+          queryEmail: i.query.byEmail,
+          ledger: i.invitedParams.ledger?.id,
+        })),
+      ),
+    );
   }
   return Result.Ok({
     type: "resRedeemInvite",

--- a/dashboard/backend/public/redeem-invite.ts
+++ b/dashboard/backend/public/redeem-invite.ts
@@ -13,21 +13,22 @@ export async function redeemInvite(
   ctx: FPApiSQLCtx,
   req: ReqWithVerifiedAuthUser<ReqRedeemInvite>,
 ): Promise<Result<ResRedeemInvite>> {
+  const query = {
+    byString: req.auth.verifiedAuth.params.email,
+    byNick: req.auth.verifiedAuth.params.nick,
+    existingUserId: req.auth.user.userId,
+  };
+  console.log("[redeemInvite p0.47] searching with query:", JSON.stringify(query));
+  const foundInvites = await findInvite(ctx, { query });
+  console.log("[redeemInvite p0.47] found invites:", foundInvites.length, "pending:", foundInvites.filter((i) => i.status === "pending").length);
+  if (foundInvites.length > 0) {
+    console.log("[redeemInvite p0.47] invite details:", JSON.stringify(foundInvites.map((i) => ({ id: i.inviteId, status: i.status, queryEmail: i.query.byEmail, ledger: i.invitedParams.ledger?.id }))));
+  }
   return Result.Ok({
     type: "resRedeemInvite",
     invites: sqlToInviteTickets(
       await Promise.all(
-        (
-          await findInvite(ctx, {
-            query: {
-              byString: req.auth.verifiedAuth.params.email,
-              byNick: req.auth.verifiedAuth.params.nick,
-              existingUserId: req.auth.user.userId,
-              // TODO
-              // andProvider: req.auth.verifiedAuth.provider,
-            },
-          })
-        )
+        foundInvites
           .filter((i) => i.status === "pending")
           .map(async (invite) => {
             if (invite.invitedParams.tenant) {


### PR DESCRIPTION
## Summary

When an invited user calls `ensureCloudToken` with an appId, they currently get a new ledger created for them (with name `{appId}-{userId}`), causing a UNIQUE constraint violation if they're invited to the owner's ledger.

This PR adds prefix matching: before creating a new ledger, check if the user has access to any ledger whose name **starts with** the appId. This allows invited users to access the owner's ledger instead of creating a duplicate.

## Question for review

**Should we use prefix matching, or should we remove the user-id suffix from ledger names entirely?**

### Option A: Prefix matching (this PR)
- Ledger name format stays: `{appId}-{ownerUserId}`  
- On `ensureCloudToken`, check for ledgers matching `LIKE '{appId}%'`
- Pros: preserves user-specific ledger names, works with existing data
- Cons: adds query complexity, relies on naming convention

### Option B: Remove user-id suffix
- Ledger name format becomes just: `{appId}`
- Simpler logic, but name collision risk if same appId used by different apps
- Would need migration for existing ledgers

## Test plan
- [x] Added test: "ensureCloudToken grants invited user access to shared ledger via prefix match"
- [x] All 34 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reuse existing app-scoped ledger bindings when available; invited users can be auto-redeemed and gain access without creating a new ledger. New ledgers are named after the app ID and binding limits are enforced.

* **Bug Fixes**
  * Avoid duplicate membership insertion by treating existing ledger memberships as successful.

* **Refactor**
  * Streamlined user lookup/condition building and tightened authorization checks.

* **Tests**
  * Expanded coverage for invite redemption, shared-ledger access, prefix-matching, and unauthorized-access scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->