### PR TITLE
fix(core): batch write queue to fix useLiveQuery concurrent write reactivity

### DIFF
--- a/core/base/ledger.ts
+++ b/core/base/ledger.ts
@@ -269,9 +269,6 @@ class LedgerImpl implements Ledger {
 
   private async _notify(updates: DocUpdate<DocTypes>[]) {
     await this.ready();
-    if (this.writeQueue.hasPending()) {
-      return;
-    }
     if (this._listeners.size) {
       const docs: DocWithId<DocTypes>[] = updates.map(({ id, value }) => ({ ...value, _id: id }));
       for (const listener of this._listeners) {

--- a/core/base/ledger.ts
+++ b/core/base/ledger.ts
@@ -269,6 +269,9 @@ class LedgerImpl implements Ledger {
 
   private async _notify(updates: DocUpdate<DocTypes>[]) {
     await this.ready();
+    if (this.writeQueue.hasPending()) {
+      return;
+    }
     if (this._listeners.size) {
       const docs: DocWithId<DocTypes>[] = updates.map(({ id, value }) => ({ ...value, _id: id }));
       for (const listener of this._listeners) {
@@ -281,6 +284,9 @@ class LedgerImpl implements Ledger {
 
   private async _no_update_notify() {
     await this.ready();
+    if (this.writeQueue.hasPending()) {
+      return;
+    }
     if (this._noupdate_listeners.size) {
       for (const listener of this._noupdate_listeners) {
         await (async () => await listener([]))().catch((e: Error) => {

--- a/core/base/write-queue.ts
+++ b/core/base/write-queue.ts
@@ -49,16 +49,18 @@ class WriteQueueImpl<T extends DocUpdate<S>, S extends DocTypes = DocTypes> impl
     try {
       this.logger.Debug().Any("opts", this.opts).Len(this.queue).Msg("Processing tasks");
       const tasksToProcess = this.queue.splice(0, this.opts.chunkSize);
-      const updates = tasksToProcess.map((item) => item.tasks).filter((item) => item) as DocUpdate<S>[][];
-      const promises = updates.map(async (update, index) => {
-        try {
-          const result = await this.worker(update);
-          tasksToProcess[index].resolve(result);
-        } catch (error) {
-          tasksToProcess[index].reject(this.logger.Error().Err(error).Msg("Error processing task").AsError());
+      const allUpdates = tasksToProcess.flatMap((item) => item.tasks || []);
+      try {
+        const result = await this.worker(allUpdates);
+        for (const task of tasksToProcess) {
+          task.resolve(result);
         }
-      });
-      await Promise.allSettled(promises);
+      } catch (error) {
+        const err = this.logger.Error().Err(error).Msg("Error processing task").AsError();
+        for (const task of tasksToProcess) {
+          task.reject(err);
+        }
+      }
       this.logger.Debug().Any("opts", this.opts).Len(this.queue).Msg("Processed tasks");
     } catch (error) {
       this.logger.Error().Err(error).Msg("Error processing tasks");
@@ -81,6 +83,9 @@ class WriteQueueImpl<T extends DocUpdate<S>, S extends DocTypes = DocTypes> impl
     this.waitForEmptyQueue = new Future();
     this.testEmptyQueue();
     return this.waitForEmptyQueue.asPromise();
+  }
+  hasPending(): boolean {
+    return this.queue.length > 0;
   }
 }
 

--- a/core/tests/fireproof/database.test.ts
+++ b/core/tests/fireproof/database.test.ts
@@ -490,6 +490,46 @@ describe("basic Ledger with no update subscription", function () {
   });
 });
 
+describe("payload subscription with concurrent writes", () => {
+  let db: Database;
+  const sthis = ensureSuperThis();
+
+  afterEach(async () => {
+    await db.close();
+    await db.destroy();
+  });
+
+  beforeEach(async () => {
+    await sthis.start();
+    db = fireproof("sub-concurrent-writes");
+  });
+
+  it("should deliver all docs to payload subscriber during concurrent puts", async () => {
+    const received: DocWithId<NonNullable<unknown>>[] = [];
+    let resolveAll: () => void;
+    const allReceived = new Promise<void>((resolve) => {
+      resolveAll = resolve;
+    });
+
+    db.subscribe((docs) => {
+      received.push(...docs);
+      if (received.length >= 4) resolveAll();
+    }, true);
+
+    // 4 concurrent puts — the minimal counterexample from property test
+    await Promise.all([
+      db.put({ _id: "a", v: 1 }),
+      db.put({ _id: "b", v: 2 }),
+      db.put({ _id: "c", v: 3 }),
+      db.put({ _id: "d", v: 4 }),
+    ]);
+
+    await allReceived;
+    const ids = received.map((d) => d._id).sort();
+    expect(ids).toEqual(["a", "b", "c", "d"]);
+  }, 10000);
+});
+
 describe("ledger with files input", () => {
   let db: Database;
   let imagefiles: FileWithCid[] = [];

--- a/core/tests/fireproof/database.test.ts
+++ b/core/tests/fireproof/database.test.ts
@@ -347,7 +347,8 @@ describe("basic Ledger parallel writes / public", () => {
   });
   it("should resolve to one head", async () => {
     const crdt = db.ledger.crdt;
-    expect(crdt.clock.head.length).toBe(9);
+    // With merged write queue chunks, parallel puts produce a single head
+    expect(crdt.clock.head.length).toBe(1);
     await db.put({ _id: "id-10", hello: "world" });
     expect(crdt.clock.head.length).toBe(1);
   });

--- a/core/types/base/types.ts
+++ b/core/types/base/types.ts
@@ -690,6 +690,7 @@ export interface WriteQueue<T extends DocUpdate<S>, S extends DocTypes = DocType
   push(task: T): Promise<MetaType>;
   bulk(tasks: T[]): Promise<MetaType>;
   close(): Promise<void>;
+  hasPending(): boolean;
 }
 
 export type TraceFn = (traceEvent: TraceEvent) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1665,6 +1665,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -2040,13 +2043,11 @@ packages:
     resolution: {integrity: sha512-8B682ZNSw4lF/dsZqRALmF2a7gzPccRef0C1EeCpnvXMC00XniEDqkex4ccAT2NdIUKxM1Almb2RieBX4cCFZA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@deno/linux-x64-glibc@2.7.5':
     resolution: {integrity: sha512-CHmb1vDEZ4wimzhH7ooq+HqX+YcQN1piVe7oT8ll8WAvCUWilCLD5GU6gvucbMUORduQrVSUlnbR9JocuXTyiQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@deno/win32-arm64@2.7.5':
     resolution: {integrity: sha512-8avZZRhGyXaTiqB4pCag5LW3J3peLYvw2QETu5XnaGX1XAgG3VhqupSIn1YANGWR4jl8E6Al+sLqy+Q8r5pYIg==}
@@ -2637,105 +2638,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3102,42 +3087,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
     resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
@@ -3220,79 +3199,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3386,28 +3352,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -4489,6 +4451,10 @@ packages:
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
+  fast-check@4.6.0:
+    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5074,12 +5040,10 @@ packages:
 
   libsql@0.3.19:
     resolution: {integrity: sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -5117,28 +5081,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5640,6 +5600,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9380,6 +9343,10 @@ snapshots:
     dependencies:
       type: 2.7.3
 
+  fast-check@4.6.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -10471,6 +10438,8 @@ snapshots:
       react-is: 16.13.1
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   queue-microtask@1.2.3: {}
 

--- a/use-fireproof/tests/package.json
+++ b/use-fireproof/tests/package.json
@@ -26,6 +26,7 @@
     "@fireproof/core-types-blockstore": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "react": "^19.2.4",
+    "fast-check": "^4.6.0",
     "use-fireproof": "workspace:0.0.0"
   },
   "keywords": [

--- a/use-fireproof/tests/use-live-query-concurrent.test.tsx
+++ b/use-fireproof/tests/use-live-query-concurrent.test.tsx
@@ -26,7 +26,7 @@ describe("HOOK: useLiveQuery reactivity after concurrent writes", () => {
       let query: LiveQueryResult<{ type: string; index: number }, string>;
       let database: ReturnType<typeof useFireproof>["database"];
 
-      renderHook(() => {
+      const { unmount } = renderHook(() => {
         const fp = useFireproof(dbName);
         database = fp.database;
         query = fp.useLiveQuery<{ type: string; index: number }>("type", { key: "batch-item" });
@@ -52,6 +52,8 @@ describe("HOOK: useLiveQuery reactivity after concurrent writes", () => {
         },
         { timeout: TEST_TIMEOUT },
       );
+
+      unmount();
     },
     TEST_TIMEOUT,
   );

--- a/use-fireproof/tests/use-live-query-concurrent.test.tsx
+++ b/use-fireproof/tests/use-live-query-concurrent.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, afterAll, beforeAll, expect, it } from "vitest";
+import { fireproof, useFireproof } from "use-fireproof";
+import type { Database, LiveQueryResult } from "use-fireproof";
+import fc from "fast-check";
+
+const TEST_TIMEOUT = 10000;
+
+describe("HOOK: useLiveQuery reactivity after concurrent writes", () => {
+  let dbName: string;
+  let db: Database;
+
+  beforeAll(async () => {
+    dbName = `useLiveQueryConcurrent-${Date.now()}-${Math.random()}`;
+    db = fireproof(dbName);
+  });
+
+  afterAll(async () => {
+    await db.close();
+    await db.destroy();
+  });
+
+  it(
+    "should reflect all documents after Promise.all batch put",
+    async () => {
+      let query: LiveQueryResult<{ type: string; index: number }, string>;
+      let database: ReturnType<typeof useFireproof>["database"];
+
+      renderHook(() => {
+        const fp = useFireproof(dbName);
+        database = fp.database;
+        query = fp.useLiveQuery<{ type: string; index: number }>("type", { key: "batch-item" });
+      });
+
+      // Wait for initial empty state
+      await waitFor(() => {
+        expect(query).toBeDefined();
+        expect(query.docs.length).toBe(0);
+      });
+
+      // Write 12 documents concurrently via Promise.all
+      const items = Array.from({ length: 12 }, (_, i) => ({
+        type: "batch-item",
+        index: i,
+      }));
+      await Promise.all(items.map((item) => database.put(item)));
+
+      // Verify live query reflects ALL 12 documents
+      await waitFor(
+        () => {
+          expect(query.docs.length).toBe(12);
+        },
+        { timeout: TEST_TIMEOUT },
+      );
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("PROPERTY: useLiveQuery concurrent write reactivity", () => {
+  it("should eventually reflect all N documents after N concurrent puts", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 1, max: 50 }), async (n: number) => {
+        const dbName = `propTest-${Date.now()}-${Math.random()}`;
+        const db = fireproof(dbName);
+        try {
+          let query: LiveQueryResult<{ type: string; i: number }, string>;
+          let database: ReturnType<typeof useFireproof>["database"];
+
+          const { unmount } = renderHook(() => {
+            const fp = useFireproof(dbName);
+            database = fp.database;
+            query = fp.useLiveQuery<{ type: string; i: number }>("type", { key: "prop" });
+          });
+
+          // Wait for initial empty
+          await waitFor(() => {
+            expect(query.docs.length).toBe(0);
+          });
+
+          // Concurrent puts
+          const items = Array.from({ length: n }, (_, i) => ({ type: "prop", i }));
+          await Promise.all(items.map((item) => database.put(item)));
+
+          // Property: live query must reflect all N docs
+          await waitFor(
+            () => {
+              expect(query.docs.length).toBe(n);
+            },
+            { timeout: 5000 },
+          );
+
+          unmount();
+        } finally {
+          await db.close();
+          await db.destroy();
+        }
+      }),
+      { timeout: 120_000, numRuns: 20 },
+    );
+  }, 180_000);
+});


### PR DESCRIPTION
## Summary

- **Merged write queue chunk processing** into a single `crdt.bulk()` call instead of parallel per-item worker calls. This ensures one transaction and one subscription notification per chunk, fixing the race where early notifications fired before sibling writes completed.
- **Gated ledger notifications** on `writeQueue.hasPending()` to suppress intermediate chunk notifications — only the final chunk fires.
- **Added property-based test** (fast-check, N=1..50) that finds the minimal failing batch size, plus a regression test for the original 12-doc case.

## Test plan

- [x] Property test passes: `useLiveQuery` reflects all N docs for N=1..50
- [x] Regression test passes: 12 concurrent puts all visible
- [x] All 1607 core tests pass (0 failures)
- [x] All 55 use-fireproof hook tests pass (0 failures)
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to detect pending write operations.

* **Bug Fixes**
  * Prevented no-update notifications while writes are still pending.
  * Improved live-query consistency and ordering during concurrent writes.

* **Tests**
  * Added concurrent-write tests for live queries and payload subscriptions (including property-based tests).
  * Added test dependency to support property-based testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->