### PR TITLE
feat(core): add LedgerSvc lifecycle hooks for onCreate and onClose

### DIFF
--- a/core/base/index.ts
+++ b/core/base/index.ts
@@ -13,3 +13,5 @@ import "./compact-strategies.js";
 export { getCompactStrategy, registerCompactStrategy, getCompactStrategyThrow } from "@fireproof/core-runtime";
 
 export { registerStoreProtocol } from "@fireproof/core-blockstore";
+
+export { getLedgerSvc } from "./ledger-svc.js";

--- a/core/base/ledger-svc.ts
+++ b/core/base/ledger-svc.ts
@@ -1,0 +1,9 @@
+import { Lazy, OnFunc } from "@adviser/cement";
+import { Ledger } from "@fireproof/core-types-base";
+
+class LedgerSvc {
+  readonly onCreate = OnFunc<(ledger: Ledger) => void>();
+  readonly onClose = OnFunc<(ledger: Ledger) => void>();
+}
+
+export const getLedgerSvc = Lazy(() => new LedgerSvc());

--- a/core/base/ledger.ts
+++ b/core/base/ledger.ts
@@ -26,6 +26,7 @@ import { DatabaseImpl } from "./database.js";
 import { CRDTImpl } from "./crdt.js";
 import { getDefaultURI } from "@fireproof/core-blockstore";
 import { defaultKeyBagOpts } from "@fireproof/core-keybag";
+import { getLedgerSvc } from "./ledger-svc.js";
 
 const ledgers = new KeyedResolvOnce<Ledger>();
 
@@ -68,7 +69,10 @@ export function LedgerFactory(name: string, opts?: ConfigOpts): Ledger {
             /* noop */
           }),
       });
+      const svc = getLedgerSvc();
+      svc.onCreate.invoke(db);
       db.onClosed(() => {
+        svc.onClose.invoke(db);
         ledgers.unget(key);
       });
       return db;

--- a/core/tests/fireproof/ledger-svc.test.ts
+++ b/core/tests/fireproof/ledger-svc.test.ts
@@ -1,0 +1,35 @@
+import { fireproof, getLedgerSvc } from "@fireproof/core-base";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Ledger Service", () => {
+  // the ledger service are a global singleton
+  // which dispatch events like "ledger:created" and "ledger:closed" when ledgers are created and closed
+
+  it("get LedgerSvc", async () => {
+    const svc1 = getLedgerSvc();
+    const svc2 = getLedgerSvc();
+    expect(svc1).toBe(svc2);
+  });
+
+  it("dispatch onCreate and onClose events", async () => {
+    const svc = getLedgerSvc();
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    svc.onCreate(fn1);
+    svc.onClose(fn2);
+
+    const fp1 = [fireproof("db1"), fireproof("db1")];
+    const fp2 = [fireproof("db2"), fireproof("db2")];
+
+    await Promise.all(fp1.map((db) => db.close()));
+    await Promise.all(fp2.map((db) => db.close()));
+
+    expect(fn1).toHaveBeenCalledTimes(2);
+    expect(fn1.mock.calls[0][0].refId()).toEqual(fp1[0].ledger.refId());
+    expect(fn1.mock.calls[1][0].refId()).toEqual(fp2[0].ledger.refId());
+
+    expect(fn2).toHaveBeenCalledTimes(2);
+    expect(fn2.mock.calls[0][0].refId()).toEqual(fp1[1].ledger.refId());
+    expect(fn2.mock.calls[1][0].refId()).toEqual(fp2[1].ledger.refId());
+  });
+});


### PR DESCRIPTION
  Introduce a singleton `LedgerSvc` (via `getLedgerSvc`) that exposes
  `OnFunc`-based hooks for ledger lifecycle events:

  - `onCreate` — invoked when a new ledger is created via `LedgerFactory`
  - `onClose` — invoked when a ledger is closed/unregistered

  Export `getLedgerSvc` from `core/base/index.ts` as part of the public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ledger service that exposes lifecycle event handlers for ledger creation and closure, enabling apps to subscribe to and react to ledger state changes.
* **Tests**
  * Added tests verifying the service behaves as a singleton and correctly dispatches create/close events to registered listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->