### PR TITLE
set explicit latest on releases

### DIFF
--- a/cli/build-cmd.ts
+++ b/cli/build-cmd.ts
@@ -605,6 +605,8 @@ export function buildCmd(sthis: SuperThis) {
           const semVer = new SemVer(args.version);
           if (semVer.prerelease.find((i) => typeof i === "string" && i.includes("dev"))) {
             tags.push("dev");
+          } else {
+            tags.push("latest"); // override to latest in prod
           }
         } catch (e) {
           console.warn(`Warn parsing version ${args.version}:`, e);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm publishing to properly tag non-development releases. The "latest" tag is now automatically applied to stable version releases in the npm registry, while development prereleases continue to use the "dev" tag. This ensures clear version identification and improves the release management process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->