### PR TITLE
fix: tenant membership on ledger invite + service auth

### DIFF
--- a/core/protocols/dashboard/token.ts
+++ b/core/protocols/dashboard/token.ts
@@ -202,6 +202,61 @@ export const deviceIdCAFromEnv = Lazy((sthis: SuperThis) => {
   );
 });
 
+export class ServiceApiToken implements FPApiToken {
+  readonly sthis: SuperThis;
+
+  constructor(sthis: SuperThis) {
+    this.sthis = sthis;
+  }
+
+  async decode(token: string): Promise<Result<VerifiedClaimsResult>> {
+    return this.verify(token);
+  }
+
+  async verify(token: string): Promise<Result<VerifiedClaimsResult>> {
+    const rEnv = this.sthis.env.gets({
+      SERVICE_API_KEY: param.OPTIONAL,
+    });
+    if (rEnv.isErr()) {
+      return Result.Err("Service auth configuration error");
+    }
+    const configuredKey = rEnv.Ok().SERVICE_API_KEY;
+    if (!configuredKey) {
+      return Result.Err("Service auth not configured");
+    }
+
+    // Compound token format: <key>|<userId>|<email>
+    const parts = token.split("|");
+    if (parts.length < 3) {
+      return Result.Err("Invalid service token format");
+    }
+    const [key, userId, email] = parts;
+
+    if (key !== configuredKey) {
+      return Result.Err("Invalid service key");
+    }
+
+    return Result.Ok({
+      type: "service",
+      token,
+      claims: {
+        userId,
+        sub: userId,
+        role: "admin",
+        params: {
+          email: email,
+          email_verified: true,
+          first: "Service",
+          last: "Account",
+          image_url: "",
+          name: "Service Account",
+          public_meta: {},
+        },
+      },
+    });
+  }
+}
+
 export const tokenApi = Lazy(async (sthis: SuperThis, opts: VerifyWithCertificateOptions) => {
   // const rDeviceIdCA = await DeviceIdCA.from(sthis, {
   //   privateKeyEnv: "DEVICE_ID_CA_PRIV_KEY",
@@ -212,5 +267,6 @@ export const tokenApi = Lazy(async (sthis: SuperThis, opts: VerifyWithCertificat
   return {
     "device-id": new DeviceIdApiToken(sthis, opts),
     clerk: new ClerkApiToken(sthis),
+    service: new ServiceApiToken(sthis),
   };
 });

--- a/core/types/protocols/dashboard/msg-types.ts
+++ b/core/types/protocols/dashboard/msg-types.ts
@@ -73,7 +73,7 @@ export interface InviteTicket {
 export type UserStatus = "active" | "inactive" | "banned" | "invited";
 
 export interface DashAuthType {
-  readonly type: "ucan" | "clerk" | "device-id";
+  readonly type: "ucan" | "clerk" | "device-id" | "service";
   readonly token: string;
   readonly clerkId?: string; // optional: identifies which Clerk instance to use for verification
 }

--- a/dashboard/backend/public/redeem-invite.ts
+++ b/dashboard/backend/public/redeem-invite.ts
@@ -56,6 +56,13 @@ export async function redeemInvite(
               if (!ledger) {
                 throw new Error("ledger not found");
               }
+              // Add user to the ledger's parent tenant (required for cloud token validation)
+              await addUserToTenant(ctx, {
+                userName: `invited-${ledger.name}`,
+                tenantId: ledger.tenantId,
+                userId: req.auth.user.userId,
+                role: invite.invitedParams.ledger.role ?? "member",
+              });
               await addUserToLedger(ctx, {
                 userName: `invited-${ledger.name}`,
                 ledgerId: ledger.ledgerId,

--- a/dashboard/backend/tests/db-api.test.ts
+++ b/dashboard/backend/tests/db-api.test.ts
@@ -1938,8 +1938,9 @@ describe("db-api", () => {
       expect(rLedger.isOk()).toBeTruthy();
       const ledgerId = rLedger.Ok().ledger.ledgerId;
 
-      // Call inviteUser with service auth (compound token: key|userId|email)
-      const serviceToken = `test-service-key|${adminData.ress.user.userId}|${adminData.ress.user.byProviders[0].cleanEmail}`;
+      // Call inviteUser with service auth (compound token: key|providerUserId|email)
+      // providerUserId is what getUser looks up by
+      const serviceToken = `test-service-key|${adminData.ress.user.byProviders[0].providerUserId}|${adminData.ress.user.byProviders[0].cleanEmail}`;
       const targetEmail = "newuser-service@example.com";
 
       const res = await svc(

--- a/dashboard/backend/tests/db-api.test.ts
+++ b/dashboard/backend/tests/db-api.test.ts
@@ -33,6 +33,7 @@ describe("db-api", () => {
   }[];
   // const logger = ensureLogger(sthis, "dashboard-backend-db-api-test");
   let deviceCA: DeviceIdCA;
+  let svc: (req: Request) => Promise<Response>;
 
   async function jwkPackage() {
     // const pair = await SessionTokenService.generateKeyPair();
@@ -72,8 +73,9 @@ describe("db-api", () => {
       MAX_ADMIN_USERS: "5",
       MAX_MEMBER_USERS: "5",
       MAX_TENANTS: "10",
+      SERVICE_API_KEY: "test-service-key",
     };
-    const svc = await createHandler(db, env);
+    svc = await createHandler(db, env);
 
     const unknownDevId = await createTestUser({
       sthis,
@@ -1914,6 +1916,74 @@ describe("db-api", () => {
   //     expect(tandC.claims.selected.tenant).toBe(tenant.Ok().tenant.tenantId);
   //     expect(tandC.claims.selected.ledger).toBeDefined();
   //   });
+
+  describe("service auth", () => {
+    it("accepts inviteUser with valid service auth", async () => {
+      // Use User A (admin) as the service identity
+      const adminData = datas[0];
+      const adminTenants = await fpApi.listTenantsByUser({
+        type: "reqListTenantsByUser",
+        auth: adminData.reqs.auth,
+      });
+      const adminTenant = adminTenants.Ok().tenants.find((t) => t.role === "admin" && t.default);
+
+      const rLedger = await fpApi.createLedger({
+        type: "reqCreateLedger",
+        auth: adminData.reqs.auth,
+        ledger: {
+          tenantId: adminTenant!.tenantId,
+          name: "service-auth-test-ledger",
+        },
+      });
+      expect(rLedger.isOk()).toBeTruthy();
+      const ledgerId = rLedger.Ok().ledger.ledgerId;
+
+      // Call inviteUser with service auth (compound token: key|userId|email)
+      const serviceToken = `test-service-key|${adminData.ress.user.userId}|${adminData.ress.user.byProviders[0].cleanEmail}`;
+      const targetEmail = "newuser-service@example.com";
+
+      const res = await svc(
+        new Request("https://test/api", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "reqInviteUser",
+            auth: { type: "service", token: serviceToken },
+            ticket: {
+              query: { byString: targetEmail },
+              invitedParams: {
+                ledger: { id: ledgerId, role: "member", right: "write" },
+              },
+            },
+          }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.type).toBe("resInviteUser");
+      expect(body.invite.status).toBe("pending");
+    });
+
+    it("rejects service auth with wrong key", async () => {
+      const res = await svc(
+        new Request("https://test/api", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "reqInviteUser",
+            auth: { type: "service", token: "wrong-key|user|email" },
+            ticket: {
+              query: { byString: "x@x.com" },
+              invitedParams: { tenant: { id: "x", role: "member" } },
+            },
+          }),
+        }),
+      );
+      expect(res.status).toBe(500); // Evento returns 500 for auth errors
+      const body = await res.json();
+      expect(body.type).toBe("error");
+    });
+  });
 });
 
 it("queryEmail strips +....@", async () => {
@@ -1943,3 +2013,4 @@ it("resWellKnownJwks", async () => {
     ],
   });
 });
+

--- a/dashboard/backend/tests/db-api.test.ts
+++ b/dashboard/backend/tests/db-api.test.ts
@@ -1208,6 +1208,76 @@ describe("db-api", () => {
     });
   });
 
+  it("redeemInvite for ledger invite also adds user to the ledger's tenant", async () => {
+    // User A (admin) creates a ledger in their default tenant
+    const userA = datas[7];
+    const userB = datas[8];
+
+    // Create a ledger under User A's tenant
+    const rLedger = await fpApi.createLedger({
+      type: "reqCreateLedger",
+      auth: userA.reqs.auth,
+      ledger: {
+        tenantId: userA.ress.tenants[0].tenantId,
+        name: "shared-ledger-tenant-test",
+      },
+    });
+    expect(rLedger.isOk()).toBeTruthy();
+    const ledgerId = rLedger.Ok().ledger.ledgerId;
+
+    // User A invites User B to the ledger
+    const rInvite = await fpApi.inviteUser({
+      type: "reqInviteUser",
+      auth: userA.reqs.auth,
+      ticket: {
+        query: {
+          existingUserId: userB.ress.user.userId,
+        },
+        invitedParams: {
+          ledger: { id: ledgerId, role: "member", right: "write" },
+        },
+      },
+    });
+    expect(rInvite.isOk()).toBeTruthy();
+    expect(rInvite.Ok().invite.status).toBe("pending");
+
+    // User B redeems the invite
+    const rRedeem = await fpApi.redeemInvite({
+      type: "reqRedeemInvite",
+      auth: userB.reqs.auth,
+    });
+    expect(rRedeem.isOk()).toBeTruthy();
+
+    // Verify: User B should now be in the ledger's tenant
+    const rTenants = await fpApi.listTenantsByUser({
+      type: "reqListTenantsByUser",
+      auth: userB.reqs.auth,
+    });
+    expect(rTenants.isOk()).toBeTruthy();
+    const memberTenant = rTenants.Ok().tenants.find(
+      (t) => t.tenantId === userA.ress.tenants[0].tenantId,
+    );
+    expect(memberTenant).toBeDefined();
+    expect(memberTenant!.role).toBe("member");
+
+    // Verify: ensureCloudToken should succeed with the shared ledger
+    const rToken = await fpApi.ensureCloudToken({
+      type: "reqEnsureCloudToken",
+      auth: userB.reqs.auth,
+      appId: "test-tenant-fix",
+      ledger: ledgerId,
+    });
+    expect(rToken.isOk()).toBeTruthy();
+    expect(rToken.Ok().tenant).toBe(userA.ress.tenants[0].tenantId);
+    expect(rToken.Ok().ledger).toBe(ledgerId);
+
+    // Verify: the cloud token's tenants array includes the admin's tenant
+    const hasTenant = rToken.Ok().claims.tenants.some(
+      (t) => t.id === userA.ress.tenants[0].tenantId,
+    );
+    expect(hasTenant).toBe(true);
+  });
+
   it("create session with claim", async () => {
     const auth: DashAuthType = datas[0].reqs.auth;
     // fpApi.sthis.env.set("CLOUD_SESSION_TOKEN_SECRET", "

--- a/dashboard/backend/utils/auth.ts
+++ b/dashboard/backend/utils/auth.ts
@@ -33,7 +33,8 @@ export async function verifyExtractClaims(
 export function coercedVerifiedAuthUser(ver: VerifiedClaimsResult): Result<VerifiedAuthResult["verifiedAuth"]> {
   switch (ver.type) {
     case "device-id":
-    case "clerk": {
+    case "clerk":
+    case "service": {
       const claims = ClerkClaimSchema.safeParse(ver.claims);
       if (!claims.success) {
         return Result.Err(claims.error);


### PR DESCRIPTION
## Summary

- **redeemInvite tenant fix:** When redeeming a ledger invite, also add the user to the ledger's parent tenant via `addUserToTenant`. Without this, `ensureCloudToken` produces a cloud token where `selected.tenant` isn't in `tenants[]`, and the Cloud Backend rejects all data operations.

- **Service auth:** Add `ServiceApiToken` class for machine-to-machine API calls. Uses compound token format (`key|providerUserId|email`). Opt-in via `SERVICE_API_KEY` env var. Needed by the VibesOS Deploy API to create Connect invites for public link sharing.

## Test plan

- [ ] Existing tests pass unchanged
- [ ] New test: ledger invite redemption creates both LedgerUsers and TenantUsers rows
- [ ] New test: ensureCloudToken succeeds after ledger invite redemption (selected.tenant in tenants[])
- [ ] New test: service auth accepted with valid key
- [ ] New test: service auth rejected with wrong key

**Note:** Pre-existing failure in "email-invite auto-redeemed on ensureUser" is unrelated (MAX_MEMBER_USERS limit hit from other tests in the suite).