### PR TITLE
fix(cloud): enable tag-to-deploy for production cloud worker

### DIFF
--- a/.github/workflows/ci-core-cf-deploy.yaml
+++ b/.github/workflows/ci-core-cf-deploy.yaml
@@ -42,6 +42,7 @@ jobs:
           ACCESS_KEY_ID: ${{ vars.ACCESS_KEY_ID }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_DATABASE_ID: ${{ vars.CLOUDFLARE_DATABASE_ID }}
+          CLOUDFLARE_ENV: ${{ vars.CLOUDFLARE_ENV }}
           FP_ENDPOINT: ${{ vars.FP_ENDPOINT }}
           STORAGE_URL: ${{ vars.STORAGE_URL }}
         run: |

--- a/cloud/backend/cf-d1/package.json
+++ b/cloud/backend/cf-d1/package.json
@@ -10,7 +10,7 @@
     "publish": "echo skip",
     "drizzle:d1-local": "drizzle-kit push --config ./drizzle.cloud.d1-local.config.ts",
     "drizzle:d1-remote": "drizzle-kit push --config ./drizzle.cloud.d1-remote.config.ts",
-    "wrangler:deploy": "wrangler deploy -c ./wrangler.toml --env dev"
+    "wrangler:deploy": "wrangler deploy -c ./wrangler.toml --env ${CLOUDFLARE_ENV:-dev}"
   },
   "keywords": [
     "ledger",

--- a/cloud/backend/cf-d1/wrangler.toml
+++ b/cloud/backend/cf-d1/wrangler.toml
@@ -79,3 +79,20 @@ binding = "FP_BACKEND_D1"
 database_name = "fp-cloud-dev"
 database_id = "b0c1ea22-b733-420c-b812-bea9ffaa1676"
 
+[env.production.vars]
+VERSION = "FP-MSG-1.0"
+
+[[env.production.migrations]]
+tag = "v1"
+new_classes = ["FPRoomDurableObject"]
+
+[env.production.durable_objects]
+bindings = [
+  { name = "FP_WS_ROOM", class_name = "FPRoomDurableObject" }
+]
+
+[[env.production.d1_databases]]
+binding = "FP_BACKEND_D1"
+database_name = "fp-cloud-production"
+database_id = "ee23476b-c3c8-44c9-8388-d9455dd1b00f"
+


### PR DESCRIPTION
## Summary

- Add `[env.production]` section to `cloud/backend/cf-d1/wrangler.toml` with DO bindings, migrations, and a **fresh empty D1 database** (`fp-cloud-production`). The old GH env variable pointed to `fp-connect-production` which has a different schema. The dev DB (`fp-cloud-dev`) has the right schema but its tenant data was created with dev secrets and wouldn't be reachable by production clients. The new DB will have its tables created automatically by `drizzle:d1-remote` on first deploy.
- Parameterize `wrangler:deploy` scripts in both `cf-d1` and `cf-storage-cors` to use `${CLOUDFLARE_ENV:-dev}` instead of hardcoded `--env dev`
- Pass `CLOUDFLARE_ENV` to both deploy steps in the workflow so the parameterized scripts pick it up

After merge, deploy with: `git tag core-cf@p0.0.1-production-env && git push origin core-cf@p0.0.1-production-env`

## Test plan

- [ ] Review that `[env.production]` section matches the structure of `[env.dev]` (DO bindings, migrations, D1)
- [ ] Verify `CLOUDFLARE_DATABASE_ID` in GH production env matches wrangler.toml (`ee23476b-c3c8-44c9-8388-d9455dd1b00f`)
- [ ] After merge, push a `core-cf@p*` tag and watch the workflow run
- [ ] Confirm worker is live at `https://fireproof-v2-cloud-production.jchris.workers.dev/fp`
- [ ] Smoke test sync from a prod vibe app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production environment configuration with database and durable object bindings
  * Enabled dynamic deployment environment selection in deployment workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->