### PR TITLE
fix(security): remove storekey=insecure encryption bypass

### DIFF
--- a/core/keybag/key-bag.ts
+++ b/core/keybag/key-bag.ts
@@ -85,11 +85,29 @@ export class KeyBag implements KeyBagIf {
     );
   }
 
+  /**
+   * Ensures a store key is present in the URL, generating one if needed.
+   * Rejects attempts to use insecure (unencrypted) storage.
+   *
+   * @param url - The URI to ensure has a store key
+   * @param keyFactory - Factory function to generate a key name if none exists
+   * @returns Result containing the URI with store key, or error if insecure mode attempted
+   * @throws Error if storekey=insecure is attempted (removed for security)
+   */
   async ensureKeyFromUrl(url: URI, keyFactory: () => string): Promise<Result<URI>> {
     // add storekey to url
     const storeKey = url.getParam(PARAM.STORE_KEY);
     if (storeKey === "insecure") {
-      return Result.Ok(url);
+      return Result.Err(
+        this.logger
+          .Error()
+          .Msg(
+            "storekey=insecure is no longer supported. " +
+              "Data must be encrypted. Remove the storekey=insecure parameter " +
+              "to use automatic key generation, or provide a valid encryption key.",
+          )
+          .AsError(),
+      );
     }
     if (!storeKey) {
       const keyName = `@${keyFactory()}@`;

--- a/core/tests/blockstore/keyed-crypto-indexeddb-file.test.ts
+++ b/core/tests/blockstore/keyed-crypto-indexeddb-file.test.ts
@@ -121,14 +121,16 @@ describe("KeyedCryptoStore", () => {
     baseUrl = baseUrl.build().defParam(PARAM.NAME, "test").URI();
     loader = mockLoader(sthis);
   });
-  it("no crypto", async () => {
+  /**
+   * Tests that creating stores with storekey=insecure is rejected.
+   * The insecure mode has been removed for security (see spec-03).
+   */
+  it("rejects insecure storekey", async () => {
     const url = baseUrl.build().setParam(PARAM.STORE_KEY, "insecure").URI();
-    for (const pstore of (await createAttachedStores(url, loader, "insecure")).stores.baseStores) {
-      const store = await pstore;
-      // await store.start();
-      const kc = await store.keyedCrypto();
-      expect(kc.constructor.name).toBe("noCrypto");
-      // expect(kc.isEncrypting).toBe(false);
-    }
+
+    // Attempting to create stores with insecure storekey should throw
+    await expect(createAttachedStores(url, loader, "test-indexeddb-file")).rejects.toThrow(
+      /storekey=insecure is no longer supported/,
+    );
   });
 });

--- a/core/tests/blockstore/keyed-crypto.test.ts
+++ b/core/tests/blockstore/keyed-crypto.test.ts
@@ -256,22 +256,17 @@ describe("KeyedCryptoStore", () => {
     kb = await getKeyBag(sthis, {});
     loader = mockLoader(sthis);
   });
-  it("no crypto", async () => {
+  it("rejects insecure storekey", async () => {
     const url = baseUrl.build().setParam(PARAM.STORE_KEY, "insecure").URI();
 
-    for (const pstore of (await createAttachedStores(url, loader, "insecure")).stores.baseStores) {
-      const store = await pstore;
-      // await store.start();
-      const kc = await store.keyedCrypto();
-      expect(kc.constructor.name).toBe("noCrypto");
-      // expect(kc.isEncrypting).toBe(false);
-      expect(kc.constructor.name).toBe("noCrypto");
-      // expect(kc.isEncrypting).toBe(false);
-    }
+    // Attempting to create stores with insecure storekey should throw
+    await expect(createAttachedStores(url, loader, "insecure")).rejects.toThrow(
+      /storekey=insecure is no longer supported/,
+    );
   });
 
   it("create key", async () => {
-    for (const pstore of (await createAttachedStores(baseUrl, loader, "insecure")).stores.baseStores) {
+    for (const pstore of (await createAttachedStores(baseUrl, loader, "test-create-key")).stores.baseStores) {
       const store = await pstore; // await bs.ensureStart(await pstore, logger);
       const kc = await store.keyedCrypto();
       expect(kc.constructor.name).toBe("cryptoAction");
@@ -286,7 +281,7 @@ describe("KeyedCryptoStore", () => {
     const key = base58btc.encode(kb.rt.crypto.randomBytes(kb.rt.keyLength));
     const genKey = await kb.getNamedKey("@heute@", false, key);
     const url = baseUrl.build().setParam(PARAM.STORE_KEY, "@heute@").URI();
-    for (const pstore of (await createAttachedStores(url, loader, "insecure")).stores.baseStores) {
+    for (const pstore of (await createAttachedStores(url, loader, "test-key-ref")).stores.baseStores) {
       const store = await pstore;
       // await store.start();
       expect(store.url().getParam(PARAM.STORE_KEY)).toBe(`@heute@`);
@@ -307,7 +302,7 @@ describe("KeyedCryptoStore", () => {
   it("key", async () => {
     const key = base58btc.encode(kb.rt.crypto.randomBytes(kb.rt.keyLength));
     const url = baseUrl.build().setParam(PARAM.STORE_KEY, key).URI();
-    for (const pstore of (await createAttachedStores(url, loader, "insecure")).stores.baseStores) {
+    for (const pstore of (await createAttachedStores(url, loader, "test-direct-key")).stores.baseStores) {
       // for (const pstore of [strt.makeDataStore(loader), strt.makeMetaStore(loader), strt.makeWALStore(loader)]) {
       const store = await pstore;
       // await store.start();

--- a/core/tests/blockstore/standalone.test.ts
+++ b/core/tests/blockstore/standalone.test.ts
@@ -105,7 +105,6 @@ describe("standalone", () => {
         default:
           uri = BuildURI.from("file://dist/standalone")
             .setParam(PARAM.NAME, "peer-log")
-            .setParam(PARAM.STORE_KEY, "insecure")
             .URI();
           break;
       }
@@ -115,10 +114,10 @@ describe("standalone", () => {
         writeQueue: { chunkSize: 32 },
         storeUrls: {
           data: {
-            meta: uri.build().setParam(PARAM.STORE, "meta").setParam(PARAM.STORE_KEY, "insecure").URI(),
-            car: uri.build().setParam(PARAM.STORE, "car").setParam(PARAM.STORE_KEY, "insecure").URI(),
-            file: uri.build().setParam(PARAM.STORE, "file").setParam(PARAM.STORE_KEY, "insecure").URI(),
-            wal: uri.build().setParam(PARAM.STORE, "wal").setParam(PARAM.STORE_KEY, "insecure").URI(),
+            meta: uri.build().setParam(PARAM.STORE, "meta").URI(),
+            car: uri.build().setParam(PARAM.STORE, "car").URI(),
+            file: uri.build().setParam(PARAM.STORE, "file").URI(),
+            wal: uri.build().setParam(PARAM.STORE, "wal").URI(),
           },
         },
       } as LedgerOpts);

--- a/core/tests/fireproof/stable-cid.test.ts
+++ b/core/tests/fireproof/stable-cid.test.ts
@@ -8,15 +8,16 @@ import { getKeyBag } from "@fireproof/core-keybag";
 import { CryptoAction, IvKeyIdData } from "@fireproof/core-types-blockstore";
 
 const sthis = ensureSuperThis();
+
+/**
+ * Tests regression of stable CID encoding with encrypted storage.
+ * Note: insecure storekey has been removed (see spec-03).
+ */
 describe.each([
   async () => {
     const kb = await getKeyBag(sthis, {});
     const keyStr = base58btc.encode(toCryptoRuntime().randomBytes(kb.rt.keyLength));
     return await keyedCryptoFactory(URI.from(`test://bla?storekey=${keyStr}`), kb, sthis);
-  },
-  async () => {
-    const kb = await getKeyBag(sthis, {});
-    return await keyedCryptoFactory(URI.from(`test://bla?storekey=insecure`), kb, sthis);
   },
 ])("regression of stable cid encoding", (factory) => {
   let kycr: CryptoAction;


### PR DESCRIPTION
## Summary
- Removes the `storekey=insecure` option that bypassed encryption
- All data is now encrypted by default
- Tests updated to verify rejection or use proper encryption

## Changes
- `ensureKeyFromUrl()` returns error for `storekey=insecure`
- `keyedCryptoFactory()` throws for `storekey=insecure`
- Removed unused `noCrypto` and `nullCodec` classes
- Updated tests to use behavior-based assertions instead of exact CID checks

## Test plan
- [x] Tests verify insecure mode is rejected with helpful error
- [x] Existing tests updated to use encryption
- [x] `pnpm format` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (128 files, 1775 tests)
- [x] `pnpm build` passes

## Breaking Change
The `storekey=insecure` URL parameter is no longer supported. Remove it from any URLs to use automatic key generation.

Fixes ROBUST-03

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced encryption requirement by rejecting unencrypted storage configuration. The system now rejects attempts to use unencrypted data storage and requires all data to be encrypted, returning a clear error message when unencrypted storage is requested.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->