### PR TITLE
fix(docker): nginx CORS, WebSocket /fp, upload limit, BLOB_PROXY_URL

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -23,6 +23,10 @@ http {
         listen 8080;
         server_name _;
 
+        # Allow large file uploads (blobs, images).
+        # nginx defaults to 1MB which causes 413 errors.
+        client_max_body_size 100m;
+
         # Strip CORS headers from upstream backends to prevent duplication.
         # The dashboard and cloud-backend services add their own CORS headers,
         # which causes "multiple values" errors when an outer reverse proxy
@@ -59,14 +63,19 @@ http {
             proxy_send_timeout 86400s;
         }
 
-        # /fp exact match - cloud-backend (prevents capturing /fp/cloud/*)
+        # /fp exact match - cloud-backend WebSocket (prevents capturing /fp/cloud/*)
+        # Fireproof clients connect here for real-time sync via WebSocket.
         location = /fp {
             proxy_pass http://cloud_backend;
             proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
         }
 
         # Blob storage - cloud-backend

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -23,6 +23,16 @@ http {
         listen 8080;
         server_name _;
 
+        # Strip CORS headers from upstream backends to prevent duplication.
+        # The dashboard and cloud-backend services add their own CORS headers,
+        # which causes "multiple values" errors when an outer reverse proxy
+        # (e.g., Caddy, Cloudflare, or a custom nginx) also adds CORS headers.
+        # Stripping here lets deployers control CORS at one layer.
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Max-Age;
+
         # Health check for the proxy itself
         location = /proxy/health {
             default_type application/json;

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -142,6 +142,12 @@ MAX_ADMIN_USERS=10
 MAX_MEMBER_USERS=50
 MAX_INVITES=100
 MAX_APPID_BINDINGS=50
+
+# Blob Proxy URL
+# For local development, the default (http://localhost:8080) works fine.
+# For remote/VM deployments, set this to the public URL of the proxy
+# so that blob download URLs are reachable by external clients.
+BLOB_PROXY_URL=${BLOB_PROXY_URL:-http://localhost:8080}
 ENVEOF
 
     log_info ".env written with freshly generated keys."

--- a/use-fireproof/clerk/use-fireproof-clerk.ts
+++ b/use-fireproof/clerk/use-fireproof-clerk.ts
@@ -9,8 +9,12 @@ import type { AttachState, SyncStatus, UseFireproofClerkResult } from "./types.j
 const REFRESH_BEFORE_EXPIRY_MS = 5 * 60 * 1000;
 // Minimum delay between refresh attempts (30 seconds)
 const MIN_REFRESH_DELAY_MS = 30 * 1000;
-// Delay before retrying after auth error (2 seconds)
-const AUTH_ERROR_RETRY_DELAY_MS = 2 * 1000;
+// Base delay before retrying after error (2 seconds, doubles each retry)
+const BASE_RETRY_DELAY_MS = 2 * 1000;
+// Maximum delay between retries (30 seconds)
+const MAX_RETRY_DELAY_MS = 30 * 1000;
+// Maximum number of retries before giving up (resets on tab return)
+const MAX_RETRY_COUNT = 8;
 // Small cleanup delay after detach (100ms)
 const DETACH_CLEANUP_DELAY_MS = 100;
 
@@ -45,6 +49,11 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
   const attachingRef = useRef(false);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const strategyRef = useRef<ClerkTokenStrategy | null>(null);
+  const retryCountRef = useRef(0);
+  const attachStateRef = useRef<AttachState>(attachState);
+
+  // Keep ref in sync with state
+  useEffect(() => { attachStateRef.current = attachState; }, [attachState]);
 
   // Use the base useFireproof hook
   const fpResult = useFireproof(name);
@@ -71,7 +80,8 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
 
   // Perform a connection refresh cycle (detach, wait, reattach)
   const performRefreshCycle = useCallback(async () => {
-    if (attachState.status !== "attached" || !attachState.attached || !dashApi) {
+    const currentState = attachStateRef.current;
+    if (currentState.status !== "attached" || !currentState.attached || !dashApi) {
       return;
     }
 
@@ -80,7 +90,7 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
 
     try {
       // Detach current connection
-      await attachState.attached.detach();
+      await currentState.attached.detach();
 
       // Small delay for cleanup
       await new Promise(resolve => setTimeout(resolve, DETACH_CLEANUP_DELAY_MS));
@@ -108,6 +118,7 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
         scheduleTokenRefresh(expiry, () => performRefreshCycle());
       }
 
+      retryCountRef.current = 0;
       setAttachState({ status: "attached", attached });
       setSyncStatus("synced");
       setLastSyncError(undefined);
@@ -117,10 +128,10 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
       setLastSyncError(error);
       setAttachState({ status: "error", error });
     }
-  }, [attachState, dashApi, config, name, database, clearRefreshTimer, scheduleTokenRefresh]);
+  }, [dashApi, config, name, database, clearRefreshTimer, scheduleTokenRefresh]);
 
   const doAttach = useCallback(async () => {
-    if (!dashApi || attachingRef.current || attachState.status === "attached") {
+    if (!dashApi || attachingRef.current || attachStateRef.current.status === "attached") {
       return;
     }
 
@@ -152,6 +163,7 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
         scheduleTokenRefresh(expiry, () => performRefreshCycle());
       }
 
+      retryCountRef.current = 0;
       setAttachState({ status: "attached", attached });
       setSyncStatus("synced");
       setLastSyncError(undefined);
@@ -163,17 +175,19 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
     } finally {
       attachingRef.current = false;
     }
-  }, [dashApi, database, config, name, attachState.status, scheduleTokenRefresh, performRefreshCycle]);
+  }, [dashApi, database, config, name, scheduleTokenRefresh, performRefreshCycle]);
 
   const doDetach = useCallback(async () => {
-    if (attachState.status !== "attached" || !attachState.attached) {
+    const currentState = attachStateRef.current;
+    if (currentState.status !== "attached" || !currentState.attached) {
       return;
     }
 
     clearRefreshTimer();
+    retryCountRef.current = 0;
 
     try {
-      await attachState.attached.detach();
+      await currentState.attached.detach();
       setAttachState({ status: "detached" });
       setSyncStatus("idle");
     } catch (err) {
@@ -183,7 +197,7 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
       });
       setSyncStatus("error");
     }
-  }, [attachState, clearRefreshTimer]);
+  }, [clearRefreshTimer]);
 
   // Auto-attach when session becomes ready
   useEffect(() => {
@@ -199,46 +213,62 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
     }
   }, [isSessionReady, attachState.status, doDetach]);
 
