### PR TITLE
the version pinning protects the update of e.g. cement

### DIFF
--- a/dashboard/backend/create-handler.ts
+++ b/dashboard/backend/create-handler.ts
@@ -355,7 +355,7 @@ export const fpApiEvento = Lazy(() => {
         await ctx.send.send(ctx, {
           type: "Response",
           payload: {
-            status: 501,
+            status: 404,
             headers: DefaultHttpHeaders({ "Content-Type": "application/json" }),
             body: JSON.stringify({ type: "error", message: "Not Found", req: ctx.enRequest }),
           },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
       "esbuild",
       "msw",
       "playwright-chromium",
-      "sharp",
       "workerd"
     ],
     "patchedDependencies": {


### PR DESCRIPTION
      in usage projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status for missing resources from 501 to 404.

* **New Features**
  * Configurable version modifiers for dependency pinning.
  * CLI flags to control patch version modification behavior.

* **Refactor**
  * Simplified package patching interface to accept options object.

* **Tests**
  * Added tests covering unmodified-dependency handling and modifier-based pinning scenarios.

* **Chores**
  * Removed an unnecessary build dependency from configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->