### PR TITLE
feat(cli): style device-id cert callback page with grid background

### DIFF
--- a/cli/cmds/device-id-cmd.ts
+++ b/cli/cmds/device-id-cmd.ts
@@ -24,6 +24,59 @@ import { type } from "arktype";
 import { CliCtx } from "../cli-ctx.js";
 import { sendMsg, sendProgress, WrapCmdTSMsg } from "../cmd-evento.js";
 
+function certSuccessHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Certificate received</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root { color-scheme: light dark; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    color: #1f2937;
+    background-color: #f8fafc;
+    background-image:
+      linear-gradient(to right, rgba(15, 23, 42, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(15, 23, 42, 0.08) 1px, transparent 1px);
+    background-size: 32px 32px;
+    background-position: -1px -1px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+  }
+  .card {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 12px;
+    padding: 2rem 2.25rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    max-width: 28rem;
+    text-align: center;
+  }
+  h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+  p { margin: 0; color: #475569; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e2e8f0; background-color: #0f172a; background-image:
+      linear-gradient(to right, rgba(226, 232, 240, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(226, 232, 240, 0.08) 1px, transparent 1px); }
+    .card { background: rgba(15, 23, 42, 0.85); border-color: rgba(226, 232, 240, 0.12); }
+    p { color: #cbd5e1; }
+  }
+</style>
+</head>
+<body>
+  <main class="card">
+    <h1>Certificate received successfully.</h1>
+    <p>You can close this window.</p>
+  </main>
+</body>
+</html>`;
+}
+
 function getStdin(): Promise<string> {
   return new Promise<string>((resolve) => {
     let data = "";
@@ -688,7 +741,7 @@ export const deviceIdRegisterEvento: EventoHandler<WrapCmdTSMsg<unknown>, ReqDev
       }
       void sendProgress(ctx, "info", "\nCertificate received from CA!");
       certFuture.resolve(cert);
-      return c.text("Certificate received successfully. You can close this window.");
+      return c.html(certSuccessHtml());
     });
 
     // Determine port: use specified port or generate random one


### PR DESCRIPTION
## Summary

- Replace the plaintext `Certificate received successfully. You can close this window.` response on `localhost:PORT/cert` (the `vibes-diy login` callback) with a small styled HTML page: graph-paper grid background, centered card, dark-mode aware.
- One self-contained `certSuccessHtml()` helper in [cli/cmds/device-id-cmd.ts](https://github.com/fireproof-storage/fireproof/blob/main/cli/cmds/device-id-cmd.ts); no new deps; `c.text(...)` -> `c.html(...)`.
- Refs [VibesDIY/vibes.diy#1616](https://github.com/VibesDIY/vibes.diy/issues/1616), which has the longer-term plan to flip the protocol so vibes can own the success page entirely. This PR is the stopgap so the last screen of onboarding isn't raw text/plain in the meantime.

## Test plan

- [ ] `pnpm install && pnpm lint && pnpm build` from repo root
- [ ] Run `vibes-diy login` end-to-end against vibes.diy and confirm the localhost callback page renders the styled card with the grid background (light + dark)
- [ ] Confirm cert is still received by the CLI (`vibes-diy` continues past the login step)
- [ ] Hit `http://localhost:PORT/cert` without a `cert=` query and confirm the existing 400 error path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the device registration flow to display an HTML confirmation page when the certificate is received, replacing the previous plain text response. Users now see a clearer message indicating successful certificate receipt with an option to close the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->