-  // Handle page visibility changes - refresh if token may have expired while hidden
+  // Handle page visibility changes - refresh if token may have expired while hidden,
+  // or reset retry budget if returning from background while in error state
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (
-        document.visibilityState === "visible" &&
-        attachState.status === "attached" &&
-        strategyRef.current
-      ) {
+      if (document.visibilityState !== "visible") return;
+
+      const currentStatus = attachStateRef.current.status;
+
+      if (currentStatus === "attached" && strategyRef.current) {
         const expiry = strategyRef.current.getLastTokenExpiry();
         if (expiry && Date.now() > expiry - REFRESH_BEFORE_EXPIRY_MS) {
           // Token is close to or past expiry, refresh now
           performRefreshCycle();
         }
+      } else if (currentStatus === "error") {
+        // User returned to tab while in error state — reset retry budget
+        // and trigger a fresh attach cycle
+        console.debug("[fireproof-clerk] Tab visible with error state, resetting retry budget");
+        retryCountRef.current = 0;
+        setAttachState({ status: "detached" });
+        setSyncStatus("idle");
       }
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, [attachState.status, performRefreshCycle]);
+  }, [performRefreshCycle]);
 
-  // Reactive error recovery - auto-retry on auth-related errors
+  // Reactive error recovery - auto-retry ALL errors with exponential backoff
   useEffect(() => {
-    if (attachState.status === "error" && attachState.error && isSessionReady) {
-      const msg = attachState.error.message.toLowerCase();
-      const isAuthError =
-        msg.includes("timeout") ||
-        msg.includes("auth") ||
-        msg.includes("token") ||
-        msg.includes("expired") ||
-        msg.includes("unauthorized");
+    if (attachState.status !== "error" || !isSessionReady) return;
 
-      if (isAuthError) {
-        const timer = setTimeout(() => {
-          // Reset to detached to trigger auto-attach
-          setAttachState({ status: "detached" });
-          setSyncStatus("idle");
-        }, AUTH_ERROR_RETRY_DELAY_MS);
-        return () => clearTimeout(timer);
-      }
+    if (retryCountRef.current >= MAX_RETRY_COUNT) {
+      console.debug(
+        `[fireproof-clerk] Max retries (${MAX_RETRY_COUNT}) reached, waiting for tab switch to reset`
+      );
+      return;
     }
+
+    const delay = Math.min(
+      BASE_RETRY_DELAY_MS * Math.pow(2, retryCountRef.current),
+      MAX_RETRY_DELAY_MS
+    );
+    retryCountRef.current += 1;
+
+    console.debug(
+      `[fireproof-clerk] Retry ${retryCountRef.current}/${MAX_RETRY_COUNT} in ${delay}ms`,
+      attachState.error?.message
+    );
+
+    const timer = setTimeout(() => {
+      // Reset to detached to trigger auto-attach
+      setAttachState({ status: "detached" });
+      setSyncStatus("idle");
+    }, delay);
+    return () => clearTimeout(timer);
   }, [attachState, isSessionReady]);
 
   // Cleanup refresh timer on unmount

--- a/use-fireproof/clerk/use-fireproof-clerk.ts
+++ b/use-fireproof/clerk/use-fireproof-clerk.ts
@@ -17,6 +17,12 @@ const MAX_RETRY_DELAY_MS = 30 * 1000;
 const MAX_RETRY_COUNT = 8;
 // Small cleanup delay after detach (100ms)
 const DETACH_CLEANUP_DELAY_MS = 100;
+// Interval for polling database after attach to kick CRDT processing (2 seconds)
+const SYNC_POLL_INTERVAL_MS = 2000;
+// Stop early once doc count is stable for this many consecutive polls
+const SYNC_STABLE_THRESHOLD = 3;
+// Hard ceiling — stop polling regardless (20 seconds)
+const SYNC_POLL_MAX_MS = 20 * 1000;
 
 /**
  * React hook that combines useFireproof with automatic Clerk-authenticated cloud sync.
@@ -270,6 +276,65 @@ export function useFireproofClerk(name: string | Database): UseFireproofClerkRes
     }, delay);
     return () => clearTimeout(timer);
   }, [attachState, isSessionReady]);
+
+  // Workaround: kick the CRDT to process sync data after initial attach.
+  // database.attach() resolves when the WebSocket connects, but historical data
+  // streams in asynchronously. The streamed metadata isn't processed until
+  // something queries the database, so useLiveQuery (which only re-queries on
+  // subscription events) never sees the data. A periodic allDocs() call forces
+  // the CRDT to process pending metadata, advancing the clock and triggering
+  // subscriptions. Once the document count stabilizes, sync has caught up and
+  // real-time updates flow through the normal subscription path — no more
+  // polling needed.
+  useEffect(() => {
+    if (attachState.status !== "attached") return;
+
+    let stopped = false;
+    let lastCount = -1;
+    let stableRuns = 0;
+
+    const poll = async () => {
+      if (stopped) return;
+      try {
+        const { rows } = await database.allDocs();
+        const count = rows.length;
+
+        if (count === lastCount) {
+          stableRuns++;
+          if (stableRuns >= SYNC_STABLE_THRESHOLD) {
+            console.debug("[fireproof-clerk] Initial sync settled, polling stopped");
+            stopped = true;
+            return;
+          }
+        } else {
+          stableRuns = 0;
+        }
+        lastCount = count;
+      } catch {
+        // ignore polling errors
+      }
+      if (!stopped) {
+        setTimeout(poll, SYNC_POLL_INTERVAL_MS);
+      }
+    };
+
+    // Start after a brief delay to let the first metadata packet arrive
+    const startTimer = setTimeout(poll, SYNC_POLL_INTERVAL_MS);
+
+    // Hard ceiling — stop regardless
+    const maxTimer = setTimeout(() => {
+      if (!stopped) {
+        console.debug("[fireproof-clerk] Sync poll hit max duration, stopping");
+        stopped = true;
+      }
+    }, SYNC_POLL_MAX_MS);
+
+    return () => {
+      stopped = true;
+      clearTimeout(startTimer);
+      clearTimeout(maxTimer);
+    };
+  }, [attachState.status, database]);
 
   // Cleanup refresh timer on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Four fixes to the Docker nginx proxy and startup script that affect production deployments:

- **Strip duplicate CORS headers** — upstream backends (dashboard, cloud-backend) add their own CORS headers. When an outer reverse proxy (Caddy, Cloudflare, custom nginx) also adds CORS, browsers reject the response due to duplicate `Access-Control-Allow-Origin`. `proxy_hide_header` strips them at the nginx layer so deployers can control CORS at one place.

- **Add WebSocket upgrade to `/fp`** — Fireproof clients connect to `/fp` for real-time sync via WebSocket, but the nginx config only had `Upgrade`/`Connection` headers on `/ws`. Without these headers on `/fp`, WebSocket connections silently fall back to polling or fail entirely.

- **Raise `client_max_body_size` to 100m** — nginx defaults to 1MB, which causes `413 Payload Too Large` errors when uploading blobs or images over 1MB.

- **Add `BLOB_PROXY_URL` to generated `.env`** — `start.sh --setup` generates `.env` but omits `BLOB_PROXY_URL`. On remote/VM deployments, the cloud-backend generates blob download URLs using its internal default (`http://localhost:8080`), which clients can't reach. Adding this variable lets deployers override it with their public URL.

## Test plan

- [ ] `./docker/start.sh --setup` generates `.env` containing `BLOB_PROXY_URL`
- [ ] `BLOB_PROXY_URL=https://example.com ./docker/start.sh --setup` propagates the override
- [ ] `./docker/start.sh --verify` passes all routes including `/fp` WebSocket
- [ ] Upload a file >1MB through the proxy without 413 error
- [ ] Confirm no duplicate CORS headers when behind an outer proxy